### PR TITLE
[fix/#106] Elasticsearch 연동 에러 해결 및 속도 개선

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,11 @@ services:
     restart: always
     ports:
       - "6379:6379"
-    command: redis-server --requirepass ${REDIS_PASSWORD}
+    command:
+      redis-server 
+      --requirepass ${REDIS_PASSWORD}
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
     networks:
       - app-network
     volumes:
@@ -45,7 +49,7 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
     networks:
       - app-network
     volumes:

--- a/src/main/java/com/techfork/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/techfork/global/config/ElasticsearchConfig.java
@@ -1,12 +1,5 @@
 package com.techfork.global.config;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
-import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.elasticsearch.config.EnableElasticsearchAuditing;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
@@ -15,19 +8,4 @@ import org.springframework.data.elasticsearch.repository.config.EnableElasticsea
 @EnableElasticsearchAuditing
 @EnableElasticsearchRepositories(basePackages = "com.techfork")
 public class ElasticsearchConfig {
-
-    @Value("${elasticsearch.host:localhost}")
-    private String elasticsearchHost;
-
-    @Value("${elasticsearch.port:9200}")
-    private int elasticsearchPort;
-
-    @Bean
-    public ElasticsearchClient elasticsearchClient() {
-        RestClient restClient = RestClient.builder(
-                new HttpHost(elasticsearchHost, elasticsearchPort, "http")).build();
-        return new ElasticsearchClient(
-                new RestClientTransport(restClient, new JacksonJsonpMapper())
-        );
-    }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -74,13 +74,13 @@ recommendation:
   knn-search-size: 100
   num-candidates: 200
   mmr-final-size: 30
-  lambda: 0.6
+  lambda: 0.3
   active-user-hours: 24
   # 임베딩 가중치 설정 (합계 1.0)
   embedding-weights:
-    title: 0.4      # 제목 중요도 40%
-    summary: 0.4    # 요약 중요도 40%
-    content: 0.2    # 콘텐츠 청크 중요도 20%
+    title: 0.2
+    summary: 0.2
+    content: 0.6
   # 시간 감쇠 가중치 설정
   time-decay:
     days-7: 1.3      # 최근 7일: +30%
@@ -89,8 +89,7 @@ recommendation:
     days-over: 0.4   # 90일 이상: -60%
 
 elasticsearch:
-  host: elasticsearch
-  port: 9200
+  uris: http://elasticsearch:9200
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -66,8 +66,7 @@ scheduler:
   enabled: true
 
 elasticsearch:
-  host: localhost
-  port: 9200
+  uris: http://elasticsearch:9200
 
 webhook:
   enabled: true
@@ -78,13 +77,13 @@ recommendation:
   knn-search-size: 100
   num-candidates: 200
   mmr-final-size: 30
-  lambda: 0.6
+  lambda: 0.3
   active-user-hours: 24
   # 임베딩 가중치 설정 (합계 1.0)
   embedding-weights:
-    title: 0.4      # 제목 중요도 40%
-    summary: 0.4    # 요약 중요도 40%
-    content: 0.2    # 콘텐츠 청크 중요도 20%
+    title: 0.2
+    summary: 0.2
+    content: 0.6
   # 시간 감쇠 가중치 설정
   time-decay:
     days-7: 1.3      # 최근 7일: +30%


### PR DESCRIPTION
## ❤️ 기능 설명
Elasticsearch의 수동 Bean 생성을 제거하여 Spring Boot가 자동으로 생성하도록 변경했습니다.
그리고 docker-compose를 수정하여 ES의 최대 메모리를 2배로 증가시켜 속도 개선을 시도했습니다.
또한, 추천 성능 평가에 따라 최적의 가중치 값을 설정에 적용하였습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #106 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 제발 latency가 개선되기를!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
