### PR TITLE
[fix/#79] 우아한형제들 테크블로그 파싱 불가 문제 해결을 위해 WebClient 사용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 	// RSS Parsing
 	implementation 'com.rometools:rome:2.1.0'
 	implementation 'com.rometools:rome-modules:2.1.0'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	//	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	//	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
+++ b/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
@@ -14,10 +14,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.configuration.annotation.StepScope;
 import org.springframework.batch.item.ItemReader;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.*;
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 public class RssFeedReader implements ItemReader<RssFeedItem> {
 
     private final TechBlogRepository techBlogRepository;
+    private final WebClient webClient;
 
     private ConcurrentLinkedQueue<RssFeedItem> itemQueue;
 
@@ -86,34 +87,27 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
     }
 
     private List<RssFeedItem> fetchRssFeed(TechBlog techBlog) throws Exception {
-        URL url = new URL(techBlog.getRssUrl());
-        HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+        // WebClient로 RSS 피드 다운로드
+        byte[] responseBytes = webClient.get()
+                .uri(techBlog.getRssUrl())
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .block(); // 동기 처리 (Spring Batch에서는 동기 필요)
 
-        try {
-            // User-Agent 설정
-            connection.setRequestProperty("User-Agent", "TechFork-Bot/1.0");
-            connection.setConnectTimeout(10000); // 10초
-            connection.setReadTimeout(10000);    // 10초
+        if (responseBytes == null || responseBytes.length == 0) {
+            throw new Exception("Empty response from RSS feed");
+        }
 
-            // 응답 코드 확인
-            int responseCode = connection.getResponseCode();
-            if (responseCode != HttpURLConnection.HTTP_OK) {
-                throw new Exception("HTTP Error: " + responseCode);
-            }
+        // RSS 파싱
+        try (InputStream inputStream = new ByteArrayInputStream(responseBytes);
+             XmlReader reader = new XmlReader(inputStream)) {
 
-            // RSS 파싱
-            try (InputStream inputStream = connection.getInputStream();
-                 XmlReader reader = new XmlReader(inputStream)) {
+            SyndFeedInput input = new SyndFeedInput();
+            SyndFeed feed = input.build(reader);
 
-                SyndFeedInput input = new SyndFeedInput();
-                SyndFeed feed = input.build(reader);
-
-                return feed.getEntries().stream()
-                        .map(entry -> convertToFeedItem(entry, techBlog))
-                        .collect(Collectors.toList());
-            }
-        } finally {
-            connection.disconnect();
+            return feed.getEntries().stream()
+                    .map(entry -> convertToFeedItem(entry, techBlog))
+                    .toList();
         }
     }
 

--- a/src/main/java/com/techfork/global/config/WebClientConfig.java
+++ b/src/main/java/com/techfork/global/config/WebClientConfig.java
@@ -1,0 +1,49 @@
+package com.techfork.global.config;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import javax.net.ssl.SSLException;
+import java.time.Duration;
+
+
+@Slf4j
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient webClient() {
+        try {
+            // SSL Context 생성 - 모든 인증서 신뢰
+            SslContext sslContext = SslContextBuilder
+                    .forClient()
+                    .trustManager(InsecureTrustManagerFactory.INSTANCE)
+                    .build();
+
+            // HttpClient 설정 (Netty 기반)
+            HttpClient httpClient = HttpClient.create()
+                    .secure(sslContextSpec -> sslContextSpec.sslContext(sslContext))
+                    .responseTimeout(Duration.ofSeconds(10));
+
+            // WebClient 생성
+            WebClient webClient = WebClient.builder()
+                    .clientConnector(new ReactorClientHttpConnector(httpClient))
+                    .defaultHeader("User-Agent", "TechFork-Bot/1.0")
+                    .build();
+
+            log.info("✅ SSL-friendly WebClient 초기화 완료");
+            return webClient;
+
+        } catch (SSLException e) {
+            log.error("❌ WebClient 초기화 실패", e);
+            throw new RuntimeException("WebClient 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/techfork/global/config/WebClientConfig.java
+++ b/src/main/java/com/techfork/global/config/WebClientConfig.java
@@ -30,19 +30,23 @@ public class WebClientConfig {
             // HttpClient 설정 (Netty 기반)
             HttpClient httpClient = HttpClient.create()
                     .secure(sslContextSpec -> sslContextSpec.sslContext(sslContext))
-                    .responseTimeout(Duration.ofSeconds(10));
+                    .responseTimeout(Duration.ofSeconds(30))
+                    .followRedirect(true); // Redirect 자동 추적
 
             // WebClient 생성
             WebClient webClient = WebClient.builder()
                     .clientConnector(new ReactorClientHttpConnector(httpClient))
-                    .defaultHeader("User-Agent", "TechFork-Bot/1.0")
+                    .defaultHeader("User-Agent", "Mozilla/5.0 (compatible; TechFork-Bot/1.0)")
+                    .defaultHeader("Accept", "application/rss+xml, application/xml, application/atom+xml, text/xml, */*")
+                    .codecs(configurer -> configurer
+                            .defaultCodecs()
+                            .maxInMemorySize(10 * 1024 * 1024))
                     .build();
 
-            log.info("✅ SSL-friendly WebClient 초기화 완료");
             return webClient;
 
         } catch (SSLException e) {
-            log.error("❌ WebClient 초기화 실패", e);
+            log.error("WebClient 초기화 실패", e);
             throw new RuntimeException("WebClient 초기화 실패", e);
         }
     }


### PR DESCRIPTION
## ❤️ 기능 설명
우아한형제들의 RSS 피드가 중간 CA 인증 문제로 SSL이 되지 않아 WebClient를 사용하여 해결하였습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1289" height="370" alt="image" src="https://github.com/user-attachments/assets/ede69e07-8ef3-4ad5-83cd-ecd02c923c49" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #79 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
