### PR TITLE
[feat/#37] RSS 크롤링 스케줄러 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -52,6 +52,7 @@ jobs:
       DB_USERNAME: ${{ secrets.DB_USERNAME }}
       DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
       REDIS_PASSWORD: ${{ secrets.REDIS_PASSWORD }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
     steps:
       - name: Checkout code
@@ -72,7 +73,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: DOCKER_IMAGE,BRANCH,SPRING_PROFILES_ACTIVE,DB_URL,DB_USERNAME,DB_PASSWORD,REDIS_PASSWORD
+          envs: DOCKER_IMAGE,BRANCH,SPRING_PROFILES_ACTIVE,DB_URL,DB_USERNAME,DB_PASSWORD,REDIS_PASSWORD,DISCORD_WEBHOOK_URL
           script: |
             cd ~/deploy
             chmod +x deploy.sh

--- a/docs/SCHEDULER_GUIDE.md
+++ b/docs/SCHEDULER_GUIDE.md
@@ -1,0 +1,159 @@
+# RSS 크롤링 스케줄러 가이드
+
+## 개요
+
+TechFork의 RSS 크롤링 스케줄러는 1시간마다 자동으로 RSS 피드를 수집하고, 실행 이력을 기록하며, 실패 시 알림을 전송합니다.
+
+## 주요 기능
+
+### 1. 자동 크롤링 (매 시간 정각)
+- **스케줄**: 매 시간 정각 (00분)
+- **동작**: RSS 피드를 자동으로 수집하여 데이터베이스에 저장
+- **중복 방지**: Redis 분산 락을 사용하여 동시 실행 방지
+
+### 2. 크롤링 실행 이력 관리
+- 모든 크롤링 실행 내역을 `crawling_histories` 테이블에 저장
+- 저장 정보:
+  - 실행 상태 (RUNNING, SUCCESS, FAILED)
+  - 시작/종료 시간
+  - 처리 건수 (전체, 성공, 실패)
+  - 에러 메시지 (실패 시)
+  - Spring Batch Job Execution ID
+
+### 3. Redis 분산 락
+- 여러 서버 인스턴스가 동시에 크롤링을 실행하는 것을 방지
+- 락 키: `lock:rss-crawling`
+- 락 유지 시간: 30분 (크롤링 최대 실행 시간)
+
+### 4. 실패 알림 (Discord)
+- 크롤링 실패 시 자동으로 Webhook 알림 전송
+- 알림 내용:
+  - 에러 메시지
+  - Job Execution ID
+  - 발생 시간
+
+### 5. 좀비 프로세스 정리
+- **스케줄**: 5분마다
+- **동작**: 1시간 이상 RUNNING 상태인 이력을 FAILED로 변경
+- 서버 장애 등으로 인한 좀비 프로세스 자동 정리
+
+## 설정 방법
+
+### 1. application-local.yml 설정
+
+```yaml
+# Webhook 알림 활성화 (선택사항)
+webhook:
+  enabled: true  # false이면 알림 비활성화
+  discord:
+    url: https://discord.com/api/webhooks/YOUR/WEBHOOK/URL
+```
+
+### 2. Redis 설정 확인
+
+```yaml
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: redis1234
+```
+
+## 수동 실행 방법
+
+스케줄러를 기다리지 않고 수동으로 크롤링을 실행하려면 기존의 BatchController를 사용하세요:
+
+## 모니터링
+### 애플리케이션 로그 확인
+
+```bash
+# 스케줄러 실행 로그
+grep "RSS crawling scheduler triggered" application.log
+
+# 크롤링 완료 로그
+grep "RSS crawling completed successfully" application.log
+
+# 크롤링 실패 로그
+grep "RSS crawling failed" application.log
+```
+
+## 스케줄 변경 방법
+
+스케줄을 변경하려면 `RssCrawlingScheduler.java`의 `@Scheduled` 어노테이션을 수정하세요:
+
+```java
+// 현재: 매 시간 정각
+@Scheduled(cron = "0 0 * * * *")
+
+// 예시: 30분마다
+@Scheduled(cron = "0 */30 * * * *")
+
+// 예시: 매일 오전 9시
+@Scheduled(cron = "0 0 9 * * *")
+
+// 예시: 평일 오전 9시~오후 6시, 매 시간
+@Scheduled(cron = "0 0 9-18 * * MON-FRI")
+```
+
+### Cron 표현식 형식
+
+```
+초 분 시 일 월 요일
+0  0  *  *  *  *
+
+0-59: 초
+0-59: 분
+0-23: 시
+1-31: 일
+1-12: 월
+0-7: 요일 (0, 7 = 일요일)
+```
+
+## 트러블슈팅
+
+### 1. 스케줄러가 실행되지 않음
+- `@EnableScheduling`이 `SchedulerConfig`에 있는지 확인
+- 애플리케이션 로그에서 스케줄러 초기화 확인
+
+### 2. 중복 실행 발생
+- Redis 연결 상태 확인
+- 분산 락 로그 확인: `"Lock acquired"` 메시지 확인
+
+### 3. 알림이 전송되지 않음
+- `webhook.enabled: true` 설정 확인
+- Webhook URL이 올바른지 확인
+- 네트워크 연결 상태 확인
+
+### 4. 크롤링 이력이 저장되지 않음
+- MySQL 연결 상태 확인
+- `crawling_histories` 테이블이 생성되었는지 확인
+
+## 운영 시 주의사항
+
+### 1. 락 타임아웃
+- 기본 락 유지 시간: 30분
+- 크롤링이 30분 이상 걸리면 락이 자동으로 해제됨
+- 필요시 `LOCK_TTL` 값 조정
+
+### 2. 데이터베이스 용량
+- 크롤링 이력이 계속 쌓이므로 주기적으로 정리 필요
+- 권장: 6개월~1년 이상된 SUCCESS 이력 삭제
+
+### 3. Webhook Rate Limit
+- Slack/Discord는 초당 요청 수 제한이 있음
+- 실패 알림이 너무 자주 발생하면 Rate Limit 발생 가능
+
+### 4. 성능 최적화
+- `rssTaskExecutor` 설정으로 병렬 처리 조절
+- 현재 설정: Core 5개, Max 10개 스레드
+- RSS 피드 개수가 많으면 스레드 수 증가 고려
+
+## API 엔드포인트 (향후 추가 예정)
+
+```
+GET  /api/crawling/histories         - 크롤링 이력 목록 조회
+GET  /api/crawling/histories/{id}    - 특정 이력 상세 조회
+POST /api/crawling/trigger            - 수동 크롤링 트리거
+GET  /api/crawling/status             - 현재 크롤링 상태 조회
+```

--- a/src/main/java/com/techfork/domain/source/entity/CrawlingHistory.java
+++ b/src/main/java/com/techfork/domain/source/entity/CrawlingHistory.java
@@ -1,10 +1,14 @@
 package com.techfork.domain.source.entity;
 
+import com.techfork.domain.source.enums.ECrawlingStatus;
 import com.techfork.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "crawling_histories")
@@ -12,7 +16,56 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CrawlingHistory extends BaseTimeEntity {
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "tech_blog_id", nullable = false)
-    private TechBlog techBlog;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ECrawlingStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime startedAt;
+
+    private LocalDateTime endedAt;
+
+    @Column(nullable = false)
+    private Integer totalCount = 0;
+
+    @Column(nullable = false)
+    private Integer successCount = 0;
+
+    @Column(nullable = false)
+    private Integer failCount = 0;
+
+    @Column(columnDefinition = "TEXT")
+    private String errorMessage;
+
+    @Column(name = "job_execution_id")
+    private Long jobExecutionId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private CrawlingHistory(ECrawlingStatus status, LocalDateTime startedAt, Long jobExecutionId) {
+        this.status = status;
+        this.startedAt = startedAt;
+        this.jobExecutionId = jobExecutionId;
+    }
+
+    public static CrawlingHistory createStarted(Long jobExecutionId) {
+        return CrawlingHistory.builder()
+                .status(ECrawlingStatus.RUNNING)
+                .startedAt(LocalDateTime.now())
+                .jobExecutionId(jobExecutionId)
+                .build();
+    }
+
+    public void complete(Integer totalCount, Integer successCount, Integer failCount) {
+        this.status = ECrawlingStatus.SUCCESS;
+        this.endedAt = LocalDateTime.now();
+        this.totalCount = totalCount;
+        this.successCount = successCount;
+        this.failCount = failCount;
+    }
+
+    public void fail(String errorMessage) {
+        this.status = ECrawlingStatus.FAILED;
+        this.endedAt = LocalDateTime.now();
+        this.errorMessage = errorMessage;
+    }
 }

