### PR TITLE
[fix/#110] Elasticsearch Config 제거

### DIFF
--- a/src/main/java/com/techfork/global/config/ElasticsearchConfig.java
+++ b/src/main/java/com/techfork/global/config/ElasticsearchConfig.java
@@ -1,9 +1,0 @@
-package com.techfork.global.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.elasticsearch.config.EnableElasticsearchAuditing;
-
-@Configuration
-@EnableElasticsearchAuditing
-public class ElasticsearchConfig {
-}


### PR DESCRIPTION
## ❤️ 기능 설명
Elasticsearch Config의 Auditing 어노테이션이 충돌을 일으키고 있습니다.
관련 필드를 사용하지 않으므로 Auditing 어노테이션도 제거하고 설정이 존재하지 않으므로 클래스도 제거합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #110 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
