### PR TITLE
[fix/#54] Docker에서 더이상 지원하지 않는 slim jdk 대신 eclipse jdk로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Java 17 기반 슬림 이미지 사용
-FROM openjdk:17-slim
+# Java 17
+FROM eclipse-temurin:17-jdk
 
 ARG JAR_FILE=build/libs/*.jar
 


### PR DESCRIPTION
## ❤️ 기능 설명
Dockerfile을 수정해서 다른 jdk를 사용하도록 변경했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #54 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
