### PR TITLE
[chore/#21] Nginx upstream 네이밍에서 언더스코어 제거

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -257,7 +257,7 @@ resource "aws_instance" "app" {
               
               echo "===== Nginx Configuration ====="
               cat > /etc/nginx/conf.d/tech-blog.conf <<'NGINX'
-              upstream spring_backend {
+              upstream springapp {
                   server 127.0.0.1:8080 fail_timeout=0;
               }
 
@@ -289,7 +289,7 @@ resource "aws_instance" "app" {
                   real_ip_header CF-Connecting-IP;
                   
                   location / {
-                      proxy_pass http://spring_backend;
+                      proxy_pass http://springapp;
                       proxy_set_header Host $host;
                       proxy_set_header X-Real-IP $remote_addr;
                       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -305,13 +305,13 @@ resource "aws_instance" "app" {
                   }
                   
                   location ~* \.(jpg|jpeg|png|gif|ico|css|js|svg|woff|woff2|ttf)$ {
-                      proxy_pass http://spring_backend;
+                      proxy_pass http://springapp;
                       expires 30d;
                       add_header Cache-Control "public, immutable";
                   }
                   
                   location /health {
-                      proxy_pass http://spring_backend/actuator/health;
+                      proxy_pass http://springapp/actuator/health;
 
                       proxy_set_header Host $host;
                       proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## ❤️ 기능 설명
Nginx upstream 네이밍에서 언더스코어로 인해 서버 주소로 접근할 수 없는 문제를 해결했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2350" height="766" alt="image" src="https://github.com/user-attachments/assets/d5ceeec1-1a42-4440-90fd-e80adfd80682" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #21 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
