### PR TITLE
[improve/#74] 게시글 조회 API에 키워드 추가

### DIFF
--- a/src/main/java/com/techfork/domain/post/batch/PostSummaryProcessor.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostSummaryProcessor.java
@@ -1,6 +1,6 @@
 package com.techfork.domain.post.batch;
 
-import com.techfork.domain.post.dto.SummaryWithKeywords;
+import com.techfork.domain.post.dto.SummaryWithKeywordsDto;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.post.service.SummaryExtractionService;
@@ -26,7 +26,7 @@ public class PostSummaryProcessor implements ItemProcessor<Post, Post> {
         try {
             log.debug("요약 및 키워드 추출 중: {}", post.getTitle());
 
-            SummaryWithKeywords result = summaryExtractionService.extractSummary(
+            SummaryWithKeywordsDto result = summaryExtractionService.extractSummary(
                     post.getTitle(),
                     post.getPlainContent()
             );

--- a/src/main/java/com/techfork/domain/post/controller/PostController.java
+++ b/src/main/java/com/techfork/domain/post/controller/PostController.java
@@ -3,7 +3,7 @@ package com.techfork.domain.post.controller;
 import com.techfork.domain.post.dto.CompanyListResponse;
 import com.techfork.domain.post.dto.PostDetailDto;
 import com.techfork.domain.post.dto.PostListResponse;
-import com.techfork.domain.post.dto.PostSortType;
+import com.techfork.domain.post.enums.EPostSortType;
 import com.techfork.domain.post.service.PostQueryService;
 import com.techfork.global.common.code.SuccessCode;
 import com.techfork.global.response.BaseResponse;
@@ -58,7 +58,7 @@ public class PostController {
     @GetMapping("/recent")
     public ResponseEntity<BaseResponse<PostListResponse>> getRecentPosts(
             @Parameter(description = "정렬 기준 (LATEST: 최신순, POPULAR: 인기순, 기본값: LATEST)")
-            @RequestParam(defaultValue = "LATEST") PostSortType sortBy,
+            @RequestParam(defaultValue = "LATEST") EPostSortType sortBy,
             @Parameter(description = "마지막 게시글 ID (커서, 선택)")
             @RequestParam(required = false) Long lastPostId,
             @Parameter(description = "페이지 크기 (기본값: 20)")

--- a/src/main/java/com/techfork/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/techfork/domain/post/converter/PostConverter.java
@@ -1,6 +1,7 @@
 package com.techfork.domain.post.converter;
 
 import com.techfork.domain.post.dto.CompanyListResponse;
+import com.techfork.domain.post.dto.PostDetailDto;
 import com.techfork.domain.post.dto.PostInfoDto;
 import com.techfork.domain.post.dto.PostListResponse;
 import org.springframework.stereotype.Component;
@@ -16,9 +17,9 @@ public class PostConverter {
                 .build();
     }
 
-    public PostListResponse toPostListResponse(List<PostInfoDto> postDtos, int requestedSize) {
-        boolean hasNext = postDtos.size() > requestedSize;
-        List<PostInfoDto> content = hasNext ? postDtos.subList(0, requestedSize) : postDtos;
+    public PostListResponse toPostListResponse(List<PostInfoDto> posts, int requestedSize) {
+        boolean hasNext = posts.size() > requestedSize;
+        List<PostInfoDto> content = hasNext ? posts.subList(0, requestedSize) : posts;
 
         Long lastPostId = content.isEmpty() ? null : content.get(content.size() - 1).id();
 
@@ -26,6 +27,19 @@ public class PostConverter {
                 .posts(content)
                 .lastPostId(lastPostId)
                 .hasNext(hasNext)
+                .build();
+    }
+
+    public PostDetailDto toPostDetailDto(PostDetailDto baseDto, List<String> keywords) {
+        return PostDetailDto.builder()
+                .id(baseDto.id())
+                .title(baseDto.title())
+                .summary(baseDto.summary())
+                .company(baseDto.company())
+                .url(baseDto.url())
+                .logoUrl(baseDto.logoUrl())
+                .publishedAt(baseDto.publishedAt())
+                .keywords(keywords)
                 .build();
     }
 }

--- a/src/main/java/com/techfork/domain/post/dto/PostDetailDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostDetailDto.java
@@ -3,6 +3,7 @@ package com.techfork.domain.post.dto;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record PostDetailDto(
@@ -12,6 +13,7 @@ public record PostDetailDto(
         String company,
         String url,
         String logoUrl,
-        LocalDateTime publishedAt
+        LocalDateTime publishedAt,
+        List<String> keywords
 ) {
 }

--- a/src/main/java/com/techfork/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostInfoDto.java
@@ -3,6 +3,7 @@ package com.techfork.domain.post.dto;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Builder
 public record PostInfoDto(
@@ -11,6 +12,7 @@ public record PostInfoDto(
         String company,
         String url,
         String logoUrl,
-        LocalDateTime publishedAt
+        LocalDateTime publishedAt,
+        List<String> keywords
 ) {
 }

--- a/src/main/java/com/techfork/domain/post/dto/SummaryWithKeywordsDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/SummaryWithKeywordsDto.java
@@ -2,7 +2,7 @@ package com.techfork.domain.post.dto;
 
 import java.util.List;
 
-public record SummaryWithKeywords(
+public record SummaryWithKeywordsDto(
         String summary,
         List<String> keywords
 ) {

--- a/src/main/java/com/techfork/domain/post/enums/EPostSortType.java
+++ b/src/main/java/com/techfork/domain/post/enums/EPostSortType.java
@@ -1,11 +1,11 @@
-package com.techfork.domain.post.dto;
+package com.techfork.domain.post.enums;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum PostSortType {
+public enum EPostSortType {
     LATEST("최신순"),
     POPULAR("인기순");
 

--- a/src/main/java/com/techfork/domain/post/repository/PostKeywordRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostKeywordRepository.java
@@ -3,6 +3,8 @@ package com.techfork.domain.post.repository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.entity.PostKeyword;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,4 +13,7 @@ public interface PostKeywordRepository extends JpaRepository<PostKeyword, Long> 
     List<PostKeyword> findByPost(Post post);
 
     void deleteByPost(Post post);
+
+    @Query("SELECT pk FROM PostKeyword pk WHERE pk.post.id IN :postIds")
+    List<PostKeyword> findByPostIdIn(@Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -36,7 +36,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt)
+            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt, null)
             FROM Post p
             JOIN TechBlog t on p.techBlog.id = t.id
             WHERE (:company IS NULL OR p.company = :company)
@@ -51,10 +51,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt)
+            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt, null)
             FROM Post p
             JOIN TechBlog t on p.techBlog.id = t.id
-            WHERE :lastPostId IS NULL OR p.id < :lastPostId 
+            WHERE :lastPostId IS NULL OR p.id < :lastPostId
             ORDER BY p.publishedAt DESC, p.id DESC
             """)
     List<PostInfoDto> findRecentPostsWithCursor(
@@ -64,7 +64,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt)
+            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt, null)
             FROM Post p
             JOIN TechBlog t on p.techBlog.id = t.id
             WHERE :lastPostId IS NULL OR p.id < :lastPostId
@@ -77,7 +77,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostDetailDto(
-            p.id, p.title, p.summary, t.companyName, p.url, t.logoUrl, p.publishedAt)
+            p.id, p.title, p.summary, t.companyName, p.url, t.logoUrl, p.publishedAt, null)
             FROM Post p
             JOIN TechBlog t on p.techBlog.id = t.id
             WHERE p.id = :id

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -2,7 +2,9 @@ package com.techfork.domain.post.service;
 
 import com.techfork.domain.post.converter.PostConverter;
 import com.techfork.domain.post.dto.*;
+import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.post.enums.EPostSortType;
+import com.techfork.domain.post.repository.PostKeywordRepository;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.global.exception.CommonErrorCode;
 import com.techfork.global.exception.GeneralException;
@@ -13,6 +15,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -21,6 +25,7 @@ import java.util.List;
 public class PostQueryService {
 
     private final PostRepository postRepository;
+    private final PostKeywordRepository postKeywordRepository;
     private final PostConverter postConverter;
 
     public CompanyListResponse getCompanies() {
@@ -30,26 +35,63 @@ public class PostQueryService {
 
     public PostListResponse getPostsByCompany(String company, Long lastPostId, int size) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
-        List<PostInfoDto> postDtos = postRepository.findByCompanyWithCursor(company, lastPostId, pageRequest);
-
-        return postConverter.toPostListResponse(postDtos, size);
+        List<PostInfoDto> posts = postRepository.findByCompanyWithCursor(company, lastPostId, pageRequest);
+        List<PostInfoDto> postsWithKeywords = attachKeywordsToPostInfoList(posts);
+        return postConverter.toPostListResponse(postsWithKeywords, size);
     }
 
     public PostListResponse getRecentPosts(EPostSortType sortBy, Long lastPostId, int size) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
-        List<PostInfoDto> postDtos;
+        List<PostInfoDto> posts;
 
         if (sortBy == EPostSortType.POPULAR) {
-            postDtos = postRepository.findPopularPostsWithCursor(lastPostId, pageRequest);
+            posts = postRepository.findPopularPostsWithCursor(lastPostId, pageRequest);
         } else {
-            postDtos = postRepository.findRecentPostsWithCursor(lastPostId, pageRequest);
+            posts = postRepository.findRecentPostsWithCursor(lastPostId, pageRequest);
         }
 
-        return postConverter.toPostListResponse(postDtos, size);
+        List<PostInfoDto> postsWithKeywords = attachKeywordsToPostInfoList(posts);
+        return postConverter.toPostListResponse(postsWithKeywords, size);
     }
 
     public PostDetailDto getPostDetail(Long postId) {
-        return postRepository.findByIdWithTechBlog(postId)
+        PostDetailDto postDetail = postRepository.findByIdWithTechBlog(postId)
                 .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND));
+
+        List<String> keywords = postKeywordRepository.findByPostIdIn(List.of(postId))
+                .stream()
+                .map(PostKeyword::getKeyword)
+                .toList();
+
+        return postConverter.toPostDetailDto(postDetail, keywords);
+    }
+
+    private List<PostInfoDto> attachKeywordsToPostInfoList(List<PostInfoDto> posts) {
+        if (posts.isEmpty()) {
+            return posts;
+        }
+
+        List<Long> postIds = posts.stream()
+                .map(PostInfoDto::id)
+                .toList();
+
+        Map<Long, List<String>> keywordMap = postKeywordRepository.findByPostIdIn(postIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        pk -> pk.getPost().getId(),
+                        Collectors.mapping(PostKeyword::getKeyword, Collectors.toList())
+                ));
+
+        return posts.stream()
+                .map(post -> PostInfoDto.builder()
+                        .id(post.id())
+                        .title(post.title())
+                        .company(post.company())
+                        .url(post.url())
+                        .logoUrl(post.logoUrl())
+                        .publishedAt(post.publishedAt())
+                        .keywords(keywordMap.getOrDefault(post.id(), List.of()))
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -2,7 +2,7 @@ package com.techfork.domain.post.service;
 
 import com.techfork.domain.post.converter.PostConverter;
 import com.techfork.domain.post.dto.*;
-import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.enums.EPostSortType;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.global.exception.CommonErrorCode;
 import com.techfork.global.exception.GeneralException;
@@ -35,11 +35,11 @@ public class PostQueryService {
         return postConverter.toPostListResponse(postDtos, size);
     }
 
-    public PostListResponse getRecentPosts(PostSortType sortBy, Long lastPostId, int size) {
+    public PostListResponse getRecentPosts(EPostSortType sortBy, Long lastPostId, int size) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
         List<PostInfoDto> postDtos;
 
-        if (sortBy == PostSortType.POPULAR) {
+        if (sortBy == EPostSortType.POPULAR) {
             postDtos = postRepository.findPopularPostsWithCursor(lastPostId, pageRequest);
         } else {
             postDtos = postRepository.findRecentPostsWithCursor(lastPostId, pageRequest);

--- a/src/main/java/com/techfork/domain/post/service/SummaryExtractionService.java
+++ b/src/main/java/com/techfork/domain/post/service/SummaryExtractionService.java
@@ -2,7 +2,7 @@ package com.techfork.domain.post.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.techfork.domain.post.dto.SummaryWithKeywords;
+import com.techfork.domain.post.dto.SummaryWithKeywordsDto;
 import com.techfork.global.llm.LlmClient;
 import com.techfork.global.util.ContentCleaner;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +50,7 @@ public class SummaryExtractionService {
             6. 너무 일반적인 키워드(예: "개발", "코딩") 제외
             """;
 
-    public SummaryWithKeywords extractSummary(String title, String content) {
+    public SummaryWithKeywordsDto extractSummary(String title, String content) {
         try {
             String processedContent = content;
             if (content != null && content.length() > 50000) {
@@ -69,11 +69,11 @@ public class SummaryExtractionService {
 
         } catch (Exception e) {
             log.error("요약 추출 실패 (제목: {}): {}", title, e.getMessage(), e);
-            return new SummaryWithKeywords("", List.of());
+            return new SummaryWithKeywordsDto("", List.of());
         }
     }
 
-    private SummaryWithKeywords parseResponse(String response) {
+    private SummaryWithKeywordsDto parseResponse(String response) {
         try {
             JsonNode jsonNode = objectMapper.readTree(response);
             String summary = jsonNode.get("summary").asText();
@@ -84,10 +84,10 @@ public class SummaryExtractionService {
                 keywordsNode.forEach(node -> keywords.add(node.asText()));
             }
 
-            return new SummaryWithKeywords(summary, keywords);
+            return new SummaryWithKeywordsDto(summary, keywords);
         } catch (Exception e) {
             log.error("JSON 응답 파싱 실패: {}", response, e);
-            return new SummaryWithKeywords("", List.of());
+            return new SummaryWithKeywordsDto("", List.of());
         }
     }
 


### PR DESCRIPTION
## ❤️ 기능 설명
게시글 조회 API에 키워드도 반환하도록 변경했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
최근 게시글 조회
<img width="2133" height="1148" alt="image" src="https://github.com/user-attachments/assets/1ec7b391-8bcf-4216-a7e7-0f0943a11308" />

<br>
기업별 게시글 조회
<img width="2137" height="1134" alt="image" src="https://github.com/user-attachments/assets/90cb070b-8e96-482e-a5f1-8e186eac11c9" />

<br>
게시글 상세 조회
<img width="2148" height="1130" alt="image" src="https://github.com/user-attachments/assets/995ae360-d6c4-46ad-8fb7-178eaafa7c24" />



<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #74 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
