### PR TITLE
[feat/#88] 1차 검색 후보군 기준 2차 리랭커 구현

### DIFF
--- a/src/main/java/com/techfork/domain/post/document/PostDocument.java
+++ b/src/main/java/com/techfork/domain/post/document/PostDocument.java
@@ -2,10 +2,6 @@ package com.techfork.domain.post.document;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.techfork.domain.post.entity.Post;
 import lombok.*;
 import org.springframework.data.annotation.Id;

--- a/src/main/java/com/techfork/domain/search/controller/SearchController.java
+++ b/src/main/java/com/techfork/domain/search/controller/SearchController.java
@@ -23,12 +23,22 @@ public class SearchController {
 
     private final SearchService searchService;
 
-    @Operation(summary = "1단계 검색(BM25 + 시맨틱)", description = "검색어(query)를 기반으로 BM25 + k-NN 하이브리드 검색을 수행하고 합산하여 상위 결과를 반환합니다. (개인화 미적용)")
+    @Operation(summary = "1단계 검색(BM25 + 시맨틱)", description = "검색어를 기반으로 BM25 + k-NN 하이브리드 검색을 수행하고 합산하여 상위 결과를 반환합니다. (개인화 미적용)")
     @GetMapping("/general")
     public BaseResponse<List<SearchResult>> searchGeneral(
             @RequestParam @Parameter(description = "검색어", required = true) String query
     ) {
         List<SearchResult> results = searchService.searchGeneral(query);
         return BaseResponse.of(SuccessCode.OK, results).getBody();
+    }
+
+    @Operation(summary = "2단계 검색(1단계 검색 후보군 추출 -> 순위 조정", description = "검색어를 기반으로 1차 검색(BM25 + k-NN)을 수행한 후보군을 개인화 리랭킹 적용합니다.")
+    @GetMapping("/personalized")
+    public BaseResponse<List<SearchResult>> searchPersonalized(
+            @RequestParam @Parameter(description = "검색어", required = true) String query,
+            @RequestParam @Parameter(description = "사용자 ID", required = true) Long userId
+    ) {
+       List<SearchResult> results = searchService.searchPersonalized(query, userId) ;
+       return BaseResponse.of(SuccessCode.OK, results).getBody();
     }
 }

--- a/src/main/java/com/techfork/domain/search/dto/SearchResult.java
+++ b/src/main/java/com/techfork/domain/search/dto/SearchResult.java
@@ -2,9 +2,10 @@ package com.techfork.domain.search.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
-@Builder
+@Builder(toBuilder = true)
 public class SearchResult {
     private Long postId;
     private String title;
@@ -17,5 +18,6 @@ public class SearchResult {
     private double personalScore;
     private double finalScore;
 
+    @Setter
     private float[] documentVector;
 }

--- a/src/main/java/com/techfork/domain/search/dto/SearchResult.java
+++ b/src/main/java/com/techfork/domain/search/dto/SearchResult.java
@@ -2,7 +2,6 @@ package com.techfork.domain.search.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 @Builder(toBuilder = true)
@@ -18,6 +17,5 @@ public class SearchResult {
     private double personalScore;
     private double finalScore;
 
-    @Setter
     private float[] documentVector;
 }

--- a/src/main/java/com/techfork/domain/search/service/GeneralSearchProperties.java
+++ b/src/main/java/com/techfork/domain/search/service/GeneralSearchProperties.java
@@ -15,32 +15,30 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties(prefix = "search.general")
 public class GeneralSearchProperties {
 
-    /** * 1단계 검색의 최종 결과 개수 (Elasticsearch size).
-     */
+    // 1단계 검색의 최종 결과 개수 (Elasticsearch size).
     private Integer searchSize = 15;
 
-    /** * BM25 키워드 검색 시 title 필드에 적용되는 가중치 (Boost).
-     */
+    // BM25 키워드 검색 시 title 필드에 적용되는 가중치 (Boost).
     private Float titleBoost = 2.0f;
 
-    /** * BM25 키워드 검색 시 summary 필드에 적용되는 가중치 (Boost).
-     */
+    // BM25 키워드 검색 시 summary 필드에 적용되는 가중치 (Boost).
     private Float summaryBoost = 2.0f;
 
-    /** * k-NN 검색 시 반환할 이웃 수 (k).
-     */
+    // k-NN 검색 시 반환할 이웃 수 (k).
     private Integer knnK = 15;
 
-    /** * k-NN 검색 시 탐색할 후보군 수 (num_candidates).
-     */
+    // k-NN 검색 시 탐색할 후보군 수 (num_candidates).
     private Integer knnNumCandidates = 30;
 
-    /** * ContentChunks BM25 쿼리 결과에 적용되는 가중치 (Boost).
-     */
+    // ContentChunks BM25 쿼리 결과에 적용되는 가중치 (Boost).
     private Float chunkBoost = 1.0f;
 
-    /**
-     * k-NN Script Score (벡터 유사도) 결과에 적용되는 가중치 (Weight).
-     */
+    // k-NN Script Score (벡터 유사도) 결과에 적용되는 가중치 (Weight).
     private Float semanticBoost = 5.0f;
+
+    // 2차 리랭킹의 1차 검색 가중치
+    private double hybridScoreWeight = 0.6;
+
+    // 2차 리랭키의 개인화 가중치
+    private double personalScoreWeight = 0.4;
 }

--- a/src/main/java/com/techfork/domain/search/service/SearchService.java
+++ b/src/main/java/com/techfork/domain/search/service/SearchService.java
@@ -1,8 +1,6 @@
 package com.techfork.domain.search.service;
 
 import com.techfork.domain.search.dto.SearchResult;
-import com.techfork.domain.user.entity.User;
-
 import java.util.List;
 
 public interface SearchService {

--- a/src/main/java/com/techfork/domain/search/service/SearchService.java
+++ b/src/main/java/com/techfork/domain/search/service/SearchService.java
@@ -12,9 +12,6 @@ public interface SearchService {
      * - 목적: 검색 품질 평가(Recall) 및 비로그인 사용자 검색
      * - 동작: RRF(BM25 + k-NN) 하이브리드 검색만 수행하여 상위 K개 결과를 반환합니다.
      * - 개인화(Re-ranking) 로직이 적용되지 않은 순수 연관도 순입니다.
-     *
-     * @param query 검색어
-     * @return 1단계 검색 결과 리스트
      */
     List<SearchResult> searchGeneral(String query);
 
@@ -25,10 +22,6 @@ public interface SearchService {
      * 1. 1단계 검색으로 후보군(Top 100) 확보
      * 2. 사용자의 프로필 벡터와 문서 간 유사도 계산 (Cosine Similarity)
      * 3. 1단계 점수와 2단계 점수를 가중합하여 재정렬
-     *
-     * @param query 검색어
-     * @param user  검색을 요청한 사용자 (프로필 벡터 활용용)
-     * @return 개인화된 최종 검색 결과 리스트 (Top 10)
      */
-    List<SearchResult> searchPersonalized(String query, User user);
+    List<SearchResult> searchPersonalized(String query, Long userId);
 }

--- a/src/main/java/com/techfork/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/techfork/domain/search/service/SearchServiceImpl.java
@@ -10,31 +10,90 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.json.JsonData;
 import com.techfork.domain.post.document.PostDocument;
 import com.techfork.domain.search.dto.SearchResult;
+import com.techfork.domain.user.document.UserProfileDocument;
 import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.repository.UserProfileDocumentRepository;
+import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.llm.EmbeddingClient;
 import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class SearchServiceImpl implements SearchService {
 
     private final ElasticsearchClient elasticsearchClient;
     private final EmbeddingClient embeddingClient;
     private final GeneralSearchProperties generalSearchProperties;
+    private final UserProfileDocumentRepository userProfileDocumentRepository;
+    private final UserRepository userRepository;
+
+    private static final class SearchConstants {
+        static final String POSTS_INDEX = "posts";
+        static final String TITLE_FIELD_FORMAT = "title^%.1f";
+        static final String SUMMARY_FIELD_FORMAT = "summary^%.1f";
+        static final String CONTENT_CHUNKS_PATH = "contentChunks";
+        static final String CHUNK_TEXT_FIELD = "contentChunks.chunkText";
+        static final String MINIMUM_SHOULD_MATCH = "0";
+        static final String SCRIPT_SOURCE = "cosineSimilarity(params.query_vector, 'summaryEmbedding') + 1.0";
+        static final String QUERY_VECTOR_PARAM = "query_vector";
+    }
 
     @Override
     public List<SearchResult> searchGeneral(String query) {
-        List<Float> queryVector = embeddingClient.embed(query);
-        String titleField = String.format("title^%.1f", generalSearchProperties.getTitleBoost());
-        String summaryField = String.format("summary^%.1f", generalSearchProperties.getSummaryBoost());
+        log.info("general search started: with query: '{}'", query);
+        List<Float> queryVector = queryEmbedding(query);
+        List<SearchResult> searchResults = performHybridSearch(query, queryVector);
+        return searchResults.stream()
+                .map(result -> result.toBuilder().documentVector(null).build())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<SearchResult> searchPersonalized(String query, Long userId) {
+        log.info("Personalized search started for userId: {} with query: '{}'", userId, query);
+        List<Float> queryVector = queryEmbedding(query);
+        List<SearchResult> initialResults = performHybridSearch(query, queryVector);
+        log.info("Found {} initial results from hybrid search.", initialResults.size());
+
+        User user = userRepository.getReferenceById(userId);
+
+        log.info("Attempting to find user profile for userId: {}", user.getId());
+        Optional<UserProfileDocument> userProfileOpt = userProfileDocumentRepository.findByUserId(user.getId());
+        log.info("Successfully fetched user profile optional. isPresent: {}", userProfileOpt.isPresent());
+
+        if (userProfileOpt.map(UserProfileDocument::getProfileVector).isEmpty()) {
+            log.warn("User profile or vector not found for userId: {}. Returning non-personalized results.", user.getId());
+            return initialResults.stream()
+                    .map(result -> result.toBuilder().documentVector(null).build())
+                    .collect(Collectors.toList());
+        }
+
+        log.info("User profile and vector found. Proceeding to personal reranking.");
+        float[] userProfileVector = userProfileOpt.get().getProfileVector();
+        List<SearchResult> rerankedResults = personalReranking(initialResults, userProfileVector);
+        log.info("Personal reranking complete. Returning {} results.", rerankedResults.size());
+        return rerankedResults;
+    }
+
+    private List<Float> queryEmbedding(String query) {
+        return embeddingClient.embed(query);
+    }
+
+    private List<SearchResult> performHybridSearch(String query, List<Float> queryVector) {
+        String titleField = String.format(SearchConstants.TITLE_FIELD_FORMAT, generalSearchProperties.getTitleBoost());
+        String summaryField = String.format(SearchConstants.SUMMARY_FIELD_FORMAT, generalSearchProperties.getSummaryBoost());
 
         try {
             Query baseQuery = Query.of(q -> q
@@ -47,17 +106,17 @@ public class SearchServiceImpl implements SearchService {
                             )
                             .should(sh -> sh
                                     .nested(n -> n
-                                            .path("contentChunks")
+                                            .path(SearchConstants.CONTENT_CHUNKS_PATH)
                                             .query(nq -> nq
                                                     .match(m -> m
-                                                            .field("contentChunks.chunkText")
+                                                            .field(SearchConstants.CHUNK_TEXT_FIELD)
                                                             .query(query)
                                                     )
                                             )
                                             .boost(generalSearchProperties.getChunkBoost())
                                     )
                             )
-                            .minimumShouldMatch("0")
+                            .minimumShouldMatch(SearchConstants.MINIMUM_SHOULD_MATCH)
                     )
             );
 
@@ -66,9 +125,9 @@ public class SearchServiceImpl implements SearchService {
                     .functions(f -> f
                             .scriptScore(ss -> ss
                                     .script(s -> s
-                                            .source("cosineSimilarity(params.query_vector, 'summaryEmbedding') + 1.0")
+                                            .source(SearchConstants.SCRIPT_SOURCE)
                                             .params(Map.of(
-                                                    "query_vector", JsonData.of(queryVector)
+                                                    SearchConstants.QUERY_VECTOR_PARAM, JsonData.of(queryVector)
                                             ))
                                     )
                             )
@@ -79,7 +138,7 @@ public class SearchServiceImpl implements SearchService {
             );
 
             SearchResponse<PostDocument> response = elasticsearchClient.search(s -> s
-                            .index("posts")
+                            .index(SearchConstants.POSTS_INDEX)
                             .size(generalSearchProperties.getSearchSize())
                             .query(q -> q.functionScore(functionScoreQuery))
                     ,
@@ -87,26 +146,22 @@ public class SearchServiceImpl implements SearchService {
             );
 
             return response.hits().hits().stream()
+                    .filter(hit -> hit.source() != null)
                     .map(this::mapToSearchResult)
                     .collect(Collectors.toList());
 
         } catch (IOException e) {
-            log.error("Elasticsearch searchGeneral failed [query={}]", query, e);
+            log.error("Elasticsearch hybrid search failed [query={}]", query, e);
             throw new RuntimeException("Elasticsearch 검색 중 오류가 발생했습니다.", e);
         }
     }
 
-    @Override
-    public List<SearchResult> searchPersonalized(String query, User user) {
-        return List.of();
-    }
-
     private SearchResult mapToSearchResult(Hit<PostDocument> hit) {
         PostDocument doc = hit.source();
-        double score = hit.score() != null ? hit.score() : 0.0;
+        double score = Objects.requireNonNullElse(hit.score(), 0.0);
 
         float[] vector = null;
-        if (doc != null && doc.getSummaryEmbedding() != null) {
+        if (Objects.requireNonNull(doc).getSummaryEmbedding() != null) {
             List<Float> embedding = doc.getSummaryEmbedding();
             vector = new float[embedding.size()];
             for (int i = 0; i < embedding.size(); i++) {
@@ -115,14 +170,53 @@ public class SearchServiceImpl implements SearchService {
         }
 
         return SearchResult.builder()
-                .postId(doc != null ? doc.getPostId() : null)
-                .title(doc != null ? doc.getTitle() : "")
-                .summary(doc != null ? doc.getSummary() : "")
-                .companyName(doc != null ? doc.getCompany() : "")
-                .url(doc != null ? doc.getUrl() : "")
+                .postId(doc.getPostId())
+                .title(doc.getTitle())
+                .summary(doc.getSummary())
+                .companyName(doc.getCompany())
+                .url(doc.getUrl())
                 .hybridScore(score)
                 .finalScore(score)
-                .documentVector(null)
+                .documentVector(vector)
                 .build();
+    }
+
+    private List<SearchResult> personalReranking(List<SearchResult> initialResults, float[] userProfileVector) {
+        return initialResults.stream()
+                .filter(result -> result.getDocumentVector() != null && result.getDocumentVector().length > 0)
+                .map(result -> {
+                    double personalScore = cosineSimilarity(userProfileVector, result.getDocumentVector());
+                    double finalScore = (result.getHybridScore() * generalSearchProperties.getHybridScoreWeight())
+                            + (personalScore * generalSearchProperties.getPersonalScoreWeight());
+
+                    return result.toBuilder()
+                            .personalScore(personalScore)
+                            .finalScore(finalScore)
+                            .documentVector(null)
+                            .build();
+                })
+                .sorted(Comparator.comparing(SearchResult::getFinalScore).reversed())
+                .collect(Collectors.toList());
+    }
+
+    private double cosineSimilarity(float[] vectorA, float[] vectorB) {
+        if (vectorA == null || vectorB == null || vectorA.length != vectorB.length || vectorA.length == 0) {
+            return 0.0;
+        }
+
+        double dotProduct = 0.0;
+        double normA = 0.0;
+        double normB = 0.0;
+        for (int i = 0; i < vectorA.length; i++) {
+            dotProduct += (double) vectorA[i] * vectorB[i];
+            normA += (double) vectorA[i] * vectorA[i];
+            normB += (double) vectorB[i] * vectorB[i];
+        }
+
+        if (normA == 0.0 || normB == 0.0) {
+            return 0.0;
+        }
+
+        return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));
     }
 }

--- a/src/main/java/com/techfork/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/techfork/domain/search/service/SearchServiceImpl.java
@@ -55,6 +55,7 @@ public class SearchServiceImpl implements SearchService {
         log.info("general search started: with query: '{}'", query);
         List<Float> queryVector = queryEmbedding(query);
         List<SearchResult> searchResults = performHybridSearch(query, queryVector);
+        log.info("Found {} results from hybrid search.", searchResults.size());
         return searchResults.stream()
                 .map(result -> result.toBuilder().documentVector(null).build())
                 .collect(Collectors.toList());

--- a/src/main/java/com/techfork/domain/user/document/UserProfileDocument.java
+++ b/src/main/java/com/techfork/domain/user/document/UserProfileDocument.java
@@ -1,10 +1,13 @@
 package com.techfork.domain.user.document;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Transient;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -15,6 +18,7 @@ import java.util.List;
 @Document(indexName = "user_profiles")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class UserProfileDocument {
 
     @Id
@@ -33,6 +37,7 @@ public class UserProfileDocument {
     private List<String> interests;
 
     @Field(type = FieldType.Date)
+    @Transient
     private LocalDateTime generatedAt;
 
     @Builder

--- a/src/main/java/com/techfork/domain/user/entity/User.java
+++ b/src/main/java/com/techfork/domain/user/entity/User.java
@@ -6,6 +6,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,7 +16,7 @@ import java.util.List;
 @Entity
 @Table(name = "users")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
 public class User extends BaseTimeEntity {
 
     @OneToMany

--- a/src/main/java/com/techfork/domain/user/repository/UserProfileDocumentRepository.java
+++ b/src/main/java/com/techfork/domain/user/repository/UserProfileDocumentRepository.java
@@ -1,7 +1,9 @@
 package com.techfork.domain.user.repository;
 
 import com.techfork.domain.user.document.UserProfileDocument;
+import java.util.Optional;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface UserProfileDocumentRepository extends ElasticsearchRepository<UserProfileDocument, String> {
+    Optional<UserProfileDocument> findByUserId(Long id);
 }

--- a/src/main/java/com/techfork/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/techfork/global/config/ElasticsearchConfig.java
@@ -1,21 +1,15 @@
 package com.techfork.global.config;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.ElasticsearchTransport;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.data.elasticsearch.client.ClientConfiguration;
 import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.config.EnableElasticsearchAuditing;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchCustomConversions;
 
 @Configuration
+@EnableElasticsearchAuditing
 public class ElasticsearchConfig extends ElasticsearchConfiguration {
 
     @Value("${elasticsearch.host:localhost}")

--- a/src/test/java/com/techfork/domain/search/GroundTruthGeneratorTest.java
+++ b/src/test/java/com/techfork/domain/search/GroundTruthGeneratorTest.java
@@ -4,6 +4,8 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.techfork.domain.search.dto.SearchResult;
 import com.techfork.domain.search.service.GeneralSearchProperties;
 import com.techfork.domain.search.service.SearchServiceImpl;
+import com.techfork.domain.user.repository.UserProfileDocumentRepository;
+import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.llm.EmbeddingClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,13 +30,19 @@ class GroundTruthGeneratorTest {
     @Autowired
     private GeneralSearchProperties generalSearchProperties;
 
+    @Autowired
+    private UserProfileDocumentRepository userProfileDocumentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
     @Test
     @DisplayName("실제 DB 데이터를 기반으로 ground-truth.json 템플릿 생성")
     void generateGroundTruthTemplate() {
         List<String> keywords = List.of("스프링", "Java", "Spring Boot", "JPA", "Docker", "MSA", "배치", "클라우드");
 
         SearchServiceImpl searchService = new SearchServiceImpl(
-                elasticsearchClient, embeddingClient, generalSearchProperties
+                elasticsearchClient, embeddingClient, generalSearchProperties, userProfileDocumentRepository, userRepository
         );
 
         System.out.println("========== [Copy Below JSON] ==========");

--- a/src/test/java/com/techfork/domain/search/SearchQualityComparisonTest.java
+++ b/src/test/java/com/techfork/domain/search/SearchQualityComparisonTest.java
@@ -9,6 +9,8 @@ import com.techfork.domain.search.service.SearchService;
 import com.techfork.domain.search.service.SearchServiceImpl;
 import com.techfork.domain.search_quality.GroundTruthItem;
 import com.techfork.domain.search_quality.SearchQualityService;
+import com.techfork.domain.user.repository.UserProfileDocumentRepository;
+import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.llm.EmbeddingClient;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +40,12 @@ class SearchQualityComparisonTest {
     private SearchQualityService searchQualityService;
 
     @Autowired
+    private UserProfileDocumentRepository userProfileDocumentRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     private static final int nDCG_K = 10;
@@ -62,7 +70,7 @@ class SearchQualityComparisonTest {
             List<Double> recallScores = new ArrayList<>();
 
             SearchService currentSearchService = new SearchServiceImpl(
-                    elasticsearchClient, embeddingClient, props
+                    elasticsearchClient, embeddingClient, props, userProfileDocumentRepository, userRepository
             );
 
             for (GroundTruthItem item : groundTruths) {

--- a/src/test/java/com/techfork/domain/search/SearchServiceImplTest.java
+++ b/src/test/java/com/techfork/domain/search/SearchServiceImplTest.java
@@ -4,6 +4,8 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.techfork.domain.search.dto.SearchResult;
 import com.techfork.domain.search.service.GeneralSearchProperties;
 import com.techfork.domain.search.service.SearchServiceImpl;
+import com.techfork.domain.user.repository.UserProfileDocumentRepository;
+import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.llm.EmbeddingClient;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +23,13 @@ class SearchServiceImplTest {
     private ElasticsearchClient elasticsearchClient;
 
     @Autowired
+    private UserProfileDocumentRepository userProfileDocumentRepository;
+
+    @Autowired
     private EmbeddingClient embeddingClient;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Test
     @DisplayName("다양한 하이퍼파라미터 시나리오별 검색 결과 비교 테스트")
@@ -110,7 +118,9 @@ class SearchServiceImplTest {
         SearchServiceImpl searchService = new SearchServiceImpl(
                 elasticsearchClient,
                 embeddingClient,
-                props
+                props,
+                userProfileDocumentRepository,
+                userRepository
         );
 
         try {

--- a/src/test/java/com/techfork/domain/search/UserProfileServiceTest.java
+++ b/src/test/java/com/techfork/domain/search/UserProfileServiceTest.java
@@ -1,0 +1,70 @@
+package com.techfork.domain.search;
+
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.entity.UserInterestCategory;
+import com.techfork.domain.user.enums.EInterestCategory;
+import com.techfork.domain.user.repository.UserInterestCategoryRepository;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.domain.user.service.UserProfileService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.techfork.domain.user.enums.EInterestCategory.*;
+
+@SpringBootTest
+class UserProfileServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserInterestCategoryRepository userInterestCategoryRepository;
+
+    @Autowired
+    private UserProfileService userProfileService;
+
+    @Test
+    @DisplayName("10명의 각기 다른 관심사를 가진 테스트 사용자를 생성하고 프로필 벡터를 생성한다.")
+    @Transactional
+    @Commit
+    void generateTestUserProfiles() {
+        List<List<EInterestCategory>> userInterests = List.of(
+                List.of(IOS, ANDROID, GAME_DEV),
+                List.of(BACKEND, DEVOPS, CLOUD),
+                List.of(FRONTEND, PRODUCT_UX, ARCHITECTURE),
+                List.of(DATA_ENGINEERING, DATA_SCIENCE, DATABASE),
+                List.of(AI_ML, DATA_SCIENCE),
+                List.of(DEVOPS, CLOUD, SECURITY, NETWORKING),
+                List.of(SYSTEMS_OS, EMBEDDED_IOT),
+                List.of(BLOCKCHAIN_WEB3, SECURITY),
+                List.of(QA_TEST, DEVOPS),
+                List.of(AR_VR_XR, GAME_DEV, AI_ML)
+        );
+
+        IntStream.range(0, 10).forEach(i -> {
+            User user = new User();
+
+            userRepository.save(user);
+
+            List<UserInterestCategory> interestCategories = userInterests.get(i).stream()
+                    .map(category -> UserInterestCategory.builder()
+                            .user(user)
+                            .category(category)
+                            .build())
+                    .collect(Collectors.toList());
+            userInterestCategoryRepository.saveAll(interestCategories);
+
+            System.out.println("Generating profile for user: " + user.getId());
+            userProfileService.generateUserProfile(user.getId());
+            System.out.println("Profile generated for user: " + user.getId());
+        });
+    }
+}

--- a/src/test/java/com/techfork/es-check.http
+++ b/src/test/java/com/techfork/es-check.http
@@ -4,6 +4,9 @@ GET http://localhost:9200/
 ### 2. 모든 인덱스(테이블) 목록 확인
 GET http://localhost:9200/_cat/indices?v
 
+###
+GET http://localhost:9200/user_profiles/_search
+
 ### 3. 'posts' 인덱스 데이터 10개 조회
 GET http://localhost:9200/posts/_search
 Content-Type: application/json


### PR DESCRIPTION
## 기능 설명
- 1차 검색 후보군을 기준으로 사용자 벡터를 사용한 개인화 목적의 리랭킹을 구현했습니다.
- 회원가입이 완료된 사용자의 경우 2차 검색 API를 호출하고, 비회원의 경우 1차 검색 API가 호출됩니다.
- 1차 검색과 2차 리랭커에 사용되는 하이퍼파라미터는 모두 GeneralSearchProperties 클래스에서 관리합니다. 2차 리랭커에서는 1차 검색 결과의 가중치와 개인화 가중치가 존재하고 각각 0.6, 0.4로 설정한 상태입니다. 리랭커를 비롯한 검색 기능에 사용되는 모든 하이퍼파라미터는 판단 목록을 사용한 Recall, nDCG 지표를 통해 조정할 예정입니다.
- Elasticsearch 데이터 매핑 과정에서 발생하던 MappingConversionException 이슈 해결을 위해 UserProfileDocument의 generatedAt을 @Transient 처리했습니다.
- 현재는 개인화 목적의 리랭커를 직접 구현한 상태입니다. 필요하다면, cohere reranker와 같은 외부 API 도입을 고려하려 합니다.

### swagger 테스트 성공 결과 스크린샷 첨부
<img width="1074" height="950" alt="스크린샷 2025-11-22 오전 12 46 36" src="https://github.com/user-attachments/assets/c1207d62-caba-4b1f-a873-4839da6a7580" />

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #88 

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
