### PR TITLE
[feat/#64] 게시글 조회 API 구현

### DIFF
--- a/src/main/java/com/techfork/domain/post/controller/PostController.java
+++ b/src/main/java/com/techfork/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.techfork.domain.post.controller;
 
 import com.techfork.domain.post.dto.CompanyListResponse;
+import com.techfork.domain.post.dto.PostDetailDto;
 import com.techfork.domain.post.dto.PostListResponse;
 import com.techfork.domain.post.dto.PostSortType;
 import com.techfork.domain.post.service.PostQueryService;
@@ -12,10 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Post", description = "게시글 API")
 @Slf4j
@@ -67,6 +65,19 @@ public class PostController {
             @RequestParam(defaultValue = "20") int size
     ) {
         PostListResponse response = postQueryService.getRecentPosts(sortBy, lastPostId, size);
+        return BaseResponse.of(SuccessCode.OK, response);
+    }
+
+    @Operation(
+            summary = "게시글 상세 조회",
+            description = "특정 게시글의 상세 정보를 조회합니다."
+    )
+    @GetMapping("/{postId}")
+    public ResponseEntity<BaseResponse<PostDetailDto>> getPostDetail(
+            @Parameter(description = "게시글 ID")
+            @PathVariable Long postId
+    ) {
+        PostDetailDto response = postQueryService.getPostDetail(postId);
         return BaseResponse.of(SuccessCode.OK, response);
     }
 }

--- a/src/main/java/com/techfork/domain/post/controller/PostController.java
+++ b/src/main/java/com/techfork/domain/post/controller/PostController.java
@@ -1,0 +1,36 @@
+package com.techfork.domain.post.controller;
+
+import com.techfork.domain.post.dto.CompanyListResponse;
+import com.techfork.domain.post.dto.PostDetailDto;
+import com.techfork.domain.post.dto.PostListResponse;
+import com.techfork.domain.post.dto.PostSortType;
+import com.techfork.domain.post.service.PostQueryService;
+import com.techfork.global.common.code.SuccessCode;
+import com.techfork.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Post", description = "게시글 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostQueryService postQueryService;
+
+    @Operation(
+            summary = "게시글이 있는 회사 목록 조회",
+            description = "게시글이 존재하는 회사명 목록을 조회합니다. (필터링 칩용)"
+    )
+    @GetMapping("/companies")
+    public ResponseEntity<BaseResponse<CompanyListResponse>> getCompanies() {
+        CompanyListResponse response = postQueryService.getCompanies();
+        return BaseResponse.of(SuccessCode.OK, response);
+    }
+}

--- a/src/main/java/com/techfork/domain/post/controller/PostController.java
+++ b/src/main/java/com/techfork/domain/post/controller/PostController.java
@@ -1,9 +1,7 @@
 package com.techfork.domain.post.controller;
 
 import com.techfork.domain.post.dto.CompanyListResponse;
-import com.techfork.domain.post.dto.PostDetailDto;
 import com.techfork.domain.post.dto.PostListResponse;
-import com.techfork.domain.post.dto.PostSortType;
 import com.techfork.domain.post.service.PostQueryService;
 import com.techfork.global.common.code.SuccessCode;
 import com.techfork.global.response.BaseResponse;
@@ -13,7 +11,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Post", description = "게시글 API")
 @Slf4j
@@ -31,6 +32,23 @@ public class PostController {
     @GetMapping("/companies")
     public ResponseEntity<BaseResponse<CompanyListResponse>> getCompanies() {
         CompanyListResponse response = postQueryService.getCompanies();
+        return BaseResponse.of(SuccessCode.OK, response);
+    }
+
+    @Operation(
+            summary = "기업별 게시글 조회",
+            description = "특정 기업의 게시글을 무한 스크롤 방식으로 조회합니다. company 파라미터가 없으면 전체 게시글을 조회합니다."
+    )
+    @GetMapping("/by-company")
+    public ResponseEntity<BaseResponse<PostListResponse>> getPostsByCompany(
+            @Parameter(description = "회사명 필터 (선택, 없으면 전체 조회)")
+            @RequestParam(required = false) String company,
+            @Parameter(description = "마지막 게시글 ID (커서, 선택)")
+            @RequestParam(required = false) Long lastPostId,
+            @Parameter(description = "페이지 크기 (기본값: 20)")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        PostListResponse response = postQueryService.getPostsByCompany(company, lastPostId, size);
         return BaseResponse.of(SuccessCode.OK, response);
     }
 }

--- a/src/main/java/com/techfork/domain/post/controller/PostController.java
+++ b/src/main/java/com/techfork/domain/post/controller/PostController.java
@@ -2,6 +2,7 @@ package com.techfork.domain.post.controller;
 
 import com.techfork.domain.post.dto.CompanyListResponse;
 import com.techfork.domain.post.dto.PostListResponse;
