### PR TITLE
[feat/#72] 사용자 프로필 생성 스케쥴러 구현 및 포스트에서 키워드도 추출하도록 변경

### DIFF
--- a/src/main/java/com/techfork/domain/activity/repository/ReadPostRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/ReadPostRepository.java
@@ -3,9 +3,17 @@ package com.techfork.domain.activity.repository;
 import com.techfork.domain.activity.entity.ReadPost;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReadPostRepository extends JpaRepository<ReadPost, Long> {
 
     boolean existsByUserAndPost(User user, Post post);
+
+    @Query("SELECT rp FROM ReadPost rp JOIN FETCH rp.post WHERE rp.user = :user ORDER BY rp.readAt DESC")
+    List<ReadPost> findRecentReadPostsByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/techfork/domain/activity/repository/ScrabPostRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/ScrabPostRepository.java
@@ -34,4 +34,7 @@ public interface ScrabPostRepository extends JpaRepository<ScrabPost, Long> {
     boolean existsByUserAndPost(User user, Post post);
 
     Optional<ScrabPost> findByUserAndPost(User user, Post post);
+
+    @Query("SELECT sp FROM ScrabPost sp JOIN FETCH sp.post WHERE sp.user = :user ORDER BY sp.scrappedAt DESC")
+    List<ScrabPost> findRecentScrapPostsByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/techfork/domain/activity/repository/SearchHistoryRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/SearchHistoryRepository.java
@@ -1,8 +1,16 @@
 package com.techfork.domain.activity.repository;
 
 import com.techfork.domain.activity.entity.SearchHistory;
+import com.techfork.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface SearchHistoryRepository extends JpaRepository<SearchHistory, Long> {
 
+    @Query("SELECT sh FROM SearchHistory sh WHERE sh.user = :user ORDER BY sh.searchedAt DESC")
+    List<SearchHistory> findRecentSearchHistoriesByUser(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/techfork/domain/post/batch/PostSummaryProcessor.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostSummaryProcessor.java
@@ -1,6 +1,8 @@
 package com.techfork.domain.post.batch;
 
+import com.techfork.domain.post.dto.SummaryWithKeywords;
 import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.post.service.SummaryExtractionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,7 +11,7 @@ import org.springframework.batch.item.ItemProcessor;
 import org.springframework.stereotype.Component;
 
 /**
- * Post에서 LLM을 사용하여 요약을 추출하고 Post 엔티티에 저장하는 Processor
+ * Post에서 LLM을 사용하여 요약과 키워드를 추출하고 Post 엔티티에 저장하는 Processor
  */
 @Slf4j
 @Component
@@ -22,18 +24,28 @@ public class PostSummaryProcessor implements ItemProcessor<Post, Post> {
     @Override
     public Post process(Post post) {
         try {
-            log.debug("요약 추출 중: {}", post.getTitle());
+            log.debug("요약 및 키워드 추출 중: {}", post.getTitle());
 
-            String summary = summaryExtractionService.extractSummary(
+            SummaryWithKeywords result = summaryExtractionService.extractSummary(
                     post.getTitle(),
                     post.getPlainContent()
             );
 
-            post.updateSummary(summary);
+            // 요약 업데이트
+            post.updateSummary(result.summary());
+
+            // 기존 키워드 삭제 후 새 키워드 추가
+            post.clearKeywords();
+            result.keywords().forEach(keyword -> {
+                PostKeyword postKeyword = PostKeyword.create(keyword, post);
+                post.addKeyword(postKeyword);
+            });
+
+            log.debug("요약 및 키워드 추출 완료: {} (키워드 {}개)", post.getTitle(), result.keywords().size());
             return post;
 
         } catch (Exception e) {
-            log.error("요약 추출 실패 (Post ID: {}): {}", post.getId(), e.getMessage(), e);
+            log.error("요약 및 키워드 추출 실패 (Post ID: {}): {}", post.getId(), e.getMessage(), e);
             post.updateSummary("");
             return post;
         }

--- a/src/main/java/com/techfork/domain/post/dto/SummaryWithKeywords.java
+++ b/src/main/java/com/techfork/domain/post/dto/SummaryWithKeywords.java
@@ -1,0 +1,9 @@
+package com.techfork.domain.post.dto;
+
+import java.util.List;
+
+public record SummaryWithKeywords(
+        String summary,
+        List<String> keywords
+) {
+}

--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -10,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "posts")
@@ -48,6 +50,9 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "tech_blog_id", nullable = false)
     private TechBlog techBlog;
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostKeyword> keywords = new ArrayList<>();
+
     @Builder
     private Post(String title, String fullContent, String plainContent, String company, String url,
                  LocalDateTime publishedAt, LocalDateTime crawledAt, TechBlog techBlog) {
@@ -80,5 +85,13 @@ public class Post extends BaseEntity {
 
     public void updateEmbedded() {
         this.embeddedAt = LocalDateTime.now();
+    }
+
+    public void addKeyword(PostKeyword keyword) {
+        this.keywords.add(keyword);
+    }
+
+    public void clearKeywords() {
+        this.keywords.clear();
     }
 }

--- a/src/main/java/com/techfork/domain/post/entity/PostKeyword.java
+++ b/src/main/java/com/techfork/domain/post/entity/PostKeyword.java
@@ -1,0 +1,35 @@
+package com.techfork.domain.post.entity;
+
+import com.techfork.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "post_keywords")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostKeyword extends BaseEntity {
+
+    @Column(nullable = false, length = 50)
+    private String keyword;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;
+
+    @Builder
+    private PostKeyword(String keyword, Post post) {
+        this.keyword = keyword;
+        this.post = post;
+    }
+
+    public static PostKeyword create(String keyword, Post post) {
+        return PostKeyword.builder()
+                .keyword(keyword)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/techfork/domain/post/repository/PostKeywordRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostKeywordRepository.java
@@ -1,0 +1,14 @@
+package com.techfork.domain.post.repository;
+
+import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.entity.PostKeyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostKeywordRepository extends JpaRepository<PostKeyword, Long> {
+
+    List<PostKeyword> findByPost(Post post);
+
+    void deleteByPost(Post post);
+}

--- a/src/main/java/com/techfork/domain/post/service/SummaryExtractionService.java
+++ b/src/main/java/com/techfork/domain/post/service/SummaryExtractionService.java
@@ -1,10 +1,16 @@
 package com.techfork.domain.post.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techfork.domain.post.dto.SummaryWithKeywords;
 import com.techfork.global.llm.LlmClient;
 import com.techfork.global.util.ContentCleaner;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * LLM을 사용한 게시글 요약 추출 서비스
@@ -16,24 +22,35 @@ import org.springframework.stereotype.Service;
 public class SummaryExtractionService {
 
     private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
 
     private static final String SYSTEM_PROMPT = """
-            너는 기술 블로그 요약 전문가야.
-            주어진 기술 블로그 글을 분석하고, 의미 기반 검색에 최적화된 요약을 작성해줘.
+            너는 기술 블로그 분석 전문가야.
+            주어진 기술 블로그 글을 분석하고, 요약과 핵심 키워드를 추출해줘.
 
-            이 요약은 검색어와 함께 벡터 검색에 사용되어, 관련 글의 chunk를 찾는데 도움을 줘야 해.
+            응답은 반드시 아래 JSON 형식으로만 작성해:
+            {
+              "summary": "요약 내용 (300-500자)",
+              "keywords": ["키워드1", "키워드2", ...]
+            }
 
             요약 작성 원칙:
             1. 글의 전체 맥락과 흐름을 포함 (300-500자)
             2. 글에서 다루는 핵심 문제와 해결 방법을 구체적으로 기술
             3. 사용된 기술 스택, 도구, 프레임워크를 정확한 명칭으로 명시
-            4. 주요 개념과 키워드를 자연스럽게 포함 (검색 매칭용)
-            5. 관련 검색어가 다양하게 매칭될 수 있도록 유사 표현 활용
-            6. 자연스러운 한국어 문장으로 작성
-            7. 마크다운이나 특수 기호 없이 순수 텍스트로만 작성
+            4. 자연스러운 한국어 문장으로 작성
+            5. 마크다운이나 특수 기호 없이 순수 텍스트로만 작성
+
+            키워드 추출 원칙:
+            1. 10-15개의 핵심 키워드 추출
+            2. 기술 스택 (예: Spring Boot, React, Kubernetes)
+            3. 주제/개념 (예: 성능 최적화, 마이크로서비스, CI/CD)
+            4. 방법론 (예: TDD, DDD, 애자일)
+            5. 영문과 한글 키워드 모두 포함
+            6. 너무 일반적인 키워드(예: "개발", "코딩") 제외
             """;
 
-    public String extractSummary(String title, String content) {
+    public SummaryWithKeywords extractSummary(String title, String content) {
         try {
             String processedContent = content;
             if (content != null && content.length() > 50000) {
@@ -46,11 +63,31 @@ public class SummaryExtractionService {
             String response = llmClient.call(SYSTEM_PROMPT, userPrompt);
 
             log.debug("LLM API 응답 (제목: {}): {}", title, response);
-            return response.trim();
+
+            // JSON 응답 파싱
+            return parseResponse(response.trim());
 
         } catch (Exception e) {
             log.error("요약 추출 실패 (제목: {}): {}", title, e.getMessage(), e);
-            return "";
+            return new SummaryWithKeywords("", List.of());
+        }
+    }
+
+    private SummaryWithKeywords parseResponse(String response) {
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response);
+            String summary = jsonNode.get("summary").asText();
+            List<String> keywords = new ArrayList<>();
+
+            JsonNode keywordsNode = jsonNode.get("keywords");
+            if (keywordsNode != null && keywordsNode.isArray()) {
+                keywordsNode.forEach(node -> keywords.add(node.asText()));
+            }
+
+            return new SummaryWithKeywords(summary, keywords);
+        } catch (Exception e) {
+            log.error("JSON 응답 파싱 실패: {}", response, e);
+            return new SummaryWithKeywords("", List.of());
         }
     }
 

--- a/src/main/java/com/techfork/domain/user/document/UserProfileDocument.java
+++ b/src/main/java/com/techfork/domain/user/document/UserProfileDocument.java
@@ -1,4 +1,64 @@
 package com.techfork.domain.user.document;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Document(indexName = "user_profiles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserProfileDocument {
+
+    @Id
+    private String id;  // userId를 문자열로
+
+    @Field(type = FieldType.Long)
+    private Long userId;
+
+    @Field(type = FieldType.Text)
+    private String profileText;
+
+    @Field(type = FieldType.Dense_Vector, dims = 3072)  // OpenAI text-embedding-3-large dimension
+    private float[] profileVector;
+
+    @Field(type = FieldType.Keyword)
+    private List<String> interests;
+
+    @Field(type = FieldType.Keyword)
+    private List<String> preferredTopics;
+
+    @Field(type = FieldType.Date)
+    private LocalDateTime generatedAt;
+
+    @Builder
+    private UserProfileDocument(Long userId, String profileText, float[] profileVector,
+                                 List<String> interests, List<String> preferredTopics, LocalDateTime generatedAt) {
+        this.id = String.valueOf(userId);
+        this.userId = userId;
+        this.profileText = profileText;
+        this.profileVector = profileVector;
+        this.interests = interests;
+        this.preferredTopics = preferredTopics;
+        this.generatedAt = generatedAt;
+    }
+
+    public static UserProfileDocument create(Long userId, String profileText, float[] profileVector,
+                                              List<String> interests, List<String> preferredTopics) {
+        return UserProfileDocument.builder()
+                .userId(userId)
+                .profileText(profileText)
+                .profileVector(profileVector)
+                .interests(interests)
+                .preferredTopics(preferredTopics)
+                .generatedAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/techfork/domain/user/document/UserProfileDocument.java
+++ b/src/main/java/com/techfork/domain/user/document/UserProfileDocument.java
@@ -32,32 +32,27 @@ public class UserProfileDocument {
     @Field(type = FieldType.Keyword)
     private List<String> interests;
 
-    @Field(type = FieldType.Keyword)
-    private List<String> preferredTopics;
-
     @Field(type = FieldType.Date)
     private LocalDateTime generatedAt;
 
     @Builder
     private UserProfileDocument(Long userId, String profileText, float[] profileVector,
-                                 List<String> interests, List<String> preferredTopics, LocalDateTime generatedAt) {
+                                 List<String> interests, LocalDateTime generatedAt) {
         this.id = String.valueOf(userId);
         this.userId = userId;
         this.profileText = profileText;
         this.profileVector = profileVector;
         this.interests = interests;
-        this.preferredTopics = preferredTopics;
         this.generatedAt = generatedAt;
     }
 
     public static UserProfileDocument create(Long userId, String profileText, float[] profileVector,
-                                              List<String> interests, List<String> preferredTopics) {
+                                              List<String> interests) {
         return UserProfileDocument.builder()
                 .userId(userId)
                 .profileText(profileText)
                 .profileVector(profileVector)
                 .interests(interests)
-                .preferredTopics(preferredTopics)
                 .generatedAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/techfork/domain/user/repository/UserProfileDocumentRepository.java
+++ b/src/main/java/com/techfork/domain/user/repository/UserProfileDocumentRepository.java
@@ -1,0 +1,7 @@
+package com.techfork.domain.user.repository;
+
+import com.techfork.domain.user.document.UserProfileDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface UserProfileDocumentRepository extends ElasticsearchRepository<UserProfileDocument, String> {
+}

--- a/src/main/java/com/techfork/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/techfork/domain/user/repository/UserRepository.java
@@ -2,6 +2,27 @@ package com.techfork.domain.user.repository;
 
 import com.techfork.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    /**
+     * 최근 특정 시간 이후 활동한 사용자 조회
+     * (읽은 포스트, 스크랩, 검색 기록 중 하나라도 있으면 활성 사용자)
+     */
+    @Query("""
+            SELECT DISTINCT u FROM User u
+            WHERE EXISTS (
+                SELECT 1 FROM ReadPost rp WHERE rp.user = u AND rp.readAt >= :since
+            ) OR EXISTS (
+                SELECT 1 FROM ScrabPost sp WHERE sp.user = u AND sp.scrappedAt >= :since
+            ) OR EXISTS (
+                SELECT 1 FROM SearchHistory sh WHERE sh.user = u AND sh.searchedAt >= :since
+            )
+            """)
+    List<User> findActiveUsersSince(@Param("since") LocalDateTime since);
 }

--- a/src/main/java/com/techfork/domain/user/scheduler/UserProfileScheduler.java
+++ b/src/main/java/com/techfork/domain/user/scheduler/UserProfileScheduler.java
@@ -1,0 +1,44 @@
+package com.techfork.domain.user.scheduler;
+
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.domain.user.service.UserProfileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserProfileScheduler {
+
+    private final UserRepository userRepository;
+    private final UserProfileService userProfileService;
+
+    /**
+     * 매일 새벽 3시에 최근 24시간 내 활성 사용자의 프로필을 재생성
+     */
+    @Scheduled(cron = "0 0 3 * * *")
+    public void regenerateActiveUserProfiles() {
+        log.info("Starting daily user profile regeneration for active users");
+
+        LocalDateTime since = LocalDateTime.now().minusHours(24);
+        List<User> activeUsers = userRepository.findActiveUsersSince(since);
+
+        log.info("Found {} active users in the last 24 hours", activeUsers.size());
+
+        activeUsers.forEach(user -> {
+            try {
+                userProfileService.generateUserProfile(user.getId());
+            } catch (Exception e) {
+                log.error("Failed to generate profile for user: {}", user.getId(), e);
+            }
+        });
+
+        log.info("Completed daily user profile regeneration for {} active users", activeUsers.size());
+    }
+}

--- a/src/main/java/com/techfork/domain/user/service/InterestCommandService.java
+++ b/src/main/java/com/techfork/domain/user/service/InterestCommandService.java
@@ -26,6 +26,7 @@ public class InterestCommandService {
 
     private final UserRepository userRepository;
     private final UserInterestCategoryRepository userInterestCategoryRepository;
+    private final UserProfileService userProfileService;
 
     public void updateUserInterests(Long userId, SaveInterestRequest request) {
         saveUserInterests(userId, request);
@@ -41,6 +42,9 @@ public class InterestCommandService {
         userInterestCategoryRepository.saveAll(categories);
 
         log.info("Saved {} interest categories for user {}", categories.size(), userId);
+
+        // 관심사 저장/수정 시 사용자 프로필 재생성
+        userProfileService.generateUserProfile(userId);
     }
 
     private List<UserInterestCategory> createCategoriesFromRequest(User user, SaveInterestRequest request) {

--- a/src/main/java/com/techfork/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/techfork/domain/user/service/UserProfileService.java
@@ -1,0 +1,196 @@
+package com.techfork.domain.user.service;
+
+import com.techfork.domain.activity.entity.ReadPost;
+import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.SearchHistory;
+import com.techfork.domain.activity.repository.ReadPostRepository;
+import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.SearchHistoryRepository;
+import com.techfork.domain.user.document.UserProfileDocument;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.entity.UserInterestCategory;
+import com.techfork.domain.user.exception.UserErrorCode;
+import com.techfork.domain.user.repository.UserInterestCategoryRepository;
+import com.techfork.domain.user.repository.UserProfileDocumentRepository;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.exception.GeneralException;
+import com.techfork.global.llm.EmbeddingClient;
+import com.techfork.global.llm.LlmClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserProfileService {
+
+    private final UserRepository userRepository;
+    private final UserInterestCategoryRepository userInterestCategoryRepository;
+    private final ReadPostRepository readPostRepository;
+    private final ScrabPostRepository scrabPostRepository;
+    private final SearchHistoryRepository searchHistoryRepository;
+    private final UserProfileDocumentRepository userProfileDocumentRepository;
+    private final LlmClient llmClient;
+    private final EmbeddingClient embeddingClient;
+
+    @Async
+    @Transactional
+    public void generateUserProfile(Long userId) {
+        try {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+            // 1. 사용자 데이터 수집
+            UserActivityData activityData = collectUserActivityData(user);
+
+            // 2. LLM으로 프로필 텍스트 생성
+            String profileText = generateProfileTextWithLLM(activityData);
+
+            // 3. 임베딩 벡터 생성
+            float[] profileVector = generateEmbeddingVector(profileText);
+
+            // 4. Elasticsearch에 저장
+            UserProfileDocument profileDocument = UserProfileDocument.create(
+                    userId,
+                    profileText,
+                    profileVector,
+                    activityData.interests,
+                    activityData.preferredTopics
+            );
+
+            userProfileDocumentRepository.save(profileDocument);
+
+            log.info("User profile generated successfully for userId: {}", userId);
+        } catch (Exception e) {
+            log.error("Failed to generate user profile for userId: {}", userId, e);
+        }
+    }
+
+    private UserActivityData collectUserActivityData(User user) {
+        // 관심사
+        List<UserInterestCategory> categories = userInterestCategoryRepository.findByUserWithKeywords(user);
+        List<String> interests = categories.stream()
+                .flatMap(c -> c.getKeywords().stream())
+                .map(k -> k.getKeyword().getDisplayName())
+                .toList();
+
+        // 최근 읽은 포스트 (최대 20개)
+        List<ReadPost> readPosts = readPostRepository.findRecentReadPostsByUser(user, PageRequest.of(0, 20));
+        List<String> readPostTitles = readPosts.stream()
+                .map(rp -> rp.getPost().getTitle())
+                .toList();
+
+        // 스크랩한 포스트 (최대 20개)
+        List<ScrabPost> scrapPosts = scrabPostRepository.findRecentScrapPostsByUser(user, PageRequest.of(0, 20));
+        List<String> scrapPostTitles = scrapPosts.stream()
+                .map(sp -> sp.getPost().getTitle())
+                .toList();
+
+        // 검색 기록 (최대 30개)
+        List<SearchHistory> searchHistories = searchHistoryRepository.findRecentSearchHistoriesByUser(user, PageRequest.of(0, 30));
+        List<String> searchWords = searchHistories.stream()
+                .map(SearchHistory::getSearchWord)
+                .toList();
+
+        // 선호 주제 (읽은 포스트의 회사명 집계)
+        List<String> preferredTopics = readPosts.stream()
+                .map(rp -> rp.getPost().getCompany())
+                .distinct()
+                .toList();
+
+        return new UserActivityData(interests, readPostTitles, scrapPostTitles, searchWords, preferredTopics);
+    }
+
+    private String generateProfileTextWithLLM(UserActivityData data) {
+        String systemPrompt = "당신은 테크 블로그 플랫폼의 사용자 프로필 분석 전문가입니다. 사용자의 활동 데이터를 분석하여 검색 고도화와 포스트 추천에 최적화된 프로필을 생성합니다.";
+        String userPrompt = buildProfileGenerationPrompt(data);
+        return llmClient.call(systemPrompt, userPrompt);
+    }
+
+    private String buildProfileGenerationPrompt(UserActivityData data) {
+        return String.format("""
+                아래 사용자의 활동 데이터를 분석하여 검색 고도화와 포스트 추천에 최적화된 프로필을 생성해주세요.
+
+                ## 사용자 데이터
+
+                ### 관심 기술 스택 및 분야
+                %s
+
+                ### 최근 읽은 포스트 제목
+                %s
+
+                ### 스크랩한 포스트 제목
+                %s
+
+                ### 검색 기록
+                %s
+
+                ## 요구사항
+
+                다음 형식으로 구조화된 프로필을 생성해주세요:
+
+                1. **기술적 관심사 요약** (2-3문장)
+                   - 사용자가 주로 관심을 갖는 기술 스택, 프레임워크, 도구
+                   - 선호하는 개발 분야 (백엔드, 프론트엔드, AI, 인프라 등)
+
+                2. **콘텐츠 선호 패턴** (2-3문장)
+                   - 어떤 유형의 콘텐츠를 선호하는지 (튜토리얼, 아키텍처, 트러블슈팅, 신기술 소개 등)
+                   - 어떤 회사나 팀의 기술 블로그를 자주 읽는지
+
+                3. **검색 의도 분석** (2-3문장)
+                   - 검색 기록에서 드러나는 학습 목적이나 해결하려는 문제
+                   - 반복되는 검색 주제나 패턴
+
+                4. **추천 키워드** (쉼표로 구분된 15-20개의 키워드)
+                   - 검색 쿼리 확장에 사용할 관련 기술 용어
+                   - 유사한 관심사를 가진 사용자가 찾을 만한 키워드
+                   - 영문과 한글 키워드 모두 포함
+
+                5. **프로필 요약** (1-2문장, 벡터 임베딩 최적화용)
+                   - 사용자의 기술적 페르소나를 한 줄로 압축
+                   - 추천 시스템이 유사 사용자를 찾는데 활용할 핵심 설명
+
+                데이터가 부족한 경우 관심 기술 스택을 기반으로 일반적인 프로필을 생성해주세요.
+                """,
+                formatList(data.interests),
+                formatList(data.readPostTitles),
+                formatList(data.scrapPostTitles),
+                formatList(data.searchWords)
+        );
+    }
+
+    private String formatList(List<String> items) {
+        if (items == null || items.isEmpty()) {
+            return "- (데이터 없음)";
+        }
+        return items.stream()
+                .map(item -> "- " + item)
+                .collect(Collectors.joining("\n"));
+    }
+
+    private float[] generateEmbeddingVector(String profileText) {
+        // OpenAI text-embedding-3-large (3072 dimensions)
+        List<Float> embedding = embeddingClient.embed(profileText);
+
+        float[] vector = new float[embedding.size()];
+        for (int i = 0; i < embedding.size(); i++) {
+            vector[i] = embedding.get(i);
+        }
+        return vector;
+    }
+
+    private record UserActivityData(
+            List<String> interests,
+            List<String> readPostTitles,
+            List<String> scrapPostTitles,
+            List<String> searchWords,
+            List<String> preferredTopics
+    ) {}
+}

--- a/src/main/java/com/techfork/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/techfork/domain/user/service/UserProfileService.java
@@ -6,6 +6,7 @@ import com.techfork.domain.activity.entity.SearchHistory;
 import com.techfork.domain.activity.repository.ReadPostRepository;
 import com.techfork.domain.activity.repository.ScrabPostRepository;
 import com.techfork.domain.activity.repository.SearchHistoryRepository;
+import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.user.document.UserProfileDocument;
 import com.techfork.domain.user.entity.User;
 import com.techfork.domain.user.entity.UserInterestCategory;
@@ -61,8 +62,7 @@ public class UserProfileService {
                     userId,
                     profileText,
                     profileVector,
-                    activityData.interests,
-                    activityData.preferredTopics
+                    activityData.interests
             );
 
             userProfileDocumentRepository.save(profileDocument);
@@ -81,16 +81,26 @@ public class UserProfileService {
                 .map(k -> k.getKeyword().getDisplayName())
                 .toList();
 
-        // 최근 읽은 포스트 (최대 20개)
+        // 최근 읽은 포스트 (최대 20개) - 제목 + 키워드
         List<ReadPost> readPosts = readPostRepository.findRecentReadPostsByUser(user, PageRequest.of(0, 20));
-        List<String> readPostTitles = readPosts.stream()
-                .map(rp -> rp.getPost().getTitle())
+        List<PostData> readPostData = readPosts.stream()
+                .map(rp -> new PostData(
+                        rp.getPost().getTitle(),
+                        rp.getPost().getKeywords().stream()
+                                .map(PostKeyword::getKeyword)
+                                .toList()
+                ))
                 .toList();
 
-        // 스크랩한 포스트 (최대 20개)
+        // 스크랩한 포스트 (최대 20개) - 제목 + 키워드
         List<ScrabPost> scrapPosts = scrabPostRepository.findRecentScrapPostsByUser(user, PageRequest.of(0, 20));
-        List<String> scrapPostTitles = scrapPosts.stream()
-                .map(sp -> sp.getPost().getTitle())
+        List<PostData> scrapPostData = scrapPosts.stream()
+                .map(sp -> new PostData(
+                        sp.getPost().getTitle(),
+                        sp.getPost().getKeywords().stream()
+                                .map(PostKeyword::getKeyword)
+                                .toList()
+                ))
                 .toList();
 
         // 검색 기록 (최대 30개)
@@ -99,13 +109,7 @@ public class UserProfileService {
                 .map(SearchHistory::getSearchWord)
                 .toList();
 
-        // 선호 주제 (읽은 포스트의 회사명 집계)
-        List<String> preferredTopics = readPosts.stream()
-                .map(rp -> rp.getPost().getCompany())
-                .distinct()
-                .toList();
-
-        return new UserActivityData(interests, readPostTitles, scrapPostTitles, searchWords, preferredTopics);
+        return new UserActivityData(interests, readPostData, scrapPostData, searchWords);
     }
 
     private String generateProfileTextWithLLM(UserActivityData data) {
@@ -123,10 +127,10 @@ public class UserProfileService {
                 ### 관심 기술 스택 및 분야
                 %s
 
-                ### 최근 읽은 포스트 제목
+                ### 최근 읽은 포스트
                 %s
 
-                ### 스크랩한 포스트 제목
+                ### 스크랩한 포스트
                 %s
 
                 ### 검색 기록
@@ -141,8 +145,8 @@ public class UserProfileService {
                    - 선호하는 개발 분야 (백엔드, 프론트엔드, AI, 인프라 등)
 
                 2. **콘텐츠 선호 패턴** (2-3문장)
-                   - 어떤 유형의 콘텐츠를 선호하는지 (튜토리얼, 아키텍처, 트러블슈팅, 신기술 소개 등)
-                   - 어떤 회사나 팀의 기술 블로그를 자주 읽는지
+                   - 읽은 포스트와 스크랩한 포스트를 분석하여 선호하는 주제와 기술 파악
+                   - 선호하는 회사/팀이나 콘텐츠 유형 (튜토리얼, 아키텍처, 트러블슈팅 등)
 
                 3. **검색 의도 분석** (2-3문장)
                    - 검색 기록에서 드러나는 학습 목적이나 해결하려는 문제
@@ -160,8 +164,8 @@ public class UserProfileService {
                 데이터가 부족한 경우 관심 기술 스택을 기반으로 일반적인 프로필을 생성해주세요.
                 """,
                 formatList(data.interests),
-                formatList(data.readPostTitles),
-                formatList(data.scrapPostTitles),
+                formatPostDataList(data.readPostData),
+                formatPostDataList(data.scrapPostData),
                 formatList(data.searchWords)
         );
     }
@@ -172,6 +176,20 @@ public class UserProfileService {
         }
         return items.stream()
                 .map(item -> "- " + item)
+                .collect(Collectors.joining("\n"));
+    }
+
+    private String formatPostDataList(List<PostData> postDataList) {
+        if (postDataList == null || postDataList.isEmpty()) {
+            return "- (데이터 없음)";
+        }
+        return postDataList.stream()
+                .map(postData -> {
+                    String keywordsStr = postData.keywords.isEmpty()
+                            ? ""
+                            : " [키워드: " + String.join(", ", postData.keywords) + "]";
+                    return "- " + postData.title + keywordsStr;
+                })
                 .collect(Collectors.joining("\n"));
     }
 
@@ -188,9 +206,13 @@ public class UserProfileService {
 
     private record UserActivityData(
             List<String> interests,
-            List<String> readPostTitles,
-            List<String> scrapPostTitles,
-            List<String> searchWords,
-            List<String> preferredTopics
+            List<PostData> readPostData,
+            List<PostData> scrapPostData,
+            List<String> searchWords
+    ) {}
+
+    private record PostData(
+            String title,
+            List<String> keywords
     ) {}
 }


### PR DESCRIPTION
## ❤️ 기능 설명
온보딩 관심사, 읽은 포스트, 스크랩한 포스트, 검색어 기반으로 사용자 프로필을 생성합니다.

이때 포스트에 대한 정보로 제목 + 키워드를 넘기기위하여 크롤링 파이프라인 속 요약 파이프라인에서 키워드도 추출하도록 변경합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #72 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 사용자 프로필 생성을 위해 llm에게 키워드도 추출하도록 변경했습니다.
- [ ] 추출한 키워드는 포스트 조회시에도 모두 조회되도록 변경할 예정입니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
