### PR TITLE
[fix/#75] 크롤링 파이프라인에서 포스트 조회할 때 키워드도 JOIN 해서 조회하도록 해서 LazyInitialization 에러 해결

### DIFF
--- a/src/main/java/com/techfork/domain/post/batch/PostSummaryReader.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostSummaryReader.java
@@ -26,7 +26,7 @@ public class PostSummaryReader implements ItemReader<Post> {
     @Override
     public Post read() {
         if (postIterator == null) {
-            List<Post> posts = postRepository.findBySummaryIsNull();
+            List<Post> posts = postRepository.findWithKeywordsBySummaryIsNull();
             log.info("요약이 없거나 비어있는 게시글 {}개 발견", posts.size());
             postIterator = posts.iterator();
         }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -18,8 +18,12 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     boolean existsByUrl(String url);
 
-    @Query("SELECT p FROM Post p WHERE p.summary IS NULL OR p.summary = ''")
-    List<Post> findBySummaryIsNull();
+    @Query("""
+            SELECT p FROM Post p 
+            LEFT JOIN FETCH p.keywords
+            WHERE p.summary IS NULL OR p.summary = ''
+            """)
+    List<Post> findWithKeywordsBySummaryIsNull();
 
     Page<Post> findBySummaryIsNotNullAndEmbeddedAtIsNull(Pageable pageable);
 


### PR DESCRIPTION
## ❤️ 기능 설명
크롤링 파이프라인 중 키워드가 JOIN 되지 않아 LazyInitialization 에러가 발생하는 걸 해결합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>
<img width="3664" height="330" alt="image" src="https://github.com/user-attachments/assets/7230a17b-3878-4569-87eb-5228ec52923b" />


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #75 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] CD가 동작하지 않으면 cloudflare 문제가 아직 해결되지 않아서입니다.
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