+import com.techfork.domain.post.dto.PostSortType;
 import com.techfork.domain.post.service.PostQueryService;
 import com.techfork.global.common.code.SuccessCode;
 import com.techfork.global.response.BaseResponse;
@@ -49,6 +50,23 @@ public class PostController {
             @RequestParam(defaultValue = "20") int size
     ) {
         PostListResponse response = postQueryService.getPostsByCompany(company, lastPostId, size);
+        return BaseResponse.of(SuccessCode.OK, response);
+    }
+
+    @Operation(
+            summary = "최근 게시글 조회",
+            description = "최근 생성된 게시글을 무한 스크롤 방식으로 조회합니다. sortBy로 정렬 기준을 선택할 수 있습니다."
+    )
+    @GetMapping("/recent")
+    public ResponseEntity<BaseResponse<PostListResponse>> getRecentPosts(
+            @Parameter(description = "정렬 기준 (LATEST: 최신순, POPULAR: 인기순, 기본값: LATEST)")
+            @RequestParam(defaultValue = "LATEST") PostSortType sortBy,
+            @Parameter(description = "마지막 게시글 ID (커서, 선택)")
+            @RequestParam(required = false) Long lastPostId,
+            @Parameter(description = "페이지 크기 (기본값: 20)")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        PostListResponse response = postQueryService.getRecentPosts(sortBy, lastPostId, size);
         return BaseResponse.of(SuccessCode.OK, response);
     }
 }

--- a/src/main/java/com/techfork/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/techfork/domain/post/converter/PostConverter.java
@@ -3,7 +3,7 @@ package com.techfork.domain.post.converter;
 import com.techfork.domain.post.dto.CompanyListResponse;
 import com.techfork.domain.post.dto.PostDetailDto;
 import com.techfork.domain.post.dto.PostListResponse;
-import com.techfork.domain.post.dto.PostSummaryDto;
+import com.techfork.domain.post.dto.PostInfoDto;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.source.entity.TechBlog;
 import org.springframework.stereotype.Component;
@@ -19,9 +19,9 @@ public class PostConverter {
                 .build();
     }
 
-    public PostListResponse toPostListResponse(List<PostSummaryDto> postDtos, int requestedSize) {
+    public PostListResponse toPostListResponse(List<PostInfoDto> postDtos, int requestedSize) {
         boolean hasNext = postDtos.size() > requestedSize;
-        List<PostSummaryDto> content = hasNext ? postDtos.subList(0, requestedSize) : postDtos;
+        List<PostInfoDto> content = hasNext ? postDtos.subList(0, requestedSize) : postDtos;
 
         Long lastPostId = content.isEmpty() ? null : content.get(content.size() - 1).id();
 

--- a/src/main/java/com/techfork/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/techfork/domain/post/converter/PostConverter.java
@@ -1,8 +1,11 @@
 package com.techfork.domain.post.converter;
 
 import com.techfork.domain.post.dto.CompanyListResponse;
+import com.techfork.domain.post.dto.PostDetailDto;
 import com.techfork.domain.post.dto.PostListResponse;
 import com.techfork.domain.post.dto.PostSummaryDto;
+import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.source.entity.TechBlog;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -26,6 +29,30 @@ public class PostConverter {
                 .posts(content)
                 .lastPostId(lastPostId)
                 .hasNext(hasNext)
+                .build();
+    }
+
+    public PostDetailDto toDetailDto(Post post) {
+        return PostDetailDto.builder()
+                .id(post.getId())
+                .title(post.getTitle())
+                .fullContent(post.getFullContent())
+                .plainContent(post.getPlainContent())
+                .summary(post.getSummary())
+                .company(post.getCompany())
+                .url(post.getUrl())
+                .publishedAt(post.getPublishedAt())
+                .crawledAt(post.getCrawledAt())
+                .techBlog(toTechBlogInfo(post.getTechBlog()))
+                .build();
+    }
+
+    private PostDetailDto.TechBlogInfo toTechBlogInfo(TechBlog techBlog) {
+        return PostDetailDto.TechBlogInfo.builder()
+                .id(techBlog.getId())
+                .companyName(techBlog.getCompanyName())
+                .blogUrl(techBlog.getBlogUrl())
+                .logoUrl(techBlog.getLogoUrl())
                 .build();
     }
 }

--- a/src/main/java/com/techfork/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/techfork/domain/post/converter/PostConverter.java
@@ -1,11 +1,8 @@
 package com.techfork.domain.post.converter;
 
 import com.techfork.domain.post.dto.CompanyListResponse;
-import com.techfork.domain.post.dto.PostDetailDto;
-import com.techfork.domain.post.dto.PostListResponse;
 import com.techfork.domain.post.dto.PostInfoDto;
-import com.techfork.domain.post.entity.Post;
-import com.techfork.domain.source.entity.TechBlog;
+import com.techfork.domain.post.dto.PostListResponse;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -29,30 +26,6 @@ public class PostConverter {
                 .posts(content)
                 .lastPostId(lastPostId)
                 .hasNext(hasNext)
-                .build();
-    }
-
-    public PostDetailDto toDetailDto(Post post) {
-        return PostDetailDto.builder()
-                .id(post.getId())
-                .title(post.getTitle())
-                .fullContent(post.getFullContent())
-                .plainContent(post.getPlainContent())
-                .summary(post.getSummary())
-                .company(post.getCompany())
-                .url(post.getUrl())
-                .publishedAt(post.getPublishedAt())
-                .crawledAt(post.getCrawledAt())
-                .techBlog(toTechBlogInfo(post.getTechBlog()))
-                .build();
-    }
-
-    private PostDetailDto.TechBlogInfo toTechBlogInfo(TechBlog techBlog) {
-        return PostDetailDto.TechBlogInfo.builder()
-                .id(techBlog.getId())
-                .companyName(techBlog.getCompanyName())
-                .blogUrl(techBlog.getBlogUrl())
-                .logoUrl(techBlog.getLogoUrl())
                 .build();
     }
 }