--- a/src/main/java/com/techfork/domain/source/enums/ECrawlingStatus.java
+++ b/src/main/java/com/techfork/domain/source/enums/ECrawlingStatus.java
@@ -1,0 +1,7 @@
+package com.techfork.domain.source.enums;
+
+public enum ECrawlingStatus {
+    RUNNING,
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/com/techfork/domain/source/repository/CrawlingHistoryRepository.java
+++ b/src/main/java/com/techfork/domain/source/repository/CrawlingHistoryRepository.java
@@ -1,0 +1,16 @@
+package com.techfork.domain.source.repository;
+
+import com.techfork.domain.source.entity.CrawlingHistory;
+import com.techfork.domain.source.enums.ECrawlingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CrawlingHistoryRepository extends JpaRepository<CrawlingHistory, Long> {
+
+    List<CrawlingHistory> findByStatusAndStartedAtBefore(ECrawlingStatus status, LocalDateTime dateTime);
+}

--- a/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
+++ b/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
@@ -1,0 +1,75 @@
+package com.techfork.domain.source.scheduler;
+
+import com.techfork.domain.source.entity.CrawlingHistory;
+import com.techfork.domain.source.enums.ECrawlingStatus;
+import com.techfork.domain.source.repository.CrawlingHistoryRepository;
+import com.techfork.domain.source.service.CrawlingService;
+import com.techfork.global.lock.DistributedLock;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+/**
+ * RSS 크롤링 스케줄러
+ * - 1시간마다 RSS 피드 크롤링 실행
+ * - Redis 분산 락으로 중복 실행 방지
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RssCrawlingScheduler {
+
+    private final CrawlingService crawlingService;
+    private final DistributedLock distributedLock;
+    private final CrawlingHistoryRepository crawlingHistoryRepository;
+
+    private static final String CRAWLING_LOCK_KEY = "rss-crawling";
+    private static final Duration LOCK_TTL = Duration.ofMinutes(30); // 크롤링 최대 실행 시간
+
+    /**
+     * 1시간마다 RSS 크롤링 실행
+     * cron: 0 0 * * * * -> 매 시간 정각
+     */
+    @Scheduled(cron = "0 0 * * * *")
+    public void scheduleCrawling() {
+        log.info("RSS crawling scheduler triggered");
+
+        String lockValue = distributedLock.tryLock(CRAWLING_LOCK_KEY, LOCK_TTL);
+
+        if (lockValue == null) {
+            log.warn("Another crawling job is already running. Skipping this execution.");
+            return;
+        }
+
+        try {
+            crawlingService.executeCrawling();
+        } catch (Exception e) {
+            log.error("Unexpected error during scheduled crawling", e);
+        } finally {
+            distributedLock.unlock(CRAWLING_LOCK_KEY, lockValue);
+        }
+    }
+
+    /**
+     * 5분마다 오래된 RUNNING 상태의 이력을 정리 (좀비 프로세스 방지)
+     * cron: 매 5분마다 실행
+     */
+    @Scheduled(cron = "0 */5 * * * *")
+    public void cleanupStaleHistories() {
+        log.debug("Checking for stale crawling histories");
+
+        var staleHistories = crawlingHistoryRepository.findByStatusAndStartedAtBefore(
+                ECrawlingStatus.RUNNING, java.time.LocalDateTime.now().minusHours(1)
+        );
+
+        for (CrawlingHistory history : staleHistories) {
+            log.warn("Found stale crawling history: id={}, startedAt={}",
+                    history.getId(), history.getStartedAt());
+            history.fail("Crawling job timed out or was interrupted");
+            crawlingHistoryRepository.save(history);
+        }
+    }
+}

