### PR TITLE
[chore/#122] 통합 테스트 전용 yml 파일 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.6'
+	id 'org.springframework.boot' version '3.5.9'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -35,8 +35,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// Testcontainers for integration tests
-	testImplementation 'org.testcontainers:testcontainers:1.19.3'
+	// Test Containers
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.testcontainers:mysql:1.19.3'
 	testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
 

--- a/src/main/java/com/techfork/global/config/InitialDataConfig.java
+++ b/src/main/java/com/techfork/global/config/InitialDataConfig.java
@@ -7,12 +7,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 import java.util.List;
 
 @Slf4j
 @Configuration
 @RequiredArgsConstructor
+@Profile({"local", "local-tunnel", "dev"})
 public class InitialDataConfig {
 
     private final TechBlogRepository techBlogRepository;

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
@@ -6,16 +6,16 @@ import com.techfork.domain.post.repository.PostKeywordRepository;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.source.repository.TechBlogRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -37,22 +37,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-@Transactional
 @Testcontainers
+@ActiveProfiles("integrationtest")
 class PostControllerIntegrationTest {
 
     @Container
-    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0")
-            .withDatabaseName("testdb")
-            .withUsername("test")
-            .withPassword("test");
-
-    @DynamicPropertySource
-    static void configureProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", mysql::getJdbcUrl);
-        registry.add("spring.datasource.username", mysql::getUsername);
-        registry.add("spring.datasource.password", mysql::getPassword);
-    }
+    @ServiceConnection
+    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
 
     @Autowired
     private MockMvc mockMvc;
@@ -111,6 +102,14 @@ class PostControllerIntegrationTest {
 
         PostKeyword keyword3 = PostKeyword.create("Kotlin", testPost2);
         postKeywordRepository.save(keyword3);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // 테스트 데이터 정리 (외래키 제약조건 순서 고려)
+        postKeywordRepository.deleteAll();
+        postRepository.deleteAll();
+        techBlogRepository.deleteAll();
     }
 
     @Test

--- a/src/test/resources/application-integrationtest.yml
+++ b/src/test/resources/application-integrationtest.yml
@@ -1,0 +1,39 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+  batch:
+    jdbc:
+      initialize-schema: always
+    job:
+      names: ''
+
+  ai:
+    anthropic:
+      api-key: test-dummy-key
+      chat:
+        options:
+          model: claude-3-5-haiku-20241022
+          temperature: 0.3
+          max-tokens: 8192
+    openai:
+      api-key: test-dummy-key
+      timeout: 60
+      chat:
+        options:
+          model: gpt-4o-mini
+          temperature: 0.3
+          max-tokens: 8192
+
+logging:
+  level:
+    com.techfork: DEBUG
+    org.springframework.batch: INFO
+    org.hibernate.SQL: DEBUG
+    org.hibernate.tool.schema: ERROR


### PR DESCRIPTION
## ❤️ 기능 설명

통합 테스트 환경 개선 작업입니다.

### 주요 변경사항

1. **테스트용 application 설정 파일 추가** (`application-integrationtest.yml`)
   - Hibernate DDL 설정 (`ddl-auto: create-drop`)
   - 테스트용 더미 API 키 설정
   - Hibernate 스키마 경고 로그 필터링 (`org.hibernate.tool.schema: ERROR`)

2. **InitialDataConfig 프로파일 제한**
   - `@Profile({"local", "local-tunnel", "dev"})` 추가
   - 테스트 환경에서 초기 데이터 삽입 방지

3. **PostControllerIntegrationTest 개선**
   - `@AfterEach` 메서드 추가로 테스트 간 데이터 정리
   - 테스트 격리 보장 (중복 키 에러 방지)
   - `DynamicProperties`를 통해 수동으로 설정을 주입하는 대신 `ServiceConnection` 어노테이션 활용함.
   - `@Transactional` 어노테이션 제거로 실제 환경과 유사하게 테스트하도록 함.

4. **Spring Boot 버전 업그레이드**
   - 현재 스프링부트 공식 문서에 나온 stable 버전이 3.5.x에서는 3.5.9이므로 3.5.6 -> 3.5.9로 업그레이드.
   - 단순 보안 취약성 문제이므로 다른 의존성은 건들 필요가 없었음.

<br>

## 연결된 issue

close #122
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 통합 테스트가 정상적으로 통과하는지 확인
- [ ] 테스트 실행 시 불필요한 경고 로그가 출력되지 않는지 확인
- [ ] 로컬/개발 환경에서 InitialDataConfig가 정상 작동하는지 확인

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