--- a/src/main/java/com/techfork/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/techfork/domain/post/converter/PostConverter.java
@@ -1,6 +1,8 @@
 package com.techfork.domain.post.converter;
 
 import com.techfork.domain.post.dto.CompanyListResponse;
+import com.techfork.domain.post.dto.PostListResponse;
+import com.techfork.domain.post.dto.PostSummaryDto;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -11,6 +13,19 @@ public class PostConverter {
     public CompanyListResponse toCompanyListResponse(List<String> companies) {
         return CompanyListResponse.builder()
                 .companies(companies)
+                .build();
+    }
+
+    public PostListResponse toPostListResponse(List<PostSummaryDto> postDtos, int requestedSize) {
+        boolean hasNext = postDtos.size() > requestedSize;
+        List<PostSummaryDto> content = hasNext ? postDtos.subList(0, requestedSize) : postDtos;
+
+        Long lastPostId = content.isEmpty() ? null : content.get(content.size() - 1).id();
+
+        return PostListResponse.builder()
+                .posts(content)
+                .lastPostId(lastPostId)
+                .hasNext(hasNext)
                 .build();
     }
 }

--- a/src/main/java/com/techfork/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/techfork/domain/post/converter/PostConverter.java
@@ -1,0 +1,16 @@
+package com.techfork.domain.post.converter;
+
+import com.techfork.domain.post.dto.CompanyListResponse;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PostConverter {
+
+    public CompanyListResponse toCompanyListResponse(List<String> companies) {
+        return CompanyListResponse.builder()
+                .companies(companies)
+                .build();
+    }
+}

--- a/src/main/java/com/techfork/domain/post/dto/CompanyListResponse.java
+++ b/src/main/java/com/techfork/domain/post/dto/CompanyListResponse.java
@@ -1,0 +1,11 @@
+package com.techfork.domain.post.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CompanyListResponse(
+        List<String> companies
+) {
+}

--- a/src/main/java/com/techfork/domain/post/dto/PostDetailDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostDetailDto.java
@@ -1,0 +1,28 @@
+package com.techfork.domain.post.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PostDetailDto(
+        Long id,
+        String title,
+        String fullContent,
+        String plainContent,
+        String summary,
+        String company,
+        String url,
+        LocalDateTime publishedAt,
+        LocalDateTime crawledAt,
+        TechBlogInfo techBlog
+) {
+    @Builder
+    public record TechBlogInfo(
+            Long id,
+            String companyName,
+            String blogUrl,
+            String logoUrl
+    ) {
+    }
+}

--- a/src/main/java/com/techfork/domain/post/dto/PostDetailDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostDetailDto.java
@@ -8,21 +8,10 @@ import java.time.LocalDateTime;
 public record PostDetailDto(
         Long id,
         String title,
-        String fullContent,
-        String plainContent,
         String summary,
         String company,
         String url,
-        LocalDateTime publishedAt,
-        LocalDateTime crawledAt,
-        TechBlogInfo techBlog
+        String logoUrl,
+        LocalDateTime publishedAt
 ) {
-    @Builder
-    public record TechBlogInfo(
-            Long id,
-            String companyName,
-            String blogUrl,
-            String logoUrl
-    ) {
-    }
 }

--- a/src/main/java/com/techfork/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostInfoDto.java
@@ -5,13 +5,12 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 
 @Builder
