### PR TITLE
[Improve/#33] docker-compose에 Elasticsearch 헬스체크 이후 스프링 헬스 체크 하도록 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@ services:
     networks:
       - app-network
     depends_on:
-      - redis
-      - elasticsearch
+      redis:
+        condition: service_started
+      elasticsearch:
+        condition: service_healthy
 
   redis:
     image: redis:7-alpine
@@ -53,6 +55,12 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    healthcheck:
+      test: [ "CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1" ]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
 networks:
   app-network:


### PR DESCRIPTION
## ❤️ 기능 설명
Elasticsearch 컨테이너에 헬스 체크를 추가하고, Spring Boot 애플리케이션이 Elasticsearch 서비스가 완전히 준비된 후에 시작되도록 개선했습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #33 
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
