### PR TITLE
[Chore/#38] 로컬 개발 환경 docker-compose 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
-application-local.yml
 
 ### Terraform ###
 .terraform/

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,76 @@
+version: '3.8'
+
+services:
+  # MySQL (개발용)
+  mysql:
+    image: mysql:8.0
+    container_name: techfork-mysql-local
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root1234
+      MYSQL_DATABASE: techblog
+      MYSQL_USER: techfork
+      MYSQL_PASSWORD: techfork1234
+      TZ: Asia/Seoul
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - techfork-network
+
+  # Redis
+  redis:
+    image: redis:7-alpine
+    container_name: techfork-redis-local
+    restart: always
+    ports:
+      - "6379:6379"
+    command: redis-server --requirepass redis1234
+    volumes:
+      - redis-data:/data
+    networks:
+      - techfork-network
+
+  # Elasticsearch
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.0
+    container_name: techfork-elasticsearch-local
+    restart: always
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - TZ=Asia/Seoul
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    networks:
+      - techfork-network
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
+
+networks:
+  techfork-network:
+    driver: bridge
+
+volumes:
+  mysql-data:
+  redis-data:
+  elasticsearch-data:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,56 @@
+spring:
+  application:
+    name: TechFork
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/techblog?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    username: techfork
+    password: techfork1234
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 5
+      connection-timeout: 20000
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        highlight_sql: true
+        use_sql_comments: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        jdbc:
+          batch_size: 20
+
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      names: ''
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: redis1234
+      timeout: 3s
+      lettuce:
+        pool:
+          max-active: 8
+          max-idle: 4
+          min-idle: 0
+          max-wait: 5s
+
+elasticsearch:
+  host: localhost
+  port: 9200
+
+logging:
+  level:
+    com.techfork: DEBUG
+    org.springframework.batch: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.type.descriptor.sql.BasicBinder: TRACE


### PR DESCRIPTION
## ❤️ 기능 설명
로컬 개발 환경을 Docker Compose로 표준화했습니다.

### 주요 변경 사항

#### 1. 로컬 개발용 Docker Compose 구성
- **MySQL 8.0**: 포트 3306, 데이터베이스 `techblog`
- **Redis 7**: 포트 6379, 비밀번호 `redis1234`
- **Elasticsearch 8.18.0**: 포트 9200/9300, 한글 검색 지원

#### 2. application-local.yml Git 추가
- 로컬 Docker와 연동되는 설정
- 하드코딩된 더미 값 사용 (보안 위험 없음)
- 모든 팀원이 동일한 설정으로 즉시 개발 가능

## 🐳 Docker Compose 실행 화면

### 컨테이너 실행
```bash
$ docker-compose -f docker-compose.local.yml up -d
[+] Running 4/4
 ✔ Network techfork_techfork-network  Created
 ✔ Container techfork-mysql-local          Started
 ✔ Container techfork-redis-local          Started
 ✔ Container techfork-elasticsearch-local  Started
```

### 상태 확인
```bash
$ docker-compose -f docker-compose.local.yml ps
NAME                              IMAGE              STATUS         PORTS
techfork-elasticsearch-local   elasticsearch:8.18.0   Up 2 minutes   0.0.0.0:9200->9200/tcp, 0.0.0.0:9300->9300/tcp
techfork-mysql-local           mysql:8.0              Up 2 minutes   0.0.0.0:3306->3306/tcp
techfork-redis-local           redis:7-alpine         Up 2 minutes   0.0.0.0:6379->6379/tcp
```

### Elasticsearch 헬스 체크
```bash
$ curl http://localhost:9200/_cluster/health
{
  "cluster_name": "docker-cluster",
  "status": "green",
  "number_of_nodes": 1,
  "active_primary_shards": 0,
  "active_shards": 0
}
```

<br>


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #{} 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?


## 📖 팀원 가이드

### 신규 팀원 온보딩 (5분 완성)
```bash
# 1. 저장소 클론
git clone https://github.com/your-repo/TechFork-server.git
cd TechFork-server

# 2. Docker 인프라 실행
docker-compose -f docker-compose.local.yml up -d

# 3. IntelliJ에서 실행
# Run/Debug Configurations → Active profiles: local
# TechForkApplication 실행

# 4. 확인
# http://localhost:8080/swagger-ui/index.html
```

### 문제 해결

#### "포트가 이미 사용 중입니다"
```bash
# 기존 MySQL/Redis 중지
brew services stop mysql
brew services stop redis

# 또는 docker-compose.local.yml에서 포트 변경
# ports:
#   - "3307:3306"  # 3306 → 3307로 변경
```

#### "Docker 메모리 부족"
```bash
# Docker Desktop → Settings → Resources
# Memory: 최소 4GB 권장
```

#### 환경 초기화
```bash
# 모든 데이터 삭제하고 처음부터 다시 시작
docker-compose -f docker-compose.local.yml down -v
docker-compose -f docker-compose.local.yml up -d
```

<br>