### PR TITLE
[chore/#125] 테스트 컨테이너 관리를 TestContainers 대신 Spring Bean으로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,8 +37,10 @@ dependencies {
 
 	// Test Containers
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-	testImplementation 'org.testcontainers:mysql:1.19.3'
-	testImplementation 'org.testcontainers:junit-jupiter:1.19.3'
+	testImplementation 'org.testcontainers:mysql:1.21.4'
+	testImplementation 'org.testcontainers:elasticsearch:1.21.4'
+	testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
+	testImplementation 'com.redis:testcontainers-redis:2.2.4'
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
@@ -6,6 +6,7 @@ import com.techfork.domain.post.repository.PostKeywordRepository;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.source.repository.TechBlogRepository;
+import com.techfork.global.configuration.MySQLTestConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -13,12 +14,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -31,20 +29,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * PostController 통합 테스트
  * - @SpringBootTest: 전체 애플리케이션 컨텍스트 로드
- * - Testcontainers: 실제 MySQL 컨테이너로 통합 테스트
+ * - MySQLTestConfig.class: 실제 MySQL 컨테이너로 통합 테스트
  * - 모든 레이어(Controller, Service, Repository) 통합 테스트
  * - MockMvc로 HTTP 요청/응답 테스트
  */
 @SpringBootTest
 @AutoConfigureMockMvc
-@Testcontainers
+@Import(MySQLTestConfig.class)
 @ActiveProfiles("integrationtest")
 class PostControllerIntegrationTest {
-
-    @Container
-    @ServiceConnection
-    static MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
-
     @Autowired
     private MockMvc mockMvc;
 

--- a/src/test/java/com/techfork/global/configuration/ElasticsearchTestConfig.java
+++ b/src/test/java/com/techfork/global/configuration/ElasticsearchTestConfig.java
@@ -1,0 +1,16 @@
+package com.techfork.global.configuration;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class ElasticsearchTestConfig {
+    @Bean
+    @ServiceConnection
+    ElasticsearchContainer elasticsearchContainer() {
+        return new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.18.0")
+                .withEnv("xpack.security.enabled", "false");
+    }
+}

--- a/src/test/java/com/techfork/global/configuration/MySQLTestConfig.java
+++ b/src/test/java/com/techfork/global/configuration/MySQLTestConfig.java
@@ -1,0 +1,15 @@
+package com.techfork.global.configuration;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MySQLContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class MySQLTestConfig {
+    @Bean
+    @ServiceConnection
+    MySQLContainer<?> mySQLContainer() {
+        return new MySQLContainer<>("mysql:8.0.36");
+    }
+}

--- a/src/test/java/com/techfork/global/configuration/RedisTestConfig.java
+++ b/src/test/java/com/techfork/global/configuration/RedisTestConfig.java
@@ -1,0 +1,17 @@
+package com.techfork.global.configuration;
+
+import com.redis.testcontainers.RedisContainer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.utility.DockerImageName;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class RedisTestConfig {
+
+    @Bean
+    @ServiceConnection
+    RedisContainer redisContainer() {
+        return new RedisContainer(DockerImageName.parse("redis:7.2-alpine"));
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
테스트 환경 개선을 위해 Testcontainers 설정을 Spring Bean 방식으로 리팩토링하고, 의존성을 최신화했습니다.

 ### 주요 변경사항

  1. **Testcontainers Bean 설정 클래스 생성**
     - `MySQLTestConfig`: MySQL 테스트 컨테이너 Bean 설정
     - `ElasticsearchTestConfig`: Elasticsearch 테스트 컨테이너 Bean 설정 (신규 추가)
     - `RedisTestConfig`: Redis 테스트 컨테이너 Bean 설정 (신규 추가)

  2. **의존성 버전 업그레이드**
     - `testcontainers:mysql`: 1.19.3 → 1.21.4
     - `testcontainers:junit-jupiter`: 1.19.3 → 1.21.4
     - `testcontainers:elasticsearch`: 1.21.4 (신규 추가)
     - `com.redis:testcontainers-redis`: 2.2.4 (신규 추가)

  3. **통합 테스트 리팩토링**
     - `PostControllerIntegrationTest`에서 `@Import(MySQLTestConfig.class)` 방식으로 변경
     - `@Testcontainers`, `@Container` 어노테이션 제거
     - Spring Bean 기반의 재사용 가능한 테스트 설정으로 개선

  ### 개선 효과
  - 테스트 컨테이너 설정을 여러 테스트에서 재사용 가능
  - 통합 테스트 환경에서 MySQL, Elasticsearch, Redis 모두 사용 가능
  - Spring Boot의 `@ServiceConnection`을 통한 자동 설정 활용

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #125 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 테스트 컨테이너 띄울 때 Import(클래스명)으로 붙이면 됩니다.
- [ ] 여러 개(Ex. MySQL + Redis) 를 띄워야할경우 Import({클래스명, 클래스명})으로 붙이면 됩니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