-public record PostSummaryDto(
+public record PostInfoDto(
         Long id,
         String title,
-        String summary,
         String company,
         String url,
-        LocalDateTime publishedAt,
-        LocalDateTime crawledAt
+        String logoUrl,
+        LocalDateTime publishedAt
 ) {
 }

--- a/src/main/java/com/techfork/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostListResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @Builder
 public record PostListResponse(
-        List<PostSummaryDto> posts,
+        List<PostInfoDto> posts,
         Long lastPostId,
         boolean hasNext
 ) {

--- a/src/main/java/com/techfork/domain/post/dto/PostListResponse.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostListResponse.java
@@ -1,0 +1,13 @@
+package com.techfork.domain.post.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record PostListResponse(
+        List<PostSummaryDto> posts,
+        Long lastPostId,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/techfork/domain/post/dto/PostSortType.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostSortType.java
@@ -1,0 +1,13 @@
+package com.techfork.domain.post.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostSortType {
+    LATEST("최신순"),
+    POPULAR("인기순");
+
+    private final String description;
+}

--- a/src/main/java/com/techfork/domain/post/dto/PostSummaryDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostSummaryDto.java
@@ -1,0 +1,17 @@
+package com.techfork.domain.post.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PostSummaryDto(
+        Long id,
+        String title,
+        String summary,
+        String company,
+        String url,
+        LocalDateTime publishedAt,
+        LocalDateTime crawledAt
+) {
+}

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -23,4 +23,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying
     @Query("UPDATE Post p SET p.embeddedAt = :embeddedAt WHERE p.id IN :ids")
     void bulkUpdateEmbeddedAt(@Param("ids") List<Long> ids, @Param("embeddedAt") LocalDateTime embeddedAt);
+
+    @Query("SELECT DISTINCT p.company FROM Post p ORDER BY p.company")
+    List<String> findDistinctCompanies();
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.techfork.domain.post.repository;
 
+import com.techfork.domain.post.dto.PostDetailDto;
 import com.techfork.domain.post.dto.PostInfoDto;
 import com.techfork.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
@@ -70,6 +71,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             Pageable pageable
     );
 
-    @Query("SELECT p FROM Post p JOIN FETCH p.techBlog WHERE p.id = :id")
-    Optional<Post> findByIdWithTechBlog(@Param("id") Long id);
+    @Query("""
+            SELECT new com.techfork.domain.post.dto.PostDetailDto(
+            p.id, p.title, p.summary, t.companyName, p.url, t.logoUrl, p.publishedAt)
+            FROM Post p
+            JOIN TechBlog t on p.techBlog.id = t.id
+            WHERE p.id = :id
+            """)
+    Optional<PostDetailDto> findByIdWithTechBlog(@Param("id") Long id);
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
@@ -63,4 +64,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("lastPostId") Long lastPostId,
             Pageable pageable
     );
+
+    @Query("SELECT p FROM Post p JOIN FETCH p.techBlog WHERE p.id = :id")
+    Optional<Post> findByIdWithTechBlog(@Param("id") Long id);
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package com.techfork.domain.post.repository;
 
+import com.techfork.domain.post.dto.PostSummaryDto;
 import com.techfork.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,4 +27,18 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT DISTINCT p.company FROM Post p ORDER BY p.company")
     List<String> findDistinctCompanies();
+
+    @Query("""
+            SELECT new com.techfork.domain.post.dto.PostSummaryDto(
+            p.id, p.title, p.summary, p.company, p.url, p.publishedAt, p.crawledAt)
+            FROM Post p
+            WHERE (:company IS NULL OR p.company = :company)
+            AND (:lastPostId IS NULL OR p.id < :lastPostId)
+            ORDER BY p.id DESC
+            """)
+    List<PostSummaryDto> findByCompanyWithCursor(
+            @Param("company") String company,
+            @Param("lastPostId") Long lastPostId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -41,4 +41,26 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             @Param("lastPostId") Long lastPostId,
             Pageable pageable
     );
+
+    @Query("""
+            SELECT new com.techfork.domain.post.dto.PostSummaryDto(
+            p.id, p.title, p.summary, p.company, p.url, p.publishedAt, p.crawledAt)
+            FROM Post p WHERE :lastPostId IS NULL OR p.id < :lastPostId 
+            ORDER BY p.publishedAt DESC, p.id DESC
+            """)
+    List<PostSummaryDto> findRecentPostsWithCursor(
+            @Param("lastPostId") Long lastPostId,
+            Pageable pageable
+    );
+
+    @Query("""
+            SELECT new com.techfork.domain.post.dto.PostSummaryDto(
+            p.id, p.title, p.summary, p.company, p.url, p.publishedAt, p.crawledAt)
+            FROM Post p WHERE :lastPostId IS NULL OR p.id < :lastPostId
+            ORDER BY p.crawledAt DESC, p.id DESC
+            """)
+    List<PostSummaryDto> findPopularPostsWithCursor(
+            @Param("lastPostId") Long lastPostId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -1,6 +1,6 @@
 package com.techfork.domain.post.repository;
 
-import com.techfork.domain.post.dto.PostSummaryDto;
+import com.techfork.domain.post.dto.PostInfoDto;
 import com.techfork.domain.post.entity.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,37 +30,42 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<String> findDistinctCompanies();
 
     @Query("""
-            SELECT new com.techfork.domain.post.dto.PostSummaryDto(
-            p.id, p.title, p.summary, p.company, p.url, p.publishedAt, p.crawledAt)
+            SELECT new com.techfork.domain.post.dto.PostInfoDto(
+            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt)
             FROM Post p
+            JOIN TechBlog t on p.techBlog.id = t.id
             WHERE (:company IS NULL OR p.company = :company)
             AND (:lastPostId IS NULL OR p.id < :lastPostId)
             ORDER BY p.id DESC
             """)
-    List<PostSummaryDto> findByCompanyWithCursor(
+    List<PostInfoDto> findByCompanyWithCursor(
             @Param("company") String company,
             @Param("lastPostId") Long lastPostId,
             Pageable pageable
     );
 
     @Query("""
-            SELECT new com.techfork.domain.post.dto.PostSummaryDto(
-            p.id, p.title, p.summary, p.company, p.url, p.publishedAt, p.crawledAt)
-            FROM Post p WHERE :lastPostId IS NULL OR p.id < :lastPostId 
+            SELECT new com.techfork.domain.post.dto.PostInfoDto(
+            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt)
+            FROM Post p
+            JOIN TechBlog t on p.techBlog.id = t.id
+            WHERE :lastPostId IS NULL OR p.id < :lastPostId 
             ORDER BY p.publishedAt DESC, p.id DESC
             """)
-    List<PostSummaryDto> findRecentPostsWithCursor(
+    List<PostInfoDto> findRecentPostsWithCursor(
             @Param("lastPostId") Long lastPostId,
             Pageable pageable
     );
 
     @Query("""
-            SELECT new com.techfork.domain.post.dto.PostSummaryDto(
-            p.id, p.title, p.summary, p.company, p.url, p.publishedAt, p.crawledAt)
-            FROM Post p WHERE :lastPostId IS NULL OR p.id < :lastPostId
+            SELECT new com.techfork.domain.post.dto.PostInfoDto(
+            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt)
+            FROM Post p
+            JOIN TechBlog t on p.techBlog.id = t.id
+            WHERE :lastPostId IS NULL OR p.id < :lastPostId
             ORDER BY p.crawledAt DESC, p.id DESC
             """)
-    List<PostSummaryDto> findPopularPostsWithCursor(
+    List<PostInfoDto> findPopularPostsWithCursor(
             @Param("lastPostId") Long lastPostId,
             Pageable pageable
     );

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -1,11 +1,11 @@
 package com.techfork.domain.post.service;
 
 import com.techfork.domain.post.converter.PostConverter;
-import com.techfork.domain.post.dto.CompanyListResponse;
-import com.techfork.domain.post.dto.PostListResponse;
-import com.techfork.domain.post.dto.PostSortType;
-import com.techfork.domain.post.dto.PostSummaryDto;
+import com.techfork.domain.post.dto.*;
+import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
+import com.techfork.global.exception.CommonErrorCode;
+import com.techfork.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -46,5 +46,12 @@ public class PostQueryService {
         }
 
         return postConverter.toPostListResponse(postDtos, size);
+    }
+
+    public PostDetailDto getPostDetail(Long postId) {
+        Post post = postRepository.findByIdWithTechBlog(postId)
+                .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND));
+
+        return postConverter.toDetailDto(post);
     }
 }

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -3,6 +3,7 @@ package com.techfork.domain.post.service;
 import com.techfork.domain.post.converter.PostConverter;
 import com.techfork.domain.post.dto.CompanyListResponse;
 import com.techfork.domain.post.dto.PostListResponse;
+import com.techfork.domain.post.dto.PostSortType;
 import com.techfork.domain.post.dto.PostSummaryDto;
 import com.techfork.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,19 @@ public class PostQueryService {
     public PostListResponse getPostsByCompany(String company, Long lastPostId, int size) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
         List<PostSummaryDto> postDtos = postRepository.findByCompanyWithCursor(company, lastPostId, pageRequest);
+
+        return postConverter.toPostListResponse(postDtos, size);
+    }
+
+    public PostListResponse getRecentPosts(PostSortType sortBy, Long lastPostId, int size) {
+        PageRequest pageRequest = PageRequest.of(0, size + 1);
+        List<PostSummaryDto> postDtos;
+
+        if (sortBy == PostSortType.POPULAR) {
+            postDtos = postRepository.findPopularPostsWithCursor(lastPostId, pageRequest);
+        } else {
+            postDtos = postRepository.findRecentPostsWithCursor(lastPostId, pageRequest);
+        }
 
         return postConverter.toPostListResponse(postDtos, size);
     }

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -1,0 +1,26 @@
+package com.techfork.domain.post.service;
+
+import com.techfork.domain.post.converter.PostConverter;
+import com.techfork.domain.post.dto.CompanyListResponse;
+import com.techfork.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostQueryService {
+
+    private final PostRepository postRepository;
+    private final PostConverter postConverter;
+
+    public CompanyListResponse getCompanies() {
+        List<String> companies = postRepository.findDistinctCompanies();
+        return postConverter.toCompanyListResponse(companies);
+    }
+}

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -30,14 +30,14 @@ public class PostQueryService {
 
     public PostListResponse getPostsByCompany(String company, Long lastPostId, int size) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
-        List<PostSummaryDto> postDtos = postRepository.findByCompanyWithCursor(company, lastPostId, pageRequest);
+        List<PostInfoDto> postDtos = postRepository.findByCompanyWithCursor(company, lastPostId, pageRequest);
 
         return postConverter.toPostListResponse(postDtos, size);
     }
 
     public PostListResponse getRecentPosts(PostSortType sortBy, Long lastPostId, int size) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
-        List<PostSummaryDto> postDtos;
+        List<PostInfoDto> postDtos;
 
         if (sortBy == PostSortType.POPULAR) {
             postDtos = postRepository.findPopularPostsWithCursor(lastPostId, pageRequest);

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -49,9 +49,7 @@ public class PostQueryService {
     }
 
     public PostDetailDto getPostDetail(Long postId) {
-        Post post = postRepository.findByIdWithTechBlog(postId)
+        return postRepository.findByIdWithTechBlog(postId)
                 .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND));
-
-        return postConverter.toDetailDto(post);
     }
 }

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -2,9 +2,12 @@ package com.techfork.domain.post.service;
 
 import com.techfork.domain.post.converter.PostConverter;
 import com.techfork.domain.post.dto.CompanyListResponse;
