### PR TITLE
feat: 검색 품질 평가 로직 및 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 	implementation 'org.springframework.ai:spring-ai-openai'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 dependencyManagement {

--- a/src/main/java/com/techfork/domain/search/GroundTruthItem.java
+++ b/src/main/java/com/techfork/domain/search/GroundTruthItem.java
@@ -1,0 +1,27 @@
+package com.techfork.domain.search;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+public class GroundTruthItem {
+    private String query;
+    private List<IdealResult> idealResults;
+
+    @Data
+    @NoArgsConstructor
+    public static class IdealResult {
+        private String docId;
+        private int relevance;  // 관련도 점수 (3: 매우 관련, 2: 관련, 1: 약간 관련)
+    }
+
+    public Map<String, Integer> getIdealResultsMap() {
+        return idealResults.stream()
+                .collect(Collectors.toMap(IdealResult::getDocId, IdealResult::getRelevance));
+    }
+}

--- a/src/main/java/com/techfork/domain/search/SearchQualityService.java
+++ b/src/main/java/com/techfork/domain/search/SearchQualityService.java
@@ -1,0 +1,86 @@
+package com.techfork.domain.search;
+
+import org.springframework.stereotype.Service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Service
+public class SearchQualityService {
+
+    /**
+     * Recall@K 계산
+     * 수식: (Top K 결과 중 정답 문서 개수) / (전체 정답 문서 개수)
+     *
+     * @param actualDocIds 검색 엔진이 반환한 문서 ID 리스트 (순서대로)
+     * @param idealDocIds  판단 목록에 있는 '관련된(Relevance > 0)' 문서 ID 집합
+     * @param k            평가할 상위 개수 (예: 5)
+     */
+    public double calculateRecall(List<String> actualDocIds, Set<String> idealDocIds, int k) {
+        if (idealDocIds == null || idealDocIds.isEmpty()) {
+            return 0.0;
+        }
+
+        List<String> topKResults = actualDocIds.stream()
+                .limit(k)
+                .toList();
+
+        long hitCount = topKResults.stream()
+                .filter(idealDocIds::contains)
+                .count();
+
+        return (double) hitCount / idealDocIds.size();
+    }
+
+    /**
+     * nDCG@K 계산
+     * 수식: DCG@K / IDCG@K
+     *
+     * @param actualDocIds    검색 엔진이 반환한 문서 ID 리스트
+     * @param idealResultsMap 문서 ID별 기대 점수 (Map<DocId, RelevanceScore>)
+     * @param k               평가할 상위 개수 (예: 10)
+     */
+    public double calculateNDCG(List<String> actualDocIds, Map<String, Integer> idealResultsMap, int k) {
+        double dcg = calculateDCG(actualDocIds, idealResultsMap, k);
+        double idcg = calculateIDCG(idealResultsMap, k);
+
+        if (idcg == 0.0) return 0.0;
+
+        return dcg / idcg;
+    }
+
+    // DCG (Discounted Cumulative Gain) 계산 - 실제 검색 결과 순서대로 점수를 매기되, 순위가 낮을수록 로그 함수로 패널티를 부여
+    private double calculateDCG(List<String> actualDocIds, Map<String, Integer> idealResultsMap, int k) {
+        double dcg = 0.0;
+
+        for (int i = 0; i < Math.min(actualDocIds.size(), k); i++) {
+            String docId = actualDocIds.get(i);
+            int relevance = idealResultsMap.getOrDefault(docId, 0);
+
+            // 순위 패널티 적용
+            if (relevance > 0) {
+                dcg += relevance / (Math.log(i + 2) / Math.log(2));
+            }
+        }
+        return dcg;
+    }
+
+    // IDCG - 정답 문서를 점수순으로 내림차순 정렬했을 때(가장 이상적인 순서)의 DCG 값
+    private double calculateIDCG(Map<String, Integer> idealResultsMap, int k) {
+        List<Integer> idealRelevances = idealResultsMap.values().stream()
+                .sorted(Comparator.reverseOrder()) // 점수 높은 순 정렬
+                .limit(k)
+                .toList();
+
+        double idcg = 0.0;
+        for (int i = 0; i < idealRelevances.size(); i++) {
+            int relevance = idealRelevances.get(i);
+            if (relevance > 0) {
+                idcg += relevance / (Math.log(i + 2) / Math.log(2));
+            }
+        }
+        return idcg;
+    }
+}

--- a/src/main/java/com/techfork/domain/search/SearchResult.java
+++ b/src/main/java/com/techfork/domain/search/SearchResult.java
@@ -1,0 +1,21 @@
+package com.techfork.domain.search;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SearchResult {
+    private Long postId;
+    private String title;
+    private String summary;
+    private String companyName;
+    private String url;
+    private String logoUrl;
+
+    private double hybridScore;
+    private double personalScore;
+    private double finalScore;
+
+    private float[] documentVector;
+}

--- a/src/main/java/com/techfork/domain/search/SearchService.java
+++ b/src/main/java/com/techfork/domain/search/SearchService.java
@@ -1,0 +1,33 @@
+package com.techfork.domain.search;
+
+import com.techfork.domain.user.entity.User;
+
+import java.util.List;
+
+public interface SearchService {
+
+    /**
+     * 1단계 일반 검색 (Retrieval)
+     * - 목적: 검색 품질 평가(Recall) 및 비로그인 사용자 검색
+     * - 동작: RRF(BM25 + k-NN) 하이브리드 검색만 수행하여 상위 K개 결과를 반환합니다.
+     * - 개인화(Re-ranking) 로직이 적용되지 않은 순수 연관도 순입니다.
+     *
+     * @param query 검색어
+     * @return 1단계 검색 결과 리스트
+     */
+    List<SearchResult> searchGeneral(String query);
+
+    /**
+     * 2단계 개인화 검색 (Re-ranking)
+     * - 목적: 실제 서비스 메인 검색 (로그인 사용자용)
+     * - 동작:
+     * 1. 1단계 검색으로 후보군(Top 100) 확보
+     * 2. 사용자의 프로필 벡터와 문서 간 유사도 계산 (Cosine Similarity)
+     * 3. 1단계 점수와 2단계 점수를 가중합하여 재정렬
+     *
+     * @param query 검색어
+     * @param user  검색을 요청한 사용자 (프로필 벡터 활용용)
+     * @return 개인화된 최종 검색 결과 리스트 (Top 10)
+     */
+    List<SearchResult> searchPersonalized(String query, User user);
+}

--- a/src/main/java/com/techfork/domain/search/SearchServiceImpl.java
+++ b/src/main/java/com/techfork/domain/search/SearchServiceImpl.java
@@ -1,0 +1,24 @@
+package com.techfork.domain.search;
+
+import com.techfork.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SearchServiceImpl implements SearchService {
+
+    @Override
+    public List<SearchResult> searchGeneral(String query) {
+        return List.of();
+    }
+
+    @Override
+    public List<SearchResult> searchPersonalized(String query, User user) {
+        return List.of();
+    }
+}

--- a/src/test/java/com/techfork/SearchQualityEvaluatorTest.java
+++ b/src/test/java/com/techfork/SearchQualityEvaluatorTest.java
@@ -1,0 +1,77 @@
+package com.techfork;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techfork.domain.search.GroundTruthItem;
+import com.techfork.domain.search.SearchQualityService;
+import com.techfork.domain.search.SearchResult;
+import com.techfork.domain.search.SearchService;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@SpringBootTest
+public class SearchQualityEvaluatorTest {
+
+    @Autowired
+    private SearchService searchService;
+
+    @Autowired
+    private SearchQualityService searchQualityService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("1단계 일반 검색 품질 평가 (nDCG@10, Recall@5)")
+    void evaluateSearchQuality() throws IOException {
+        List<GroundTruthItem> groundTruths = loadGroundTruth();
+
+        List<Double> nDcgScores = new ArrayList<>();
+        List<Double> recallScores = new ArrayList<>();
+
+        log.info("===== 검색 품질 평가 시작 (총 {}개 시나리오) =====", groundTruths.size());
+
+        for (GroundTruthItem item : groundTruths) {
+            String query = item.getQuery();
+            Map<String, Integer> idealMap = item.getIdealResultsMap();
+
+            List<SearchResult> results = searchService.searchGeneral(query);
+
+            List<String> actualDocIds = results.stream()
+                    .map(result -> String.valueOf(result.getPostId()))
+                    .toList();
+
+            double nDCG = searchQualityService.calculateNDCG(actualDocIds, idealMap, 10);
+            double recall = searchQualityService.calculateRecall(actualDocIds, idealMap.keySet(), 5);
+
+            nDcgScores.add(nDCG);
+            recallScores.add(recall);
+
+            log.info("[Query: {}] nDCG@10: {}, Recall@5: {}",
+                    query, String.format("%.4f", nDCG), String.format("%.4f", recall));
+        }
+
+        double avgNDCG = nDcgScores.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+        double avgRecall = recallScores.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+
+        log.info("===== 최종 평가 결과 =====");
+        log.info("Average nDCG@10: {}", String.format("%.4f", avgNDCG));
+        log.info("Average Recall@5: {}", String.format("%.4f", avgRecall));
+    }
+
+    private List<GroundTruthItem> loadGroundTruth() throws IOException {
+        // src/test/resources/ground-truth.json 파일을 읽음
+        ClassPathResource resource = new ClassPathResource("ground-truth.json");
+        return objectMapper.readValue(resource.getInputStream(), new TypeReference<>() {});
+    }
+}

--- a/src/test/java/com/techfork/es-check.http
+++ b/src/test/java/com/techfork/es-check.http
@@ -1,0 +1,26 @@
+### 1. 연결 확인
+GET http://localhost:9200/
+
+### 2. 모든 인덱스(테이블) 목록 확인
+GET http://localhost:9200/_cat/indices?v
+
+### 3. 'posts' 인덱스 데이터 10개 조회
+GET http://localhost:9200/posts/_search
+Content-Type: application/json
+
+{
+  "query": { "match_all": {} },
+  "size": 10
+}
+
+### 4. 게시글의 제목과 임베딩 벡터 존재 여부 확인
+GET http://localhost:9200/posts/_search
+Content-Type: application/json
+
+{
+  "size": 1,
+  "_source": ["postId", "title", "titleEmbedding"],
+  "query": {
+    "match_all": {}
+  }
+}


### PR DESCRIPTION
## 기능 설명

검색 엔진의 품질을 객관적인 수치로 평가하기 위해 recall, nDCG 지표를 사용했습니다. 검색 결과의 정확도와 순위 적합성을 측정하기 위해 nDCG@10과 Recall@5 지표 계산 로직을 구현하고, 이를 자동화된 테스트 환경에서 수행할 수 있는 파이프라인을 구축했습니다.

**주요 변경 사항**
- 검색 품질 평가 로직 구현 (SearchQualityService)

- Recall@K: 검색된 상위 K개 결과 중 정답 문서가 얼마나 포함되었는지 계산

- nDCG@K: 검색 결과의 순위 가중치를 반영하여 점수 계산 (로그 함수 기반 패널티 적용)

**평가용 데이터 구조 정의**

- GroundTruthItem: 쿼리별 이상적인 결과(정답지)를 매핑할 DTO 정의

- SearchResult: 검색 결과를 통일된 포맷으로 반환하기 위한 DTO 정의

**검색 서비스 인터페이스 설계 (SearchService)**

- 기존 DB 조회(PostQueryService)와 분리하여, ES 기반의 1차 검색(Retrieval) 및 2차 리랭킹(Personalized)을 담당할 인터페이스 명세 정의

**자동화된 평가 테스트 작성 (SearchQualityEvaluatorTest)**

- ground-truth.json 파일을 읽어 실제 검색 결과와 비교하고, nDCG/Recall 점수를 로그로 출력하는 통합 테스트 구현

**테스트 환경 설정 (build.gradle)**

- 테스트 코드에서도 Lombok(@Slf4j 등)을 사용할 수 있도록 의존성 추가

## 연결된 issue
close #78 

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
