### PR TITLE
[deploy/#113] 시연용 EC2 인스턴스 업그레이드 및 ES 메모리 확장

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
     networks:
       - app-network
     volumes:

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -31,7 +31,7 @@ variable "db_password" {
 variable "ec2_instance_type" {
   description = "EC2 인스턴스 타입"
   type        = string
-  default     = "t3.small"
+  default     = "t3.medium"
 }
 
 variable "rds_instance_class" {


### PR DESCRIPTION
## ❤️ 기능 설명
ES 성능 부족으로 에러가 발생하므로 EC2 인스턴스를 긴급하게 t3.medium으로 변경하고 ES 메모리를 2기가로 변경합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #113 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
