### PR TITLE
[Improve/#48] RSS 크롤링 시 정제된 콘텐츠도 함께 저장

### DIFF
--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -23,6 +23,9 @@ public class Post extends BaseEntity {
     @Column(columnDefinition = "MEDIUMTEXT")
     private String fullContent;
 
+    @Column(columnDefinition = "MEDIUMTEXT")
+    private String plainContent;
+
     @Column(nullable = false)
     private String company;
 
@@ -40,10 +43,11 @@ public class Post extends BaseEntity {
     private TechBlog techBlog;
 
     @Builder
-    private Post(String title, String fullContent, String company, String url,
+    private Post(String title, String fullContent, String plainContent, String company, String url,
                  LocalDateTime publishedAt, LocalDateTime crawledAt, TechBlog techBlog) {
         this.title = title;
         this.fullContent = fullContent;
+        this.plainContent = plainContent;
         this.company = company;
         this.url = url;
         this.publishedAt = publishedAt;
@@ -55,6 +59,7 @@ public class Post extends BaseEntity {
         return Post.builder()
                 .title(item.title())
                 .fullContent(item.content())
+                .plainContent(item.plainContent())
                 .company(item.company())
                 .url(item.url())
                 .publishedAt(item.publishedAt())

--- a/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
+++ b/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
@@ -2,6 +2,7 @@ package com.techfork.domain.source.batch;
 
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
+import com.techfork.global.util.JdbcBulkInsert;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -9,9 +10,12 @@ import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 /**
  * Post를 배치로 저장하는 Writer
  * Processor에서 중복 체크가 완료되므로 여기서는 단순 저장만 수행
+ * JDBC Bulk Insert를 사용하여 성능 최적화
  */
 @Slf4j
 @Component
@@ -19,7 +23,13 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PostBatchWriter implements ItemWriter<Post> {
 
-    private final PostRepository postRepository;
+    private final JdbcBulkInsert jdbcBulkInsert;
+
+    private static final String INSERT_SQL = """
+            INSERT INTO posts
+            (title, full_content, plain_content, company, url, published_at, crawled_at, tech_blog_id, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            """;
 
     @Override
     public void write(Chunk<? extends Post> chunk) {
@@ -27,7 +37,19 @@ public class PostBatchWriter implements ItemWriter<Post> {
             return;
         }
 
-        postRepository.saveAll(chunk.getItems());
-        log.info("{}개 게시글 저장 완료", chunk.size());
+        List<? extends Post> items = chunk.getItems();
+
+        int inserted = jdbcBulkInsert.batchInsert(INSERT_SQL, items, (ps, post, i) -> {
+            ps.setString(1, post.getTitle());
+            ps.setString(2, post.getFullContent());
+            ps.setString(3, post.getPlainContent());
+            ps.setString(4, post.getCompany());
+            ps.setString(5, post.getUrl());
+            ps.setTimestamp(6, JdbcBulkInsert.toTimestamp(post.getPublishedAt()));
+            ps.setTimestamp(7, JdbcBulkInsert.toTimestamp(post.getCrawledAt()));
+            ps.setLong(8, post.getTechBlog().getId());
+        });
+
+        log.info("{}개 게시글 Bulk Insert 완료", inserted);
     }
 }

--- a/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
+++ b/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
@@ -27,8 +27,8 @@ public class PostBatchWriter implements ItemWriter<Post> {
 
     private static final String INSERT_SQL = """
             INSERT INTO posts
-            (title, full_content, plain_content, company, url, published_at, crawled_at, tech_blog_id, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, NOW(), NOW())
+            (title, full_content, plain_content, company, url, published_at, crawled_at, tech_blog_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """;
 
     @Override

--- a/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
+++ b/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
@@ -8,6 +8,7 @@ import com.rometools.rome.io.XmlReader;
 import com.techfork.domain.source.dto.RssFeedItem;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.source.repository.TechBlogRepository;
+import com.techfork.global.util.ContentCleaner;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
@@ -113,6 +114,9 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
         // 본문 추출 (description 또는 content 중 더 긴 것 사용)
         String content = extractContent(entry);
 
+        // HTML 태그 및 마크다운 제거한 plain text 생성
+        String plainContent = ContentCleaner.clean(content);
+
         // 발행일 변환
         LocalDateTime publishedAt = convertToLocalDateTime(entry.getPublishedDate());
 
@@ -123,6 +127,7 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
                 .title(entry.getTitle())
                 .url(entry.getLink())
                 .content(content)
+                .plainContent(plainContent)
                 .publishedAt(publishedAt)
                 .company(techBlog.getCompanyName())
                 .techBlogId(techBlog.getId())

--- a/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
+++ b/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -31,30 +32,47 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
 
     private final TechBlogRepository techBlogRepository;
 
-    private Iterator<TechBlog> techBlogIterator;
-    private Iterator<RssFeedItem> currentBlogItemIterator;
+    private ConcurrentLinkedQueue<RssFeedItem> itemQueue;
 
     @Override
     public RssFeedItem read() {
-        // 현재 블로그의 아이템이 남아있으면 반환
-        if (currentBlogItemIterator != null && currentBlogItemIterator.hasNext()) {
-            return currentBlogItemIterator.next();
+        // 첫 실행 시 모든 RSS 아이템을 큐에 추가
+        if (itemQueue == null) {
+            initializeQueue();
         }
 
-        // 첫 실행이거나 다음 블로그로 넘어가야 하는 경우
-        if (techBlogIterator == null) {
-            initializeTechBlogIterator();
+        // 큐에서 아이템 꺼내기 (Thread-Safe)
+        RssFeedItem item = itemQueue.poll();
+
+        if (item == null) {
+            log.info("모든 RSS 피드 수집 완료");
         }
 
-        // 다음 블로그 처리
-        while (techBlogIterator.hasNext()) {
-            TechBlog techBlog = techBlogIterator.next();
+        return item;
+    }
+
+    /**
+     * 모든 RSS 피드를 미리 수집하여 큐에 저장
+     * 한 번만 실행되며, 여러 스레드가 큐에서 안전하게 아이템을 가져감
+     */
+    private synchronized void initializeQueue() {
+        // Double-checked locking
+        if (itemQueue != null) {
+            return;
+        }
+
+        itemQueue = new ConcurrentLinkedQueue<>();
+        List<TechBlog> techBlogs = techBlogRepository.findAll();
+        log.info("총 {}개 테크 블로그 RSS 수집 시작", techBlogs.size());
+
+        int totalItems = 0;
+        for (TechBlog techBlog : techBlogs) {
             try {
                 List<RssFeedItem> items = fetchRssFeed(techBlog);
                 if (!items.isEmpty()) {
-                    currentBlogItemIterator = items.iterator();
+                    itemQueue.addAll(items);
+                    totalItems += items.size();
                     log.info("[{}] RSS 수집 성공: {}개 아이템", techBlog.getCompanyName(), items.size());
-                    return currentBlogItemIterator.next();
                 } else {
                     log.warn("[{}] RSS 피드에 아이템이 없습니다", techBlog.getCompanyName());
                 }
@@ -64,15 +82,7 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
             }
         }
 
-        // 모든 블로그 처리 완료
-        log.info("모든 RSS 피드 수집 완료");
-        return null;
-    }
-
-    private void initializeTechBlogIterator() {
-        List<TechBlog> techBlogs = techBlogRepository.findAll();
-        this.techBlogIterator = techBlogs.iterator();
-        log.info("총 {}개 테크 블로그 RSS 수집 시작", techBlogs.size());
+        log.info("RSS 수집 초기화 완료: 총 {}개 아이템을 큐에 추가", totalItems);
     }
 
     private List<RssFeedItem> fetchRssFeed(TechBlog techBlog) throws Exception {

--- a/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
+++ b/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
@@ -85,12 +85,7 @@ public class RssCrawlingJobConfig {
                 .writer(postBatchWriter)
                 // 병렬 처리: 5개 스레드로 동시에 RSS 수집
                 .taskExecutor(rssTaskExecutor())
-                // 재시도 정책: 네트워크 오류 발생 시 최대 3회 재시도
                 .faultTolerant()
-                .retryLimit(3)
-                .retry(SocketTimeoutException.class)
-                .retry(Exception.class)
-                .noRetry(IllegalStateException.class) // TechBlog를 못 찾는 경우는 재시도 안 함
                 // 건너뛰기 정책: 최대 10개 아이템까지 건너뛰기 허용
                 .skipLimit(10)
                 .skip(Exception.class)

--- a/src/main/java/com/techfork/domain/source/dto/RssFeedItem.java
+++ b/src/main/java/com/techfork/domain/source/dto/RssFeedItem.java
@@ -9,6 +9,7 @@ public record RssFeedItem(
         String title,
         String url,
         String content,
+        String plainContent,
         LocalDateTime publishedAt,
         String company,
         Long techBlogId,

--- a/src/main/java/com/techfork/global/util/JdbcBulkInsert.java
+++ b/src/main/java/com/techfork/global/util/JdbcBulkInsert.java
@@ -1,0 +1,86 @@
+package com.techfork.global.util;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.List;
+
+/**
+ * JDBC Batch Insert를 위한 유틸리티 클래스
+ * JPA의 saveAll보다 훨씬 빠른 대량 삽입 제공
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JdbcBulkInsert {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * Batch Insert 실행
+     *
+     * @param sql INSERT 쿼리 (PreparedStatement 형식)
+     * @param items 삽입할 데이터 리스트
+     * @param setter 각 항목에 대한 PreparedStatement 설정 로직
+     * @param <T> 데이터 타입
+     * @return 실제로 삽입된 행의 수
+     */
+    public <T> int batchInsert(String sql, List<T> items, BatchParameterSetter<T> setter) {
+        if (items == null || items.isEmpty()) {
+            return 0;
+        }
+
+        int[] updateCounts = jdbcTemplate.batchUpdate(sql, new BatchPreparedStatementSetter() {
+            @Override
+            public void setValues(PreparedStatement ps, int i) throws SQLException {
+                setter.setValues(ps, items.get(i), i);
+            }
+
+            @Override
+            public int getBatchSize() {
+                return items.size();
+            }
+        });
+
+        int totalInserted = 0;
+        for (int count : updateCounts) {
+            if (count > 0) {
+                totalInserted += count;
+            }
+        }
+
+        log.debug("Bulk insert 완료: {}개 항목 중 {}개 삽입됨", items.size(), totalInserted);
+        return totalInserted;
+    }
+
+    /**
+     * PreparedStatement에 파라미터를 설정하는 함수형 인터페이스
+     *
+     * @param <T> 데이터 타입
+     */
+    @FunctionalInterface
+    public interface BatchParameterSetter<T> {
+        /**
+         * PreparedStatement에 파라미터 설정
+         *
+         * @param ps PreparedStatement
+         * @param item 현재 항목
+         * @param index 현재 인덱스
+         * @throws SQLException SQL 예외
+         */
+        void setValues(PreparedStatement ps, T item, int index) throws SQLException;
+    }
+
+    /**
+     * Timestamp 변환 헬퍼 메서드
+     */
+    public static Timestamp toTimestamp(java.time.LocalDateTime dateTime) {
+        return dateTime != null ? Timestamp.valueOf(dateTime) : null;
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
RSS 크롤링 Step에서 원본 콘텐츠(`fullContent`)와 정제된 콘텐츠(`cleanedContent`)를 동시에 저장하도록 개선했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="554" height="229" alt="image" src="https://github.com/user-attachments/assets/b090a48b-3707-48d8-9ed6-8d8f4a806253" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #48 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 메타데이터 추출 파이프라인은 요약 생성으로 변경할 예정이므로 다음 이슈에서 수정하겠습니다.
- [ ] claude api 키를 누락해 현재 CD가 제대로 되지 않는데, 이것도 chatGPT로 변경할 예정이므로 다음 이슈에서 해결합니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