+import com.techfork.domain.post.dto.PostListResponse;
+import com.techfork.domain.post.dto.PostSummaryDto;
 import com.techfork.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,5 +25,12 @@ public class PostQueryService {
     public CompanyListResponse getCompanies() {
         List<String> companies = postRepository.findDistinctCompanies();
         return postConverter.toCompanyListResponse(companies);
+    }
+
+    public PostListResponse getPostsByCompany(String company, Long lastPostId, int size) {
+        PageRequest pageRequest = PageRequest.of(0, size + 1);
+        List<PostSummaryDto> postDtos = postRepository.findByCompanyWithCursor(company, lastPostId, pageRequest);
+
+        return postConverter.toPostListResponse(postDtos, size);
     }
 }

--- a/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
+++ b/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
@@ -1,7 +1,6 @@
 package com.techfork.domain.source.batch;
 
 import com.techfork.domain.post.entity.Post;
-import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.global.util.JdbcBulkInsert;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/techfork/domain/source/entity/TechBlog.java
+++ b/src/main/java/com/techfork/domain/source/entity/TechBlog.java
@@ -36,14 +36,21 @@ public class TechBlog extends BaseTimeEntity {
         this.companyName = companyName;
         this.blogUrl = blogUrl;
         this.rssUrl = rssUrl;
-        this.logoUrl = logoUrl;
+
+        if (this.logoUrl != null && !this.logoUrl.isBlank()) {
+            this.logoUrl = logoUrl;
+        } else {
+            this.logoUrl = String.format("https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=https://%s/&size=40", this.blogUrl);
+        }
     }
 