--- a/src/main/java/com/techfork/domain/source/service/CrawlingService.java
+++ b/src/main/java/com/techfork/domain/source/service/CrawlingService.java
@@ -29,10 +29,6 @@ public class CrawlingService {
     private final CrawlingHistoryRepository crawlingHistoryRepository;
     private final WebhookNotificationService webhookNotificationService;
 
-    /**
-     * RSS 크롤링 실행
-     */
-    @Transactional
     public void executeCrawling() {
         log.info("Starting RSS crawling job");
 
@@ -77,9 +73,6 @@ public class CrawlingService {
         }
     }
 
-    /**
-     * Job 실행 완료 대기 및 결과 처리
-     */
     private void waitForJobCompletion(JobExecution jobExecution, CrawlingHistory history) {
         BatchStatus batchStatus = jobExecution.getStatus();
 

--- a/src/main/java/com/techfork/domain/source/service/CrawlingService.java
+++ b/src/main/java/com/techfork/domain/source/service/CrawlingService.java
@@ -1,0 +1,147 @@
+package com.techfork.domain.source.service;
+
+import com.techfork.domain.source.entity.CrawlingHistory;
+import com.techfork.domain.source.repository.CrawlingHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.*;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * RSS 크롤링 실행 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CrawlingService {
+
+    private final JobLauncher jobLauncher;
+    private final Job rssCrawlingJob;
+    private final CrawlingHistoryRepository crawlingHistoryRepository;
+    private final WebhookNotificationService webhookNotificationService;
+
+    /**
+     * RSS 크롤링 실행
+     */
+    @Transactional
+    public void executeCrawling() {
+        log.info("Starting RSS crawling job");
+
+        CrawlingHistory history = null;
+        JobExecution jobExecution = null;
+
+        try {
+            // Job 파라미터 생성 (매번 다른 파라미터로 실행)
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addLong("timestamp", System.currentTimeMillis())
+                    .toJobParameters();
+
+            jobExecution = jobLauncher.run(rssCrawlingJob, jobParameters);
+            Long jobExecutionId = jobExecution.getId();
+
+            history = CrawlingHistory.createStarted(jobExecutionId);
+            crawlingHistoryRepository.save(history);
+
+            log.info("RSS crawling job started: jobExecutionId={}", jobExecutionId);
+
+            // Job 실행 완료 대기 및 결과 처리
+            waitForJobCompletion(jobExecution, history);
+
+        } catch (JobExecutionAlreadyRunningException e) {
+            log.warn("Job is already running", e);
+            if (history != null) {
+                history.fail("Job is already running");
+                crawlingHistoryRepository.save(history);
+            }
+        } catch (JobRestartException e) {
+            log.error("Job restart failed", e);
+            handleJobFailure(history, jobExecution, "Job restart failed: " + e.getMessage());
+        } catch (JobInstanceAlreadyCompleteException e) {
+            log.error("Job instance already complete", e);
+            handleJobFailure(history, jobExecution, "Job instance already complete: " + e.getMessage());
+        } catch (JobParametersInvalidException e) {
+            log.error("Invalid job parameters", e);
+            handleJobFailure(history, jobExecution, "Invalid job parameters: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("Unexpected error during crawling", e);
+            handleJobFailure(history, jobExecution, "Unexpected error: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Job 실행 완료 대기 및 결과 처리
+     */
+    private void waitForJobCompletion(JobExecution jobExecution, CrawlingHistory history) {
+        BatchStatus batchStatus = jobExecution.getStatus();
+
+        while (batchStatus.isRunning()) {
+            try {
+                Thread.sleep(1000);
+                batchStatus = jobExecution.getStatus();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Job execution monitoring interrupted", e);
+                break;
+            }
+        }
+
+        // Job 실행 결과 처리
+        if (batchStatus == BatchStatus.COMPLETED) {
+            handleJobSuccess(history, jobExecution);
+        } else {
+            handleJobFailure(history, jobExecution,
+                    "Job failed with status: " + batchStatus);
+        }
+    }
+
+    /**
+     * Job 성공 처리
+     */
+    @Transactional
+    public void handleJobSuccess(CrawlingHistory history, JobExecution jobExecution) {
+        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+        int readCount = (int) stepExecution.getReadCount();
+        int writeCount = (int) stepExecution.getWriteCount();
+        int skipCount = (int) stepExecution.getSkipCount();
+
+        history.complete(readCount, writeCount, skipCount);
+        crawlingHistoryRepository.save(history);
+
+        log.info("RSS crawling completed successfully: " +
+                        "total={}, success={}, failed={}",
+                readCount, writeCount, skipCount);
+    }
+
+    /**
+     * Job 실패 처리
+     */
+    @Transactional
+    public void handleJobFailure(CrawlingHistory history, JobExecution jobExecution, String errorMessage) {
+        if (history != null) {
+            history.fail(errorMessage);
+            crawlingHistoryRepository.save(history);
+        }
+
+        log.error("RSS crawling failed: {}", errorMessage);
+
+        // 실패 알림 전송
+        Map<String, Object> context = new HashMap<>();
+        context.put("errorMessage", errorMessage);
+        context.put("timestamp", LocalDateTime.now());
+        if (jobExecution != null) {
+            context.put("jobExecutionId", jobExecution.getId());
+        }
+
+        webhookNotificationService.sendCrawlingFailureNotification(context);
+    }
+}

--- a/src/main/java/com/techfork/domain/source/service/WebhookNotificationService.java
+++ b/src/main/java/com/techfork/domain/source/service/WebhookNotificationService.java
@@ -1,0 +1,75 @@
+package com.techfork.domain.source.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WebhookNotificationService {
+
+    @Value("${webhook.discord.url:#{null}}")
+    private String discordWebhookUrl;
+
+    @Value("${webhook.enabled:false}")
+    private boolean webhookEnabled;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void sendCrawlingFailureNotification(Map<String, Object> context) {
+        if (!webhookEnabled) {
+            log.debug("Webhook notification is disabled");
+            return;
+        }
+
+        String errorMessage = (String) context.getOrDefault("errorMessage", "Unknown error");
+        LocalDateTime timestamp = (LocalDateTime) context.getOrDefault("timestamp", LocalDateTime.now());
+        Long jobExecutionId = (Long) context.get("jobExecutionId");
+
+        String message = buildFailureMessage(errorMessage, timestamp, jobExecutionId);
+
+        if (discordWebhookUrl != null && !discordWebhookUrl.isEmpty()) {
+            sendDiscordNotification(message);
+        }
+    }
+
+    private String buildFailureMessage(String errorMessage, LocalDateTime timestamp, Long jobExecutionId) {
+        return String.format(
+                "🚨 RSS Crawling Failed\n" +
+                        "- Error: %s\n" +
+                        "- Job Execution ID: %s\n" +
+                        "- Time: %s",
+                errorMessage,
+                jobExecutionId != null ? jobExecutionId : "N/A",
+                timestamp.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"))
+        );
+    }
+
+    private void sendDiscordNotification(String message) {
+        try {
+            Map<String, String> payload = new HashMap<>();
+            payload.put("content", message);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+
+            HttpEntity<Map<String, String>> request = new HttpEntity<>(payload, headers);
+            restTemplate.postForEntity(discordWebhookUrl, request, String.class);
+
+            log.info("Discord notification sent successfully");
+        } catch (Exception e) {
+            log.error("Failed to send Discord notification", e);
+        }
+    }
+}

--- a/src/main/java/com/techfork/global/config/RedisConfig.java
+++ b/src/main/java/com/techfork/global/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package com.techfork.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * Redis 설정
+ */
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+
+        return template;
+    }
+}

--- a/src/main/java/com/techfork/global/config/SchedulerConfig.java
+++ b/src/main/java/com/techfork/global/config/SchedulerConfig.java
@@ -1,0 +1,12 @@
+package com.techfork.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * 스케줄러 설정
+ */
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/src/main/java/com/techfork/global/lock/DistributedLock.java
+++ b/src/main/java/com/techfork/global/lock/DistributedLock.java
@@ -1,0 +1,102 @@
+package com.techfork.global.lock;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.UUID;
+
+/**
+ * Redis 기반 분산 락 구현
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DistributedLock {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String LOCK_PREFIX = "lock:";
+
+    /**
+     * 락 획득 시도
+     *
+     * @param key 락 키
+     * @param ttl 락 유지 시간
+     * @return 락 획득 성공 시 락 식별자, 실패 시 null
+     */
+    public String tryLock(String key, Duration ttl) {
+        String lockKey = LOCK_PREFIX + key;
+        String lockValue = UUID.randomUUID().toString();
+
+        Boolean success = redisTemplate.opsForValue()
+                .setIfAbsent(lockKey, lockValue, ttl);
+
+        if (Boolean.TRUE.equals(success)) {
+            log.debug("Lock acquired: key={}, value={}", lockKey, lockValue);
+            return lockValue;
+        }
+
+        log.debug("Lock acquisition failed: key={}", lockKey);
+        return null;
+    }
+
+    /**
+     * 락 해제
+     *
+     * @param key 락 키
+     * @param lockValue 락 획득 시 받은 식별자
+     * @return 락 해제 성공 여부
+     */
+    public boolean unlock(String key, String lockValue) {
+        if (lockValue == null) {
+            return false;
+        }
+
+        String lockKey = LOCK_PREFIX + key;
+        String currentValue = redisTemplate.opsForValue().get(lockKey);
+
+        if (lockValue.equals(currentValue)) {
+            Boolean deleted = redisTemplate.delete(lockKey);
+            log.debug("Lock released: key={}, success={}", lockKey, deleted);
+            return Boolean.TRUE.equals(deleted);
+        }
+
+        log.warn("Lock value mismatch: key={}, expected={}, current={}", lockKey, lockValue, currentValue);
+        return false;
+    }
+
+    /**
+     * 락 획득을 기다리며 시도
+     *
+     * @param key 락 키
+     * @param ttl 락 유지 시간
+     * @param waitTime 대기 시간
+     * @param retryInterval 재시도 간격
+     * @return 락 획득 성공 시 락 식별자, 실패 시 null
+     */
+    public String tryLockWithWait(String key, Duration ttl, Duration waitTime, Duration retryInterval) {
+        long startTime = System.currentTimeMillis();
+        long waitMillis = waitTime.toMillis();
+        long retryMillis = retryInterval.toMillis();
+
+        while (System.currentTimeMillis() - startTime < waitMillis) {
+            String lockValue = tryLock(key, ttl);
+            if (lockValue != null) {
+                return lockValue;
+            }
+
+            try {
+                Thread.sleep(retryMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.error("Lock acquisition interrupted: key={}", key, e);
+                return null;
+            }
+        }
+
+        log.warn("Lock acquisition timeout: key={}, waitTime={}", key, waitTime);
+        return null;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -44,6 +44,11 @@ spring:
           min-idle: 0
           max-wait: 5s
 
+webhook:
+  enabled: true
+  discord:
+    url: ${DISCORD_WEBHOOK_URL:}
+
 elasticsearch:
   host: elasticsearch
   port: 9200

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -48,6 +48,11 @@ elasticsearch:
   host: localhost
   port: 9200
 
+webhook:
+  enabled: true
+  discord:
+    url: ${DISCORD_WEBHOOK_URL:}
+
 logging:
   level:
     com.techfork: DEBUG


### PR DESCRIPTION
## ❤️ 기능 설명
1시간 주기로 자동 RSS 크롤링을 수행하는 스케줄러를 구현했습니다.

### 주요 변경 사항
- `RssCrawlingScheduler` 생성: `@Scheduled`로 1시간마다 `rssCrawlingJob` 실행
- Redis 분산 락 적용: 동시 실행 방지
- 크롤링 이력 로깅: 시작/종료 시각, 수집 건수, 성공/실패 기록
- 실패 시 Discord 웹훅 알림


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #37 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
