### PR TITLE
[Improve/#29] Elasticsearch 버전 호환성 문제 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - redis-data:/data
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
     container_name: tech-fork-elasticsearch
     restart: always
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     networks:
       - app-network
     volumes:


### PR DESCRIPTION
## ❤️ 기능 설명
Elasticsearch 버전을 8.11.0에서 8.18.0으로 업그레이드하여 Spring Boot 3.5.6과의 호환성 문제를 해결했습니다.

### 변경 사항
1. **Elasticsearch 버전 업그레이드**
   - `8.11.0` → `8.18.0`
   - Spring Boot 3.5.6의 Elasticsearch Java Client(8.18.6)와 호환

2. **메모리 설정 최적화**
   - `ES_JAVA_OPTS`: `1g` → `512m`
   - EC2 t2.micro 환경 고려

### 해결된 에러
```
Missing required property 'HealthResponse.unassignedPrimaryShards'
```

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #29 
<br>
<br>


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