-    public static TechBlog create(String companyName, String blogUrl, String rssUrl) {
+    public static TechBlog create(String companyName, String blogUrl, String rssUrl, String logoUrl) {
         return TechBlog.builder()
                 .companyName(companyName)
                 .blogUrl(blogUrl)
                 .rssUrl(rssUrl)
+                .logoUrl(logoUrl)
                 .build();
     }
+
 }

--- a/src/main/java/com/techfork/global/config/InitialDataConfig.java
+++ b/src/main/java/com/techfork/global/config/InitialDataConfig.java
@@ -28,38 +28,38 @@ public class InitialDataConfig {
             log.info("TechBlog 초기 데이터 삽입 시작...");
 
             List<TechBlog> techBlogs = List.of(
-                    TechBlog.create("무신사", "https://medium.com/musinsa-tech", "https://medium.com/feed/musinsa-tech"),
-                    TechBlog.create("HYPERCONNECT", "https://hyperconnect.github.io", "https://hyperconnect.github.io/feed.xml"),
-                    TechBlog.create("여기어때", "https://techblog.gccompany.co.kr", "https://techblog.gccompany.co.kr/rss"),
-                    TechBlog.create("인프랩", "https://tech.inflab.com", "https://tech.inflab.com/rss.xml"),
+                    TechBlog.create("무신사", "https://medium.com/musinsa-tech", "https://medium.com/feed/musinsa-tech", "https://miro.medium.com/v2/resize:fill:160:160/1*Qs-0adxK8doDYyzZXMXkmg.png"),
+                    TechBlog.create("HYPERCONNECT", "https://hyperconnect.github.io", "https://hyperconnect.github.io/feed.xml", null),
+                    TechBlog.create("여기어때", "https://techblog.gccompany.co.kr", "https://techblog.gccompany.co.kr/rss", "https://miro.medium.com/v2/resize:fill:128:128/1*rGdUGkMoxT5SfrVKVAqbEw.png"),
+                    TechBlog.create("인프랩", "https://tech.inflab.com", "https://tech.inflab.com/rss.xml", null),
 
-                    TechBlog.create("네이버D2", "https://d2.naver.com/home", "https://d2.naver.com/d2.atom"),
-                    TechBlog.create("요기요", "https://techblog.yogiyo.co.kr", "https://techblog.yogiyo.co.kr/feed"),
-                    TechBlog.create("올리브영", "https://oliveyoung.tech", "https://oliveyoung.tech/rss.xml"),
-                    TechBlog.create("쏘카", "https://tech.socarcorp.kr/", "https://tech.socarcorp.kr/feed"),
+                    TechBlog.create("네이버D2", "https://d2.naver.com/home", "https://d2.naver.com/d2.atom", null),
+                    TechBlog.create("요기요", "https://techblog.yogiyo.co.kr", "https://techblog.yogiyo.co.kr/feed", "https://miro.medium.com/v2/resize:fill:128:128/1*yMAs19hb_LGVSSVcalnkHw.jpeg"),
+                    TechBlog.create("올리브영", "https://oliveyoung.tech", "https://oliveyoung.tech/rss.xml", null),
+                    TechBlog.create("쏘카", "https://tech.socarcorp.kr/", "https://tech.socarcorp.kr/feed", null),
 
-                    TechBlog.create("당근마켓", "https://medium.com/daangn", "https://medium.com/feed/daangn"),
-                    TechBlog.create("29CM", "https://medium.com/29cm", "https://medium.com/feed/29cm"),
-                    TechBlog.create("우아한형제들", "https://techblog.woowahan.com", "https://techblog.woowahan.com/feed/"),
-                    TechBlog.create("토스", "https://toss.tech", "https://toss.tech/rss.xml"),
-                    TechBlog.create("리디", "https://www.ridicorp.com/story-category/tech-blog/", "https://www.ridicorp.com/story-category/tech-blog/feed/"),
+                    TechBlog.create("당근마켓", "https://medium.com/daangn", "https://medium.com/feed/daangn", "https://miro.medium.com/v2/resize:fill:128:128/1*Bm8_nGjfNiKV0PASwiPELg.png"),
+                    TechBlog.create("29CM", "https://medium.com/29cm", "https://medium.com/feed/29cm", "https://miro.medium.com/v2/resize:fill:128:128/1*TP1aY6ZJaPSPs3fKA6sYKA.png"),
+                    TechBlog.create("우아한형제들", "https://techblog.woowahan.com", "https://techblog.woowahan.com/feed/", null),
+                    TechBlog.create("토스", "https://toss.tech", "https://toss.tech/rss.xml", null),
+                    TechBlog.create("리디", "https://www.ridicorp.com/story-category/tech-blog/", "https://www.ridicorp.com/story-category/tech-blog/feed/", null),
 
-                    TechBlog.create("SK C&C", "https://engineering-skcc.github.io", "https://engineering-skcc.github.io/feed.xml"),
-                    TechBlog.create("카카오엔터프라이즈", "https://tech.kakaoenterprise.com", "https://tech.kakaoenterprise.com/feed"),
-                    TechBlog.create("NHN", "https://meetup.nhncloud.com", "https://meetup.nhncloud.com/rss"),
-                    TechBlog.create("원티드", "https://medium.com/wantedjobs", "https://medium.com/feed/wantedjobs"),
-                    TechBlog.create("SSG", "https://medium.com/ssgtech", "https://medium.com/feed/ssgtech"),
+                    TechBlog.create("SK C&C", "https://engineering-skcc.github.io", "https://engineering-skcc.github.io/feed.xml", null),
+                    TechBlog.create("카카오엔터프라이즈", "https://tech.kakaoenterprise.com", "https://tech.kakaoenterprise.com/feed", null),
+                    TechBlog.create("NHN", "https://meetup.nhncloud.com", "https://meetup.nhncloud.com/rss", null),
+                    TechBlog.create("원티드", "https://medium.com/wantedjobs", "https://medium.com/feed/wantedjobs", "https://miro.medium.com/v2/resize:fill:128:128/1*FJkqW-xbLo_-zwoSzR1C6Q.jpeg"),
+                    TechBlog.create("SSG", "https://medium.com/ssgtech", "https://medium.com/feed/ssgtech", "https://miro.medium.com/v2/resize:fill:128:128/1*IFPbUqRn__nXbkPrxhi38A.png"),
 
-                    TechBlog.create("왓챠", "https://medium.com/watcha", "https://medium.com/feed/watcha"),
-                    TechBlog.create("롯데ON", "https://techblog.lotteon.com", "https://techblog.lotteon.com/feed"),
-                    TechBlog.create("네이버 플레이스", "https://medium.com/naver-place-dev", "https://medium.com/feed/naver-place-dev"),
-                    TechBlog.create("데브시스터즈", "https://tech.devsisters.com", "https://tech.devsisters.com/rss.xml"),
+                    TechBlog.create("왓챠", "https://medium.com/watcha", "https://medium.com/feed/watcha", "https://miro.medium.com/v2/resize:fill:128:128/1*3YwZ4pRivcBi8nWl7u98gA.png"),
+                    TechBlog.create("롯데ON", "https://techblog.lotteon.com", "https://techblog.lotteon.com/feed", "https://miro.medium.com/v2/resize:fill:128:128/1*_xLrBUD-sQT0-URzwwZcAA.png"),
+                    TechBlog.create("네이버 플레이스", "https://medium.com/naver-place-dev", "https://medium.com/feed/naver-place-dev", "https://miro.medium.com/v2/resize:fill:128:128/1*eQjirn85ojpPPzCAw9fU1g.png"),
+                    TechBlog.create("데브시스터즈", "https://tech.devsisters.com", "https://tech.devsisters.com/rss.xml", null),
 
-                    TechBlog.create("지마켓", "https://dev.gmarket.com", "https://dev.gmarket.com/rss"),
-                    TechBlog.create("번개장터", "https://medium.com/bunjang-tech-blog", "https://medium.com/feed/bunjang-tech-blog"),
-                    TechBlog.create("스포카", "https://spoqa.github.io", "https://spoqa.github.io/rss"),
-                    TechBlog.create("줌인터넷", "https://zuminternet.github.io", "https://zuminternet.github.io/feed.xml"),
-                    TechBlog.create("AWS 한국", "https://aws.amazon.com/ko/blogs/tech/", "https://aws.amazon.com/ko/blogs/tech/feed")
+                    TechBlog.create("지마켓", "https://dev.gmarket.com", "https://dev.gmarket.com/rss", null),
+                    TechBlog.create("번개장터", "https://medium.com/bunjang-tech-blog", "https://medium.com/feed/bunjang-tech-blog", "https://miro.medium.com/v2/resize:fill:128:128/1*XQ-7fuly8bBP4EVwj3ESbA.jpeg"),
+                    TechBlog.create("스포카", "https://spoqa.github.io", "https://spoqa.github.io/rss", null),
+                    TechBlog.create("줌인터넷", "https://zuminternet.github.io", "https://zuminternet.github.io/feed.xml", null),
+                    TechBlog.create("AWS 한국", "https://aws.amazon.com/ko/blogs/tech/", "https://aws.amazon.com/ko/blogs/tech/feed", null)
             );
 
             techBlogRepository.saveAll(techBlogs);


### PR DESCRIPTION
## ❤️ 기능 설명
### 1. 회사 목록 조회 API
- **엔드포인트**: `GET /api/v1/posts/companies`
- **기능**: 게시글이 있는 회사 목록을 알파벳순으로 반환
- **최적화**: Redis 캐싱 (1시간 TTL) 적용으로 DB 부하 최소화

### 2. 기업별 게시글 조회 API
- **엔드포인트**: `GET /api/v1/posts/by-company`
- **기능**: 특정 회사의 게시글 또는 전체 게시글 조회 (무한 스크롤)
- **필터링**: `company` 파라미터로 회사별 필터링 지원
- **정렬**: 최신 발행일순 정렬

### 3. 최근 생성된 게시글 조회 API
- **엔드포인트**: `GET /api/v1/posts/recent`
- **기능**: 최근 게시글 조회 (무한 스크롤)
- **정렬**: 최신순(latest) / 인기순(popular) 지원
- **홈 화면**: 섹션 3에서 무한 스크롤로 사용

### 4. 게시글 상세 조회 API
- **엔드포인트**: `GET /api/v1/posts/{postId}`
- **기능**: 특정 게시글의 상세 정보 조회
- **예외 처리**: 존재하지 않는 게시글 조회 시 404 에러

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

<img width="2128" height="1054" alt="image" src="https://github.com/user-attachments/assets/1dbe8278-1073-49eb-af0e-22f61100bd62" />


<img width="1720" height="1046" alt="image" src="https://github.com/user-attachments/assets/21b7c2d9-4954-47c1-b3f5-de60054c3938" />


<img width="1611" height="949" alt="image" src="https://github.com/user-attachments/assets/83c4f4b6-93ee-4ccc-b76b-6a01ced81111" />

<img width="2134" height="858" alt="image" src="https://github.com/user-attachments/assets/78a8fd67-5c55-4ef1-ad1a-c9894bb26c36" />



연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #64 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
