### PR TITLE
feat: Elasticsearch Hybrid Search (BM25 + Vector) 1단계 검색 구현 #82

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
 	//	testImplementation 'org.springframework.security:spring-security-test'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	//	implementation 'org.springframework.ai:spring-ai-advisors-vector-store'
 	//	implementation 'org.springframework.ai:spring-ai-starter-vector-store-elasticsearch'
 

--- a/src/main/java/com/techfork/domain/post/document/PostDocument.java
+++ b/src/main/java/com/techfork/domain/post/document/PostDocument.java
@@ -1,5 +1,11 @@
 package com.techfork.domain.post.document;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.techfork.domain.post.entity.Post;
 import lombok.*;
 import org.springframework.data.annotation.Id;
@@ -15,6 +21,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PostDocument {
 
     @Id
@@ -36,6 +43,7 @@ public class PostDocument {
     private String url;
 
     @Field(type = FieldType.Date)
+    @JsonIgnore
     private LocalDateTime publishedAt;
 
     @Field(type = FieldType.Dense_Vector, dims = 3072)

--- a/src/main/java/com/techfork/domain/search/GeneralSearchProperties.java
+++ b/src/main/java/com/techfork/domain/search/GeneralSearchProperties.java
@@ -1,0 +1,44 @@
+package com.techfork.domain.search;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "search.general")
+public class GeneralSearchProperties {
+
+    /** * 1단계 검색의 최종 결과 개수 (Elasticsearch size).
+     * RRF의 rankWindowSize와 동일하게 설정하는 것이 일반적입니다.
+     */
+    private Integer searchSize = 15;
+
+    /** * BM25 키워드 검색 시 title 필드에 적용되는 가중치 (Boost).
+     * 예: "title^2.0"
+     */
+    private Float titleBoost = 2.0f;
+
+    /** * k-NN 검색 시 반환할 이웃 수 (k).
+     * 이 값은 RRF에 전달되는 BM25 결과의 개수를 제한합니다. (searchSize와 동일하게 설정)
+     */
+    private Integer knnK = 15;
+
+    /** * k-NN 검색 시 탐색할 후보군 수 (num_candidates).
+     * 이 값이 높을수록 정확도가 높아지지만, 성능은 느려집니다.
+     */
+    private Integer knnNumCandidates = 30;
+
+    /** * RRF (Reciprocal Rank Fusion) 랭크 퓨전의 윈도우 크기 (rank_window_size).
+     * BM25 및 k-NN 검색 각각에서 몇 개의 결과를 RRF에 사용할지 결정합니다.
+     */
+//    private Long rrfWindowSize = 100L;
+
+    /** * RRF 상수 K (rank_constant).
+     * 이 값이 높을수록 개별 검색 결과의 원래 랭크 점수보다 최종 점수에 영향을 더 많이 미칩니다.
+     * 일반적으로 60을 사용합니다.
+     */
+//    private Long rrfRankConstant = 60L;
+}

--- a/src/main/java/com/techfork/domain/search/SearchController.java
+++ b/src/main/java/com/techfork/domain/search/SearchController.java
@@ -1,0 +1,32 @@
+package com.techfork.domain.search;
+
+import com.techfork.global.common.code.SuccessCode;
+import com.techfork.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "검색 API", description = "Elasticsearch 기반의 통합 검색 기능을 제공합니다.")
+@RestController
+@RequestMapping("/api/v1/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @Operation(summary = "1단계 검색(BM25 + 시맨틱)", description = "검색어(query)를 기반으로 BM25 + k-NN 하이브리드 검색을 수행하고 합산하여 상위 결과를 반환합니다. (개인화 미적용)")
+    @GetMapping("/general")
+    public BaseResponse<List<SearchResult>> searchGeneral(
+            @RequestParam @Parameter(description = "검색어", required = true) String query
+    ) {
+        List<SearchResult> results = searchService.searchGeneral(query);
+        return BaseResponse.of(SuccessCode.OK, results).getBody();
+    }
+}

--- a/src/main/java/com/techfork/domain/search/SearchServiceImpl.java
+++ b/src/main/java/com/techfork/domain/search/SearchServiceImpl.java
@@ -1,6 +1,13 @@
 package com.techfork.domain.search;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.techfork.domain.post.document.PostDocument;
 import com.techfork.domain.user.entity.User;
