### PR TITLE
[feat/#58] 임베딩 및 색인 파이프라인 구현

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -66,6 +66,19 @@ services:
       retries: 30
       start_period: 60s
 
+  kibana:
+    image: kibana:8.18.0
+    container_name: kibana
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    volumes:
+      - ./kibana.local.yml:/usr/share/kibana/config/kibana.local.yml:ro
+    networks:
+      - techfork-network
+
 networks:
   techfork-network:
     driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,20 @@ services:
       retries: 30
       start_period: 60s
 
+  kibana:
+    image: kibana:8.18.0
+    container_name: tech-fork-kibana
+    restart: always
+    ports:
+      - "5601:5601"
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    volumes:
+      - ./kibana.yml:/usr/share/kibana/config/kibana.yml:ro
+    networks:
+      - app-network
+
 networks:
   app-network:
     driver: bridge

--- a/kibana.local.yml
+++ b/kibana.local.yml
@@ -1,0 +1,12 @@
+server.host: "0.0.0.0"
+server.shutdownTimeout: "5s"
+elasticsearch.hosts: [ "http://techfork-elasticsearch-local:9200" ]
+
+# 암호화 키 설정
+xpack.encryptedSavedObjects.encryptionKey: "a_dummy_key_must_be_at_least_32_chars_long"
+
+# Enterprise Search 플러그인 비활성화
+enterpriseSearch.enabled: false
+
+# 모니터링 설정
+monitoring.ui.container.elasticsearch.enabled: true

--- a/kibana.yml
+++ b/kibana.yml
@@ -1,0 +1,12 @@
+server.host: "0.0.0.0"
+server.shutdownTimeout: "5s"
+elasticsearch.hosts: [ "http://tech-fork-elasticsearch:9200" ]
+
+# 암호화 키 설정
+xpack.encryptedSavedObjects.encryptionKey: "a_dummy_key_must_be_at_least_32_chars_long"
+
+# Enterprise Search 플러그인 비활성화
+enterpriseSearch.enabled: false
+
+# 모니터링 설정
+monitoring.ui.container.elasticsearch.enabled: true

--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingProcessor.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingProcessor.java
@@ -1,0 +1,60 @@
+package com.techfork.domain.post.batch;
+
+import com.techfork.domain.post.document.ContentChunk;
+import com.techfork.domain.post.document.PostDocument;
+import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.service.ContentChunkerService;
+import com.techfork.global.llm.EmbeddingClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostEmbeddingProcessor implements ItemProcessor<Post, PostDocument> {
+
+    private final ContentChunkerService contentChunkerService;
+    private final EmbeddingClient embeddingClient;
+
+    @Override
+    public PostDocument process(Post post) throws Exception {
+        log.info("임베딩 처리 시작: Post ID={}, Title={}", post.getId(), post.getTitle());
+
+        try {
+            List<Float> titleEmbedding = embeddingClient.embed(post.getTitle());
+            List<Float> summaryEmbedding = embeddingClient.embed(post.getSummary());
+
+            List<String> chunks = contentChunkerService.chunkContent(post.getFullContent());
+            log.info("Post ID={} 청크 개수: {}", post.getId(), chunks.size());
+
+            List<List<Float>> chunkEmbeddings = embeddingClient.embedBatch(chunks);
+
+            List<ContentChunk> contentChunks = new ArrayList<>();
+            for (int i = 0; i < chunks.size(); i++) {
+                ContentChunk chunk = ContentChunk.create(i, chunks.get(i), chunkEmbeddings.get(i));
+                contentChunks.add(chunk);
+            }
+
+            PostDocument postDocument = PostDocument.create(
+                    post,
+                    titleEmbedding,
+                    summaryEmbedding,
+                    contentChunks
+            );
+
+            post.updateEmbedded();
+
+            log.info("임베딩 처리 완료: Post ID={}, Chunks={}", post.getId(), contentChunks.size());
+            return postDocument;
+
+        } catch (Exception e) {
+            log.error("임베딩 처리 실패: Post ID={}, Error={}", post.getId(), e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingProcessor.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingProcessor.java
@@ -66,8 +66,6 @@ public class PostEmbeddingProcessor implements ItemProcessor<Post, PostDocument>
                     contentChunks
             );
 
-            post.updateEmbedded();
-
             log.info("임베딩 처리 완료: Post ID={}, Chunks={}", post.getId(), contentChunks.size());
             return postDocument;
 

--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingProcessor.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingProcessor.java
@@ -25,18 +25,37 @@ public class PostEmbeddingProcessor implements ItemProcessor<Post, PostDocument>
     public PostDocument process(Post post) throws Exception {
         log.info("임베딩 처리 시작: Post ID={}, Title={}", post.getId(), post.getTitle());
 
+        if (post.getTitle() == null || post.getTitle().isBlank()) {
+            log.warn("Post ID={}의 제목이 비어있어 임베딩을 스킵합니다.", post.getId());
+            return null;
+        }
+        if (post.getSummary() == null || post.getSummary().isBlank()) {
+            log.warn("Post ID={}의 요약이 비어있어 임베딩을 스킵합니다.", post.getId());
+            return null;
+        }
+
         try {
             List<Float> titleEmbedding = embeddingClient.embed(post.getTitle());
             List<Float> summaryEmbedding = embeddingClient.embed(post.getSummary());
 
-            List<String> chunks = contentChunkerService.chunkContent(post.getFullContent());
-            log.info("Post ID={} 청크 개수: {}", post.getId(), chunks.size());
+            List<String> rawChunks = contentChunkerService.chunkContent(post.getFullContent());
 
-            List<List<Float>> chunkEmbeddings = embeddingClient.embedBatch(chunks);
+            List<String> validChunks = rawChunks.stream()
+                    .filter(chunk -> chunk != null && !chunk.isBlank())
+                    .toList();
+
+            log.info("Post ID={} 청크 개수: (원본: {}, 유효: {})", post.getId(), rawChunks.size(), validChunks.size());
+
+            if (validChunks.isEmpty()) {
+                log.warn("Post ID={}의 본문에서 유효한 텍스트 청크를 찾을 수 없어 스킵합니다.", post.getId());
+                return null;
+            }
+
+            List<List<Float>> chunkEmbeddings = embeddingClient.embedBatch(validChunks);
 
             List<ContentChunk> contentChunks = new ArrayList<>();
-            for (int i = 0; i < chunks.size(); i++) {
-                ContentChunk chunk = ContentChunk.create(i, chunks.get(i), chunkEmbeddings.get(i));
+            for (int i = 0; i < validChunks.size(); i++) {
+                ContentChunk chunk = ContentChunk.create(i, validChunks.get(i), chunkEmbeddings.get(i));
                 contentChunks.add(chunk);
             }
 

--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingReader.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingReader.java
@@ -1,0 +1,38 @@
+package com.techfork.domain.post.batch;
+
+import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.Iterator;
+
+/**
+ * 요약이 완료되고 임베딩이 필요한 Post를 읽어오는 Reader
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostEmbeddingReader implements ItemReader<Post> {
+
+    private final PostRepository postRepository;
+    private Iterator<Post> postIterator;
+
+    @Override
+    public Post read() {
+        if(postIterator == null) {
+            Pageable pageable = PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "id"));
+            Page<Post> posts = postRepository.findBySummaryIsNotNullAndEmbeddedAtIsNull(pageable);
+            log.info("임베딩 대상 Post 개수: {}", posts.getContent().size());
+            postIterator = posts.iterator();
+        }
+
+        return postIterator.hasNext() ? postIterator.next() : null;
+    }
+}

--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingWriter.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingWriter.java
@@ -1,6 +1,8 @@
 package com.techfork.domain.post.batch;
 
 import com.techfork.domain.post.document.PostDocument;
+import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
@@ -23,6 +25,7 @@ import java.util.List;
 public class PostEmbeddingWriter implements ItemWriter<PostDocument> {
 
     private final ElasticsearchOperations elasticsearchOperations;
+    private final PostRepository postRepository;
 
     @Override
     public void write(Chunk<? extends PostDocument> chunk) throws Exception {
@@ -48,6 +51,15 @@ public class PostEmbeddingWriter implements ItemWriter<PostDocument> {
             if (result.size() != documents.size()) {
                 log.warn("일부 문서 저장 실패: 요청={}, 성공={}", documents.size(), result.size());
             }
+
+            // ES 저장 성공 후 embeddedAt Bulk 업데이트
+            List<Long> successPostIds = documents.stream()
+                    .map(PostDocument::getPostId)
+                    .toList();
+
+            postRepository.bulkUpdateEmbeddedAt(successPostIds, java.time.LocalDateTime.now());
+
+            log.info("Post embeddedAt Bulk 업데이트 완료: {} 개", successPostIds.size());
 
         } catch (Exception e) {
             log.error("Elasticsearch Bulk Insert 실패: {}", e.getMessage(), e);

--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingWriter.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingWriter.java
@@ -1,0 +1,57 @@
+package com.techfork.domain.post.batch;
+
+import com.techfork.domain.post.document.PostDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexedObjectInformation;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.IndexQuery;
+import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * PostDocument를 Elasticsearch에 Bulk Insert하는 Writer
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostEmbeddingWriter implements ItemWriter<PostDocument> {
+
+    private final ElasticsearchOperations elasticsearchOperations;
+
+    @Override
+    public void write(Chunk<? extends PostDocument> chunk) throws Exception {
+        var documents = chunk.getItems();
+
+        if (documents.isEmpty()) {
+            return;
+        }
+
+        try {
+            List<IndexQuery> queries = documents.stream()
+                    .map(doc -> new IndexQueryBuilder()
+                            .withId(doc.getId())
+                            .withObject(doc)
+                            .build())
+                    .toList();
+
+            IndexCoordinates index = IndexCoordinates.of("posts");
+            List<IndexedObjectInformation> result = elasticsearchOperations.bulkIndex(queries, index);
+
+            log.info("Elasticsearch Bulk Insert 완료: {} 개 성공", result.size());
+
+            if (result.size() != documents.size()) {
+                log.warn("일부 문서 저장 실패: 요청={}, 성공={}", documents.size(), result.size());
+            }
+
+        } catch (Exception e) {
+            log.error("Elasticsearch Bulk Insert 실패: {}", e.getMessage(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/techfork/domain/post/batch/PostSummaryReader.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostSummaryReader.java
@@ -12,7 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 
 /**
- * summary가 null인 Post들을 읽어오는 Reader
+ * summary가 null이거나 빈 문자열인 Post들을 읽어오는 Reader
  */
 @Slf4j
 @Component
@@ -27,7 +27,7 @@ public class PostSummaryReader implements ItemReader<Post> {
     public Post read() {
         if (postIterator == null) {
             List<Post> posts = postRepository.findBySummaryIsNull();
-            log.info("요약이 없는 게시글 {}개 발견", posts.size());
+            log.info("요약이 없거나 비어있는 게시글 {}개 발견", posts.size());
             postIterator = posts.iterator();
         }
 

--- a/src/main/java/com/techfork/domain/post/document/ContentChunk.java
+++ b/src/main/java/com/techfork/domain/post/document/ContentChunk.java
@@ -1,0 +1,31 @@
+package com.techfork.domain.post.document;
+
+import lombok.*;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ContentChunk {
+
+    @Field(type = FieldType.Integer)
+    private Integer chunkOrder;
+
+    @Field(type = FieldType.Text)
+    private String chunkText;
+
+    @Field(type = FieldType.Dense_Vector, dims = 3072)
+    private List<Float> embedding;
+
+    public static ContentChunk create(int order, String text, List<Float> embedding) {
+        return ContentChunk.builder()
+                .chunkOrder(order)
+                .chunkText(text)
+                .embedding(embedding)
+                .build();
+    }
+}

--- a/src/main/java/com/techfork/domain/post/document/PostDocument.java
+++ b/src/main/java/com/techfork/domain/post/document/PostDocument.java
@@ -1,4 +1,66 @@
 package com.techfork.domain.post.document;
 
+import com.techfork.domain.post.entity.Post;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Document(indexName = "posts")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostDocument {
+
+    @Id
+    private String id;
+
+    @Field(type = FieldType.Long)
+    private Long postId;
+
+    @Field(type = FieldType.Text)
+    private String title;
+
+    @Field(type = FieldType.Text)
+    private String summary;
+
+    @Field(type = FieldType.Keyword)
+    private String company;
+
+    @Field(type = FieldType.Keyword)
+    private String url;
+
+    @Field(type = FieldType.Date)
+    private LocalDateTime publishedAt;
+
+    @Field(type = FieldType.Dense_Vector, dims = 3072)
+    private List<Float> titleEmbedding;
+
+    @Field(type = FieldType.Dense_Vector, dims = 3072)
+    private List<Float> summaryEmbedding;
+
+    @Field(type = FieldType.Nested)
+    private List<ContentChunk> contentChunks;
+
+    public static PostDocument create(Post post, List<Float> titleEmbedding,
+                                      List<Float> summaryEmbedding,
+                                      List<ContentChunk> contentChunks) {
+        return PostDocument.builder()
+                .id(String.valueOf(post.getId()))
+                .postId(post.getId())
+                .title(post.getTitle())
+                .summary(post.getSummary())
+                .company(post.getCompany())
+                .url(post.getUrl())
+                .publishedAt(post.getPublishedAt())
+                .titleEmbedding(titleEmbedding)
+                .summaryEmbedding(summaryEmbedding)
+                .contentChunks(contentChunks)
+                .build();
+    }
 }

--- a/src/main/java/com/techfork/domain/post/document/PostVector.java
+++ b/src/main/java/com/techfork/domain/post/document/PostVector.java
@@ -1,8 +1,0 @@
-package com.techfork.domain.post.document;
-
-import jakarta.persistence.Id;
-import lombok.Builder;
-import lombok.Getter;
-
-public class PostVector {
-}

--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -41,6 +41,9 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private LocalDateTime crawledAt;
 
+    @Column
+    private LocalDateTime embeddedAt;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tech_blog_id", nullable = false)
     private TechBlog techBlog;
@@ -73,5 +76,9 @@ public class Post extends BaseEntity {
 
     public void updateSummary(String summary) {
         this.summary = summary;
+    }
+
+    public void updateEmbedded() {
+        this.embeddedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostDocumentRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostDocumentRepository.java
@@ -1,0 +1,10 @@
+package com.techfork.domain.post.repository;
+
+import com.techfork.domain.post.document.PostDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostDocumentRepository extends ElasticsearchRepository<PostDocument, String> {
+
+}

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package com.techfork.domain.post.repository;
 
 import com.techfork.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,4 +12,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     boolean existsByUrl(String url);
 
     List<Post> findBySummaryIsNull();
+
+    Page<Post> findBySummaryIsNotNullAndEmbeddedAtIsNull(Pageable pageable);
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -4,14 +4,23 @@ import com.techfork.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     boolean existsByUrl(String url);
 
+    @Query("SELECT p FROM Post p WHERE p.summary IS NULL OR p.summary = ''")
     List<Post> findBySummaryIsNull();
 
     Page<Post> findBySummaryIsNotNullAndEmbeddedAtIsNull(Pageable pageable);
+
+    @Modifying
+    @Query("UPDATE Post p SET p.embeddedAt = :embeddedAt WHERE p.id IN :ids")
+    void bulkUpdateEmbeddedAt(@Param("ids") List<Long> ids, @Param("embeddedAt") LocalDateTime embeddedAt);
 }

--- a/src/main/java/com/techfork/domain/post/service/ContentChunkerService.java
+++ b/src/main/java/com/techfork/domain/post/service/ContentChunkerService.java
@@ -1,15 +1,19 @@
 package com.techfork.domain.post.service;
 
+import com.techfork.global.util.ContentCleaner;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * HTML 기반 fullContent를 의미 있는 청크로 분할하는 서비스
+ * HTML 및 Markdown 기반 fullContent를 의미 있는 청크로 분할하는 서비스
  * - RSS 피드는 대부분 HTML 형식
  * - <h1>~<h6> 태그로 섹션 분할
  * - <p> 태그로 세부 분할
@@ -30,8 +34,9 @@ public class ContentChunkerService {
     // HTML 헤더 패턴 (h1~h6 태그로 섹션 시작 위치 찾기)
     private static final Pattern HTML_HEADER = Pattern.compile("<h[1-6][^>]*>", Pattern.CASE_INSENSITIVE);
 
-    // HTML 단락 패턴 (p 태그)
-    private static final Pattern HTML_PARAGRAPH = Pattern.compile("<p[^>]*>.*?</p>", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+    // 마크다운 헤더 패턴 (#, ## 등)
+    // (m) 플래그: ^가 각 줄의 시작과 일치하도록 함
+    private static final Pattern MARKDOWN_HEADER = Pattern.compile("(?m)^\\s*#{1,6}\\s+");
 
     /**
      * HTML 컨텐츠를 청크로 분할
@@ -41,7 +46,7 @@ public class ContentChunkerService {
             return List.of();
         }
 
-        List<String> chunks = chunkByHtmlStructure(content);
+        List<String> chunks = chunkByStructure(content);
 
         // 청크 크기 조정 및 오버랩 추가
         return adjustChunkSizes(chunks);
@@ -50,30 +55,39 @@ public class ContentChunkerService {
     /**
      * HTML 구조 기반 청크 분할
      * 1. <h1>~<h6> 태그로 섹션 분할
-     * 2. HTML 태그 제거하여 순수 텍스트 추출
+     * 2. HTML/Markdown 태그 제거하여 순수 텍스트 추출
      */
-    private List<String> chunkByHtmlStructure(String content) {
+    private List<String> chunkByStructure(String content) {
         List<String> chunks = new ArrayList<>();
+        
+        Set<Integer> startSet = new TreeSet<>();
+        startSet.add(0);
 
-        // HTML 헤더 태그(<h1>~<h6>)로 섹션 시작 위치 찾기
+        // 1. HTML 헤더 태그(<h1>~<h6>)로 시작 위치 찾기
         Matcher headerMatcher = HTML_HEADER.matcher(content);
-        List<Integer> sectionStarts = new ArrayList<>();
-        sectionStarts.add(0);
-
         while (headerMatcher.find()) {
-            sectionStarts.add(headerMatcher.start());
+            startSet.add(headerMatcher.start());
         }
-        sectionStarts.add(content.length());
+
+        // 2. Markdown 헤더 위치 찾기
+        Matcher mdMatcher = MARKDOWN_HEADER.matcher(content);
+        while (mdMatcher.find()) {
+            startSet.add(mdMatcher.start());
+        }
+
+        startSet.add(content.length());
+
+        List<Integer> sectionStarts = new ArrayList<>(startSet);
 
         // 각 섹션 추출
         for (int i = 0; i < sectionStarts.size() - 1; i++) {
             int start = sectionStarts.get(i);
             int end = sectionStarts.get(i + 1);
-            String sectionHtml = content.substring(start, end).trim();
+            String sectionMarkup = content.substring(start, end).trim();
 
-            if (!sectionHtml.isEmpty()) {
-                // HTML 태그 제거하여 순수 텍스트로 변환
-                String cleanText = removeHtmlTags(sectionHtml);
+            if (!sectionMarkup.isEmpty()) {
+                // HTML 및 마크다운 태그 제거하여 순수 텍스트로 변환
+                String cleanText = ContentCleaner.clean(sectionMarkup);
                 if (!cleanText.isBlank()) {
                     chunks.add(cleanText);
                 }
@@ -82,7 +96,7 @@ public class ContentChunkerService {
 
         // 헤더가 없는 경우 (헤더 없이 바로 본문 시작)
         if (chunks.isEmpty()) {
-            String cleanContent = removeHtmlTags(content);
+            String cleanContent = ContentCleaner.clean(content);
             if (!cleanContent.isBlank()) {
                 chunks.add(cleanContent);
             }
@@ -108,7 +122,11 @@ public class ContentChunkerService {
                 if (!adjustedChunks.isEmpty()) {
                     int lastIndex = adjustedChunks.size() - 1;
                     String merged = adjustedChunks.get(lastIndex) + "\n\n" + chunk;
-                    adjustedChunks.set(lastIndex, merged);
+
+                    // 병합된 쳥크가 최대 크기를 넘지 않도록 방어 로직 추가
+                    if (merged.length() <= MAX_CHUNK_SIZE * 1.1) { // 약간의 여유 허용
+                        adjustedChunks.set(lastIndex, merged);
+                    }
                 } else {
                     adjustedChunks.add(chunk);
                 }
@@ -135,7 +153,19 @@ public class ContentChunkerService {
                     currentChunk.append("\n\n");
                 }
             }
-            currentChunk.append(paragraph).append("\n\n");
+
+            // 만약 단락 자체가 최대 크기보다 크다면, 강제로 분할 (간단한 처리)
+            if (paragraph.length() > MAX_CHUNK_SIZE) {
+                // 현재 청크가 있다면 먼저 추가
+                if (currentChunk.length() > 0) {
+                    splits.add(currentChunk.toString().trim());
+                    currentChunk = new StringBuilder();
+                }
+                // 큰 단락을 분할해서 추가
+                splits.addAll(forceSplitText(paragraph, MAX_CHUNK_SIZE, OVERLAP_SIZE));
+            } else {
+                currentChunk.append(paragraph).append("\n\n");
+            }
         }
 
         if (currentChunk.length() > 0) {
@@ -155,12 +185,21 @@ public class ContentChunkerService {
         return text.substring(text.length() - OVERLAP_SIZE);
     }
 
-    /**
-     * HTML 태그 제거
-     */
-    private String removeHtmlTags(String html) {
-        return html.replaceAll("<[^>]+>", " ")
-                .replaceAll("\\s+", " ")
-                .trim();
+    private List<String> forceSplitText(String text, int size, int overlap) {
+        List<String> parts = new ArrayList<>();
+        int length = text.length();
+        int start = 0;
+
+        while (start < length) {
+            int end = Math.min(start + size, length);
+            parts.add(text.substring(start, end));
+            start += (size - overlap);
+            if (start >= length) break;
+            // 오버랩이 너무 커서 무한 루프 도는 것 방지
+            if (start <= end - size + overlap) {
+                start = end; // 오버랩 없이 다음으로 넘어감
+            }
+        }
+        return parts;
     }
 }

--- a/src/main/java/com/techfork/domain/post/service/ContentChunkerService.java
+++ b/src/main/java/com/techfork/domain/post/service/ContentChunkerService.java
@@ -1,0 +1,166 @@
+package com.techfork.domain.post.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * HTML 기반 fullContent를 의미 있는 청크로 분할하는 서비스
+ * - RSS 피드는 대부분 HTML 형식
+ * - <h1>~<h6> 태그로 섹션 분할
+ * - <p> 태그로 세부 분할
+ */
+@Slf4j
+@Service
+public class ContentChunkerService {
+
+    // 최대 청크 크기 (약 500 토큰)
+    private static final int MAX_CHUNK_SIZE = 2000;
+
+    // 최소 청크 크기 (너무 작은 청크 방지)
+    private static final int MIN_CHUNK_SIZE = 100;
+
+    // 청크 간 오버랩 크기
+    private static final int OVERLAP_SIZE = 200;
+
+    // HTML 헤더 패턴 (h1~h6 태그로 섹션 시작 위치 찾기)
+    private static final Pattern HTML_HEADER = Pattern.compile("<h[1-6][^>]*>", Pattern.CASE_INSENSITIVE);
+
+    // HTML 단락 패턴 (p 태그)
+    private static final Pattern HTML_PARAGRAPH = Pattern.compile("<p[^>]*>.*?</p>", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    /**
+     * HTML 컨텐츠를 청크로 분할
+     */
+    public List<String> chunkContent(String content) {
+        if (content == null || content.isBlank()) {
+            return List.of();
+        }
+
+        List<String> chunks = chunkByHtmlStructure(content);
+
+        // 청크 크기 조정 및 오버랩 추가
+        return adjustChunkSizes(chunks);
+    }
+
+    /**
+     * HTML 구조 기반 청크 분할
+     * 1. <h1>~<h6> 태그로 섹션 분할
+     * 2. HTML 태그 제거하여 순수 텍스트 추출
+     */
+    private List<String> chunkByHtmlStructure(String content) {
+        List<String> chunks = new ArrayList<>();
+
+        // HTML 헤더 태그(<h1>~<h6>)로 섹션 시작 위치 찾기
+        Matcher headerMatcher = HTML_HEADER.matcher(content);
+        List<Integer> sectionStarts = new ArrayList<>();
+        sectionStarts.add(0);
+
+        while (headerMatcher.find()) {
+            sectionStarts.add(headerMatcher.start());
+        }
+        sectionStarts.add(content.length());
+
+        // 각 섹션 추출
+        for (int i = 0; i < sectionStarts.size() - 1; i++) {
+            int start = sectionStarts.get(i);
+            int end = sectionStarts.get(i + 1);
+            String sectionHtml = content.substring(start, end).trim();
+
+            if (!sectionHtml.isEmpty()) {
+                // HTML 태그 제거하여 순수 텍스트로 변환
+                String cleanText = removeHtmlTags(sectionHtml);
+                if (!cleanText.isBlank()) {
+                    chunks.add(cleanText);
+                }
+            }
+        }
+
+        // 헤더가 없는 경우 (헤더 없이 바로 본문 시작)
+        if (chunks.isEmpty()) {
+            String cleanContent = removeHtmlTags(content);
+            if (!cleanContent.isBlank()) {
+                chunks.add(cleanContent);
+            }
+        }
+
+        return chunks;
+    }
+
+    /**
+     * 청크 크기 조정 및 오버랩 추가
+     */
+    private List<String> adjustChunkSizes(List<String> chunks) {
+        List<String> adjustedChunks = new ArrayList<>();
+
+        for (String chunk : chunks) {
+            // 청크가 최대 크기보다 크면 분할
+            if (chunk.length() > MAX_CHUNK_SIZE) {
+                adjustedChunks.addAll(splitLargeChunk(chunk));
+            } else if (chunk.length() >= MIN_CHUNK_SIZE) {
+                adjustedChunks.add(chunk);
+            } else {
+                // 너무 작은 청크는 이전 청크와 병합
+                if (!adjustedChunks.isEmpty()) {
+                    int lastIndex = adjustedChunks.size() - 1;
+                    String merged = adjustedChunks.get(lastIndex) + "\n\n" + chunk;
+                    adjustedChunks.set(lastIndex, merged);
+                } else {
+                    adjustedChunks.add(chunk);
+                }
+            }
+        }
+
+        return adjustedChunks;
+    }
+
+    /**
+     * 큰 청크를 여러 개로 분할
+     */
+    private List<String> splitLargeChunk(String chunk) {
+        List<String> splits = new ArrayList<>();
+        String[] paragraphs = chunk.split("\n\n+");
+
+        StringBuilder currentChunk = new StringBuilder();
+        for (String paragraph : paragraphs) {
+            if (currentChunk.length() + paragraph.length() > MAX_CHUNK_SIZE) {
+                if (currentChunk.length() > 0) {
+                    splits.add(currentChunk.toString().trim());
+                    // 오버랩을 위해 마지막 부분 일부 유지
+                    currentChunk = new StringBuilder(getOverlapText(currentChunk.toString()));
+                    currentChunk.append("\n\n");
+                }
+            }
+            currentChunk.append(paragraph).append("\n\n");
+        }
+
+        if (currentChunk.length() > 0) {
+            splits.add(currentChunk.toString().trim());
+        }
+
+        return splits;
+    }
+
+    /**
+     * 오버랩용 텍스트 추출 (마지막 N자)
+     */
+    private String getOverlapText(String text) {
+        if (text.length() <= OVERLAP_SIZE) {
+            return text;
+        }
+        return text.substring(text.length() - OVERLAP_SIZE);
+    }
+
+    /**
+     * HTML 태그 제거
+     */
+    private String removeHtmlTags(String html) {
+        return html.replaceAll("<[^>]+>", " ")
+                .replaceAll("\\s+", " ")
+                .trim();
+    }
+}

--- a/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
+++ b/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
@@ -115,10 +115,12 @@ public class RssCrawlingJobConfig {
     @Bean
     public Step embedAndIndexStep() {
         return new StepBuilder("embedAndIndexStep", jobRepository)
-                .<Post, PostDocument>chunk(5, transactionManager) // 5개씩 배치 처리
+                .<Post, PostDocument>chunk(20, transactionManager) // 5개씩 배치 처리
                 .reader(postEmbeddingReader)
                 .processor(postEmbeddingProcessor)
                 .writer(postEmbeddingWriter)
+                // 3개씩 병렬 처리
+                .taskExecutor(embeddingTaskExecutor())
                 // OpenAI API 호출이 있으므로 재시도 정책 설정
                 .faultTolerant()
                 .retryLimit(2)
@@ -128,12 +130,6 @@ public class RssCrawlingJobConfig {
                 .build();
     }
 
-    /**
-     * RSS 수집용 스레드 풀 설정
-     * - Core Pool Size: 5 (기본 5개 스레드)
-     * - Max Pool Size: 10 (최대 10개 스레드)
-     * - Queue Capacity: 20 (대기 큐 크기)
-     */
     @Bean
     public TaskExecutor rssTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -147,26 +143,17 @@ public class RssCrawlingJobConfig {
         return executor;
     }
 
-    /**
-     * 재시도 템플릿 설정 (필요시 사용)
-     */
     @Bean
-    public RetryTemplate retryTemplate() {
-        RetryTemplate retryTemplate = new RetryTemplate();
-
-        // 재시도할 예외 타입과 최대 재시도 횟수 설정
-        Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<>();
-        retryableExceptions.put(SocketTimeoutException.class, true);
-        retryableExceptions.put(Exception.class, true);
-
-        SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(3, retryableExceptions);
-        retryTemplate.setRetryPolicy(retryPolicy);
-
-        // 재시도 간격 설정 (2초)
-        FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
-        backOffPolicy.setBackOffPeriod(2000);
-        retryTemplate.setBackOffPolicy(backOffPolicy);
-
-        return retryTemplate;
+    public TaskExecutor embeddingTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("embedding-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
     }
+
 }

--- a/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
+++ b/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
@@ -1,8 +1,12 @@
 package com.techfork.domain.source.config;
 
+import com.techfork.domain.post.batch.PostEmbeddingProcessor;
+import com.techfork.domain.post.batch.PostEmbeddingReader;
+import com.techfork.domain.post.batch.PostEmbeddingWriter;
 import com.techfork.domain.post.batch.PostSummaryProcessor;
 import com.techfork.domain.post.batch.PostSummaryReader;
 import com.techfork.domain.post.batch.PostSummaryWriter;
+import com.techfork.domain.post.document.PostDocument;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.source.batch.PostBatchWriter;
 import com.techfork.domain.source.batch.RssFeedReader;
@@ -40,6 +44,11 @@ import java.util.Map;
  * - Reader: 요약이 없는 Post 조회
  * - Processor: GPT API로 구조화된 요약 추출
  * - Writer: PostSummary 저장 (의미 기반 검색 최적화)
+ *
+ * Step 3: 임베딩 생성 및 Elasticsearch 저장
+ * - Reader: 요약이 완료되고 임베딩되지 않은 Post 조회
+ * - Processor: Chunk 분할 + OpenAI 임베딩 생성
+ * - Writer: Elasticsearch에 PostDocument 저장
  */
 @Slf4j
 @Configuration
@@ -57,11 +66,16 @@ public class RssCrawlingJobConfig {
     private final PostSummaryProcessor postSummaryProcessor;
     private final PostSummaryWriter postSummaryWriter;
 
+    private final PostEmbeddingReader postEmbeddingReader;
+    private final PostEmbeddingProcessor postEmbeddingProcessor;
+    private final PostEmbeddingWriter postEmbeddingWriter;
+
     @Bean
     public Job rssCrawlingJob() {
         return new JobBuilder("rssCrawlingJob", jobRepository)
                 .start(fetchAndSaveRssStep())
                 .next(extractSummaryStep())
+                .next(embedAndIndexStep())
                 .build();
     }
 
@@ -94,6 +108,22 @@ public class RssCrawlingJobConfig {
                 .retryLimit(2)
                 .retry(Exception.class)
                 .skipLimit(10)  // 실패 허용 개수 증가
+                .skip(Exception.class)
+                .build();
+    }
+
+    @Bean
+    public Step embedAndIndexStep() {
+        return new StepBuilder("embedAndIndexStep", jobRepository)
+                .<Post, PostDocument>chunk(5, transactionManager) // 5개씩 배치 처리
+                .reader(postEmbeddingReader)
+                .processor(postEmbeddingProcessor)
+                .writer(postEmbeddingWriter)
+                // OpenAI API 호출이 있으므로 재시도 정책 설정
+                .faultTolerant()
+                .retryLimit(2)
+                .retry(Exception.class)
+                .skipLimit(20)  // 임베딩 실패 허용 개수
                 .skip(Exception.class)
                 .build();
     }

--- a/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
+++ b/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
@@ -33,7 +33,7 @@ public class RssCrawlingScheduler {
      * 1시간마다 RSS 크롤링 실행
      * cron: 0 0 * * * * -> 매 시간 정각
      */
-    @Scheduled(cron = "0 0 * * * *")
+    @Scheduled(cron = "0 0 5 * * *")
     public void scheduleCrawling() {
         log.info("RSS crawling scheduler triggered");
 

--- a/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
+++ b/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
@@ -30,8 +30,8 @@ public class RssCrawlingScheduler {
     private static final Duration LOCK_TTL = Duration.ofMinutes(30); // 크롤링 최대 실행 시간
 
     /**
-     * 1시간마다 RSS 크롤링 실행
-     * cron: 0 0 * * * * -> 매 시간 정각
+     * 매일 오전 5시마다 RSS 크롤링 실행
+     * cron: 0 0 5 * * * -> 매 시간 정각
      */
     @Scheduled(cron = "0 0 5 * * *")
     public void scheduleCrawling() {

--- a/src/main/java/com/techfork/global/llm/EmbeddingClient.java
+++ b/src/main/java/com/techfork/global/llm/EmbeddingClient.java
@@ -1,0 +1,25 @@
+package com.techfork.global.llm;
+
+import java.util.List;
+
+/**
+ * 텍스트 임베딩 생성 클라이언트 인터페이스
+ */
+public interface EmbeddingClient {
+
+    /**
+     * 단일 텍스트를 임베딩 벡터로 변환
+     *
+     * @param text 임베딩할 텍스트
+     * @return 임베딩 벡터
+     */
+    List<Float> embed(String text);
+
+    /**
+     * 여러 텍스트를 배치로 임베딩 벡터로 변환
+     *
+     * @param texts 임베딩할 텍스트 리스트
+     * @return 임베딩 벡터 리스트
+     */
+    List<List<Float>> embedBatch(List<String> texts);
+}

--- a/src/main/java/com/techfork/global/llm/config/OpenAiConfig.java
+++ b/src/main/java/com/techfork/global/llm/config/OpenAiConfig.java
@@ -1,7 +1,10 @@
 package com.techfork.global.llm.config;
 
+import org.springframework.ai.document.MetadataMode;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
 import org.springframework.ai.openai.api.OpenAiApi;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -37,5 +40,19 @@ public class OpenAiConfig {
                 .openAiApi(openAiApi)
                 .defaultOptions(options)
                 .build();
+    }
+
+    @Bean
+    public OpenAiEmbeddingModel openAiEmbeddingModel() {
+        OpenAiApi openAiApi = OpenAiApi.builder()
+                .apiKey(apiKey)
+                .build();
+
+        OpenAiEmbeddingOptions options = OpenAiEmbeddingOptions.builder()
+                .model("text-embedding-3-large")
+                .dimensions(3072)
+                .build();
+
+        return new OpenAiEmbeddingModel(openAiApi, MetadataMode.EMBED, options);
     }
 }

--- a/src/main/java/com/techfork/global/llm/impl/OpenAiEmbeddingClient.java
+++ b/src/main/java/com/techfork/global/llm/impl/OpenAiEmbeddingClient.java
@@ -1,0 +1,98 @@
+package com.techfork.global.llm.impl;
+
+import com.techfork.global.llm.EmbeddingClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * OpenAI text-embedding-3-large 모델을 사용한 임베딩 클라이언트
+ */
+@Slf4j
+@Component
+@Primary
+@RequiredArgsConstructor
+public class OpenAiEmbeddingClient implements EmbeddingClient {
+
+    private final OpenAiEmbeddingModel embeddingModel;
+
+    private static final int EMBEDDING_DIMENSIONS = 3072;
+
+    @Override
+    public List<Float> embed(String text) {
+        if (text == null || text.isBlank()) {
+            log.warn("빈 텍스트에 대한 임베딩 요청");
+            return createZeroEmbedding();
+        }
+
+        try {
+            EmbeddingResponse response = embeddingModel.embedForResponse(List.of(text));
+
+            if (response.getResults().isEmpty()) {
+                log.error("임베딩 응답이 비어있음");
+                return createZeroEmbedding();
+            }
+
+            float[] embedding = response.getResults().get(0).getOutput();
+            return convertToFloatList(embedding);
+
+        } catch (Exception e) {
+            log.error("OpenAI 임베딩 생성 실패: {}", e.getMessage(), e);
+            return createZeroEmbedding();
+        }
+    }
+
+    @Override
+    public List<List<Float>> embedBatch(List<String> texts) {
+        if (texts == null || texts.isEmpty()) {
+            return List.of();
+        }
+
+        try {
+            EmbeddingResponse response = embeddingModel.embedForResponse(texts);
+
+            List<List<Float>> embeddings = new ArrayList<>();
+            for (var result : response.getResults()) {
+                float[] embedding = result.getOutput();
+                embeddings.add(convertToFloatList(embedding));
+            }
+
+            return embeddings;
+
+        } catch (Exception e) {
+            log.error("OpenAI 배치 임베딩 생성 실패: {}", e.getMessage(), e);
+            // 실패 시 각 텍스트마다 제로 벡터 반환
+            return texts.stream()
+                    .map(text -> createZeroEmbedding())
+                    .toList();
+        }
+    }
+
+    /**
+     * float[] 배열을 List<Float>로 변환
+     */
+    private List<Float> convertToFloatList(float[] embedding) {
+        List<Float> result = new ArrayList<>(embedding.length);
+        for (float value : embedding) {
+            result.add(value);
+        }
+        return result;
+    }
+
+    /**
+     * 제로 벡터 생성 (오류 발생 시 대체용)
+     */
+    private List<Float> createZeroEmbedding() {
+        List<Float> zeros = new ArrayList<>(EMBEDDING_DIMENSIONS);
+        for (int i = 0; i < EMBEDDING_DIMENSIONS; i++) {
+            zeros.add(0.0f);
+        }
+        return zeros;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -60,6 +60,10 @@ spring:
           temperature: 0.3
           max-tokens: 8192
 
+  devtools:
+    restart:
+      enabled: false
+
 scheduler:
   enabled: true
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -60,6 +60,10 @@ spring:
           temperature: 0.3
           max-tokens: 8192
 
+  devtools:
+    restart:
+      enabled: false
+
 scheduler:
   enabled: true
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    default: local
+    default: local-tunnel
 ---
 spring:
   config:


### PR DESCRIPTION
## ❤️ 기능 설명
임베딩 및 색인 파이프라인을 구현했습니다.

임베딩 모듈은 현재는 OpenAI를 사용하지만 추후에 변경될 여지가 있기에 인터페이스로 구현하였습니다.
임베딩은 요약이 있는 Post만 조회하여 제목, 요약, 그리고 내용들을 chunk시켜 임베딩한 후 ES에 색인합니다.
이때 chunk는 html 태그뿐만 아니라 마크다운 태그로도 분리시킵니다.
ES 조회를 위해 docker-compose 및 docker-compose.local에 Kibana도 추가했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #58 
<br>
<br>

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
