### PR TITLE
[chore/#51] 테크 블로그 RSS 피드가 제대로 지원되지 않는 블로그 대체

### DIFF
--- a/src/main/java/com/techfork/global/config/InitialDataConfig.java
+++ b/src/main/java/com/techfork/global/config/InitialDataConfig.java
@@ -29,42 +29,37 @@ public class InitialDataConfig {
 
             List<TechBlog> techBlogs = List.of(
                     TechBlog.create("무신사", "https://medium.com/musinsa-tech", "https://medium.com/feed/musinsa-tech"),
-                    TechBlog.create("라인", "https://engineering.linecorp.com/ko/blog", "https://engineering.linecorp.com/ko/feed/"),
                     TechBlog.create("HYPERCONNECT", "https://hyperconnect.github.io", "https://hyperconnect.github.io/feed.xml"),
                     TechBlog.create("여기어때", "https://techblog.gccompany.co.kr", "https://techblog.gccompany.co.kr/rss"),
                     TechBlog.create("인프랩", "https://tech.inflab.com", "https://tech.inflab.com/rss.xml"),
 
                     TechBlog.create("네이버D2", "https://d2.naver.com/home", "https://d2.naver.com/d2.atom"),
                     TechBlog.create("요기요", "https://techblog.yogiyo.co.kr", "https://techblog.yogiyo.co.kr/feed"),
-                    TechBlog.create("넷마블", "https://netmarble.engineering", "https://netmarble.engineering/feed/"),
                     TechBlog.create("올리브영", "https://oliveyoung.tech", "https://oliveyoung.tech/rss.xml"),
+                    TechBlog.create("쏘카", "https://tech.socarcorp.kr/", "https://tech.socarcorp.kr/feed"),
 
-                    TechBlog.create("마켓컬리", "https://helloworld.kurly.com", "https://helloworld.kurly.com/feed.xml"),
                     TechBlog.create("당근마켓", "https://medium.com/daangn", "https://medium.com/feed/daangn"),
                     TechBlog.create("29CM", "https://medium.com/29cm", "https://medium.com/feed/29cm"),
-
                     TechBlog.create("우아한형제들", "https://techblog.woowahan.com", "https://techblog.woowahan.com/feed/"),
                     TechBlog.create("토스", "https://toss.tech", "https://toss.tech/rss.xml"),
                     TechBlog.create("리디", "https://www.ridicorp.com/story-category/tech-blog/", "https://www.ridicorp.com/story-category/tech-blog/feed/"),
-                    TechBlog.create("SK C&C", "https://engineering-skcc.github.io", "https://engineering-skcc.github.io/feed.xml"),
 
+                    TechBlog.create("SK C&C", "https://engineering-skcc.github.io", "https://engineering-skcc.github.io/feed.xml"),
                     TechBlog.create("카카오엔터프라이즈", "https://tech.kakaoenterprise.com", "https://tech.kakaoenterprise.com/feed"),
                     TechBlog.create("NHN", "https://meetup.nhncloud.com", "https://meetup.nhncloud.com/rss"),
                     TechBlog.create("원티드", "https://medium.com/wantedjobs", "https://medium.com/feed/wantedjobs"),
+                    TechBlog.create("SSG", "https://medium.com/ssgtech", "https://medium.com/feed/ssgtech"),
 
-                    TechBlog.create("카카오", "https://tech.kakao.com/blog", "https://tech.kakao.com/feed/"),
                     TechBlog.create("왓챠", "https://medium.com/watcha", "https://medium.com/feed/watcha"),
                     TechBlog.create("롯데ON", "https://techblog.lotteon.com", "https://techblog.lotteon.com/feed"),
                     TechBlog.create("네이버 플레이스", "https://medium.com/naver-place-dev", "https://medium.com/feed/naver-place-dev"),
-
                     TechBlog.create("데브시스터즈", "https://tech.devsisters.com", "https://tech.devsisters.com/rss.xml"),
-                    TechBlog.create("뱅크샐러드", "https://blog.banksalad.com/tech", "https://blog.banksalad.com/rss.xml"),
-                    TechBlog.create("지마켓", "https://dev.gmarket.com", "https://dev.gmarket.com/rss"),
 
-                    TechBlog.create("카카오페이", "https://tech.kakaopay.com", "https://tech.kakaopay.com/rss.xml"),
+                    TechBlog.create("지마켓", "https://dev.gmarket.com", "https://dev.gmarket.com/rss"),
                     TechBlog.create("번개장터", "https://medium.com/bunjang-tech-blog", "https://medium.com/feed/bunjang-tech-blog"),
                     TechBlog.create("스포카", "https://spoqa.github.io", "https://spoqa.github.io/rss"),
-                    TechBlog.create("줌인터넷", "https://zuminternet.github.io", "https://zuminternet.github.io/feed.xml")
+                    TechBlog.create("줌인터넷", "https://zuminternet.github.io", "https://zuminternet.github.io/feed.xml"),
+                    TechBlog.create("AWS 한국", "https://aws.amazon.com/ko/blogs/tech/", "https://aws.amazon.com/ko/blogs/tech/feed")
             );
 
             techBlogRepository.saveAll(techBlogs);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -61,7 +61,7 @@ spring:
           max-tokens: 8192
 
 scheduler:
-  enabled: false
+  enabled: true
 
 webhook:
   enabled: true


### PR DESCRIPTION
## ❤️ 기능 설명
테크 블로그 중 
- 마켓컬리
- 카카오페이
- 카카오 
- 뱅크샐러드
- 라인
- 넷마블
<br>
RSS 피드의 full_content가 제대로 지원되지 않아 


- 쏘카
- SSG
- AWS 한국으로 변경했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #51 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [x] 이제 EC2에서 스케쥴러가 동작하도록 변경했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
