### PR TITLE
[improve/#76] 사용자 프로필 생성 시 게시글을 읽은 시간도 프롬프트로 전달하도록 변경

### DIFF
--- a/src/main/java/com/techfork/domain/activity/repository/ReadPostRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/ReadPostRepository.java
@@ -14,6 +14,12 @@ public interface ReadPostRepository extends JpaRepository<ReadPost, Long> {
 
     boolean existsByUserAndPost(User user, Post post);
 
-    @Query("SELECT rp FROM ReadPost rp JOIN FETCH rp.post WHERE rp.user = :user ORDER BY rp.readAt DESC")
-    List<ReadPost> findRecentReadPostsByUser(@Param("user") User user, Pageable pageable);
+    @Query("""
+            SELECT rp FROM ReadPost rp
+            JOIN FETCH rp.post 
+            WHERE rp.user = :user 
+            AND (rp.readDurationSeconds IS NULL OR rp.readDurationSeconds > 10)
+            ORDER BY rp.readAt DESC
+            """)
+    List<ReadPost> findRecentReadPostsByUserWithMinDuration(@Param("user") User user, Pageable pageable);
 }

--- a/src/main/java/com/techfork/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/techfork/domain/user/service/UserProfileService.java
@@ -48,16 +48,10 @@ public class UserProfileService {
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
-            // 1. 사용자 데이터 수집
             UserActivityData activityData = collectUserActivityData(user);
-
-            // 2. LLM으로 프로필 텍스트 생성
             String profileText = generateProfileTextWithLLM(activityData);
-
-            // 3. 임베딩 벡터 생성
             float[] profileVector = generateEmbeddingVector(profileText);
 
-            // 4. Elasticsearch에 저장
             UserProfileDocument profileDocument = UserProfileDocument.create(
                     userId,
                     profileText,
@@ -74,36 +68,34 @@ public class UserProfileService {
     }
 
     private UserActivityData collectUserActivityData(User user) {
-        // 관심사
         List<UserInterestCategory> categories = userInterestCategoryRepository.findByUserWithKeywords(user);
         List<String> interests = categories.stream()
                 .flatMap(c -> c.getKeywords().stream())
                 .map(k -> k.getKeyword().getDisplayName())
                 .toList();
 
-        // 최근 읽은 포스트 (최대 20개) - 제목 + 키워드
-        List<ReadPost> readPosts = readPostRepository.findRecentReadPostsByUser(user, PageRequest.of(0, 20));
+        List<ReadPost> readPosts = readPostRepository.findRecentReadPostsByUserWithMinDuration(user, PageRequest.of(0, 20));
         List<PostData> readPostData = readPosts.stream()
                 .map(rp -> new PostData(
                         rp.getPost().getTitle(),
                         rp.getPost().getKeywords().stream()
                                 .map(PostKeyword::getKeyword)
-                                .toList()
+                                .toList(),
+                        convertReadingDurationToNaturalLanguage(rp.getReadDurationSeconds())
                 ))
                 .toList();
 
-        // 스크랩한 포스트 (최대 20개) - 제목 + 키워드
         List<ScrabPost> scrapPosts = scrabPostRepository.findRecentScrapPostsByUser(user, PageRequest.of(0, 20));
         List<PostData> scrapPostData = scrapPosts.stream()
                 .map(sp -> new PostData(
                         sp.getPost().getTitle(),
                         sp.getPost().getKeywords().stream()
                                 .map(PostKeyword::getKeyword)
-                                .toList()
+                                .toList(),
+                        null
                 ))
                 .toList();
 
-        // 검색 기록 (최대 30개)
         List<SearchHistory> searchHistories = searchHistoryRepository.findRecentSearchHistoriesByUser(user, PageRequest.of(0, 30));
         List<String> searchWords = searchHistories.stream()
                 .map(SearchHistory::getSearchWord)
@@ -188,13 +180,15 @@ public class UserProfileService {
                     String keywordsStr = postData.keywords.isEmpty()
                             ? ""
                             : " [키워드: " + String.join(", ", postData.keywords) + "]";
-                    return "- " + postData.title + keywordsStr;
+                    String engagementStr = postData.readingEngagement != null
+                            ? " (" + postData.readingEngagement + ")"
+                            : "";
+                    return "- " + postData.title + keywordsStr + engagementStr;
                 })
                 .collect(Collectors.joining("\n"));
     }
 
     private float[] generateEmbeddingVector(String profileText) {
-        // OpenAI text-embedding-3-large (3072 dimensions)
         List<Float> embedding = embeddingClient.embed(profileText);
 
         float[] vector = new float[embedding.size()];
@@ -202,6 +196,24 @@ public class UserProfileService {
             vector[i] = embedding.get(i);
         }
         return vector;
+    }
+
+    private String convertReadingDurationToNaturalLanguage(Integer durationSeconds) {
+        if (durationSeconds == null) {
+            return "읽음";
+        }
+
+        if (durationSeconds <= 30) {
+            return "가볍게 훑어봄";
+        } else if (durationSeconds <= 90) {
+            return "빠르게 읽음";
+        } else if (durationSeconds <= 300) {
+            return "읽음";
+        } else if (durationSeconds <= 600) {
+            return "정독함";
+        } else {
+            return "깊게 읽음";
+        }
     }
 
     private record UserActivityData(
@@ -213,6 +225,7 @@ public class UserProfileService {
 
     private record PostData(
             String title,
-            List<String> keywords
+            List<String> keywords,
+            String readingEngagement
     ) {}
 }


### PR DESCRIPTION
## ❤️ 기능 설명
사용자 프로필 생성 시 읽은 포스트에 읽은 시간도 프롬프트로 추가했습니다.
이때 LLM은 정량적인 시간보다 자연어를 더 잘 받아들이므로 자연어로 변환하였고,
10초 이하로 읽은 게시글은 읽지 않은 것으로 생각하고 조회할 때 필터링 조건을 추가하였습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2877" height="533" alt="image" src="https://github.com/user-attachments/assets/226ac6e3-1e02-457c-ad83-d46832f5a752" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #76 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 회의 때 언급한 LLM에게 프로필 생성하지 않고 그대로 임베딩을 사용하는 것은 현 방식으로 성능 평가후에 적용해보겠습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