+import com.techfork.global.llm.EmbeddingClient;
+import java.io.IOException;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,13 +19,127 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SearchServiceImpl implements SearchService {
 
+    private final ElasticsearchClient elasticsearchClient;
+    private final EmbeddingClient embeddingClient;
+
+    // 하이퍼파라미터
+    private final GeneralSearchProperties generalSearchProperties;
+
     @Override
     public List<SearchResult> searchGeneral(String query) {
-        return List.of();
+        List<Float> queryVector = embeddingClient.embed(query);
+
+        // title - 가중치 부여
+        String titleField = String.format("title^%.1f", generalSearchProperties.getTitleBoost());
+
+        // rrf - es 라이센스 필요로 잠시 보류
+        /*
+        try {
+            SearchResponse<PostDocument> response = elasticsearchClient.search(s -> s
+                            .index("posts")
+                            .size(generalSearchProperties.getSearchSize())
+                            .query(q -> q
+                                    .bool(b -> b
+                                            .should(sh -> sh
+                                                    .multiMatch(m -> m
+                                                            .query(query)
+                                                            .fields(titleField, "summary")
+                                                    )
+                                            )
+                                    )
+                            )
+                            .knn(k -> k
+                                    .field("summaryEmbedding")
+                                    .queryVector(queryVector)
+                                    .k(generalSearchProperties.getKnnK())
+                                    .numCandidates(generalSearchProperties.getKnnNumCandidates())
+                            )
+                            .rank(r -> r
+                                    .rrf(rrf -> rrf
+                                            .rankWindowSize(generalSearchProperties.getRrfWindowSize())
+                                            .rankConstant(generalSearchProperties.getRrfRankConstant())
+                                    )
+                            ),
+                    PostDocument.class
+            );
+
+            // 3. 결과 매핑
+            return response.hits().hits().stream()
+                    .map(this::mapToSearchResult)
+                    .collect(Collectors.toList());
+
+        } catch (IOException e) {
+            log.error("Elasticsearch searchGeneral failed [query={}]", query, e);
+            throw new RuntimeException("Elasticsearch 검색 중 오류가 발생했습니다.", e);
+        }
+        */
+        try {
+            SearchResponse<PostDocument> response = elasticsearchClient.search(s -> s
+                            .index("posts")
+                            .size(generalSearchProperties.getSearchSize())
+                            .query(q -> q
+                                    .bool(b -> b
+                                            .should(sh -> sh
+                                                    .multiMatch(m -> m
+                                                            .query(query)
+                                                            .fields(titleField, "summary")
+                                                    )
+                                            )
+                                            .should(sh -> sh
+                                                    .knn(k -> k
+                                                            .field("summaryEmbedding")
+                                                            .queryVector(queryVector)
+                                                            .k(generalSearchProperties.getKnnK())
+                                                            .numCandidates(generalSearchProperties.getKnnNumCandidates())
+                                                    )
+                                            )
+                                    )
+                            )
+                    ,
+                    PostDocument.class
+            );
+
+            // 3. 결과 매핑
+            return response.hits().hits().stream()
+                    .map(this::mapToSearchResult)
+                    .collect(Collectors.toList());
+
+        } catch (IOException e) {
+            log.error("Elasticsearch searchGeneral failed [query={}]", query, e);
+            throw new RuntimeException("Elasticsearch 검색 중 오류가 발생했습니다.", e);
+        }
     }
 
     @Override
     public List<SearchResult> searchPersonalized(String query, User user) {
         return List.of();
+    }
+
+    /**
+     * Elasticsearch 검색 결과 Hit을 SearchResult DTO로 변환
+     */
+    private SearchResult mapToSearchResult(Hit<PostDocument> hit) {
+        PostDocument doc = hit.source();
+        double score = hit.score() != null ? hit.score() : 0.0;
+
+        float[] vector = null;
+        if (doc != null && doc.getSummaryEmbedding() != null) {
+            List<Float> embedding = doc.getSummaryEmbedding();
+            vector = new float[embedding.size()];
+            for (int i = 0; i < embedding.size(); i++) {
+                vector[i] = embedding.get(i);
+            }
+        }
+
+        return SearchResult.builder()
+                .postId(doc != null ? doc.getPostId() : null)
+                .title(doc != null ? doc.getTitle() : "")
+                .summary(doc != null ? doc.getSummary() : "")
+                .companyName(doc != null ? doc.getCompany() : "")
+                .url(doc != null ? doc.getUrl() : "")
+                .hybridScore(score)
+                .finalScore(score) // 1단계에서는 개인화 점수 없이 hybridScore가 finalScore
+                .documentVector(null)
+                .build();
     }
 }

--- a/src/main/java/com/techfork/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/techfork/global/config/ElasticsearchConfig.java
@@ -1,7 +1,17 @@
 package com.techfork.global.config;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
 


### PR DESCRIPTION
## 기능 설명

로그인하지 않은 사용자나 검색 품질 평가를 위한 1단계 일반 검색 기능 (searchGeneral)을 Elasticsearch 기반의 하이브리드 검색을 통해 구현했습니다. 이 과정에서 Elasticsearch 라이선스 제약 및 Jackson 역직렬화 관련 문제를 해결하고, 검색 품질 조정을 위한 하이퍼파라미터 설정 완료했습니다.

ES 라이센스가 무료인 상태라 RRF로 BM25 결과와 시맨틱 결과를 합하지 않고 임의로 가중치 합 계산하여 구현함.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1088" height="799" alt="스크린샷 2025-11-19 오후 4 11 53" src="https://github.com/user-attachments/assets/4e440914-7fac-41d5-a888-dc3d1098d4d2" />


## 연결된 issue

close #47 

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
