### PR TITLE
[refactor/#123] Post와 TechBlog 엔티티간 logoUrl 반정규화 진행

### DIFF
--- a/src/main/java/com/techfork/domain/post/document/PostDocument.java
+++ b/src/main/java/com/techfork/domain/post/document/PostDocument.java
@@ -39,6 +39,9 @@ public class PostDocument {
     @Field(type = FieldType.Keyword)
     private String url;
 
+    @Field(type = FieldType.Keyword)
+    private String logoUrl;
+
     @Field(type = FieldType.Keyword, name = "publishedAt")
     @JsonProperty("publishedAt")
     @Getter(AccessLevel.NONE)
@@ -76,6 +79,7 @@ public class PostDocument {
                 .summary(post.getSummary())
                 .company(post.getCompany())
                 .url(post.getUrl())
+                .logoUrl(post.getLogoUrl())
                 .publishedAtString(post.getPublishedAt() != null ? post.getPublishedAt().toString() : null)
                 .titleEmbedding(titleEmbedding)
                 .summaryEmbedding(summaryEmbedding)

--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -91,10 +91,6 @@ public class Post extends BaseEntity {
         this.summary = summary;
     }
 
-    public void updateEmbedded() {
-        this.embeddedAt = LocalDateTime.now();
-    }
-
     public void addKeyword(PostKeyword keyword) {
         this.keywords.add(keyword);
     }

--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -34,6 +34,9 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private String company;
 
+    @Column(length = 500)
+    private String logoUrl;
+
     @Column(unique = true, nullable = false, length = 1000)
     private String url;
 
@@ -57,12 +60,13 @@ public class Post extends BaseEntity {
     private List<PostKeyword> keywords = new ArrayList<>();
 
     @Builder
-    private Post(String title, String fullContent, String plainContent, String company, String url,
+    private Post(String title, String fullContent, String plainContent, String company, String logoUrl, String url,
                  LocalDateTime publishedAt, LocalDateTime crawledAt, TechBlog techBlog) {
         this.title = title;
         this.fullContent = fullContent;
         this.plainContent = plainContent;
         this.company = company;
+        this.logoUrl = logoUrl;
         this.url = url;
         this.publishedAt = publishedAt;
         this.crawledAt = crawledAt;
@@ -75,6 +79,7 @@ public class Post extends BaseEntity {
                 .fullContent(item.content())
                 .plainContent(item.plainContent())
                 .company(item.company())
+                .logoUrl(item.logoUrl())
                 .url(item.url())
                 .publishedAt(item.publishedAt())
                 .crawledAt(LocalDateTime.now())

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -36,9 +36,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.publishedAt, p.viewCount, null)
             FROM Post p
-            JOIN TechBlog t on p.techBlog.id = t.id
             WHERE (:company IS NULL OR p.company = :company)
             AND (:lastPostId IS NULL OR p.id < :lastPostId)
             ORDER BY p.id DESC
@@ -51,9 +50,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.publishedAt, p.viewCount, null)
             FROM Post p
-            JOIN TechBlog t on p.techBlog.id = t.id
             WHERE :lastPostId IS NULL OR p.id < :lastPostId
             ORDER BY p.publishedAt DESC, p.id DESC
             """)
@@ -64,9 +62,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, t.companyName, p.url, t.logoUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.publishedAt, p.viewCount, null)
             FROM Post p
-            JOIN TechBlog t on p.techBlog.id = t.id
             WHERE :lastPostId IS NULL OR p.id < :lastPostId
             ORDER BY p.viewCount DESC, p.id DESC
             """)
@@ -77,9 +74,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostDetailDto(
-            p.id, p.title, p.summary, t.companyName, p.url, t.logoUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.summary, p.company, p.url, p.logoUrl, p.publishedAt, p.viewCount, null)
             FROM Post p
-            JOIN TechBlog t on p.techBlog.id = t.id
             WHERE p.id = :id
             """)
     Optional<PostDetailDto> findByIdWithTechBlog(@Param("id") Long id);

--- a/src/main/java/com/techfork/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/techfork/domain/search/service/SearchServiceImpl.java
@@ -311,6 +311,7 @@ public class SearchServiceImpl implements SearchService {
                 .summary(doc.getSummary())
                 .companyName(doc.getCompany())
                 .url(doc.getUrl())
+                .logoUrl(doc.getLogoUrl())
                 .hybridScore(score)
                 .finalScore(score)
                 .titleVector(titleVector)

--- a/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
+++ b/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
@@ -26,7 +26,7 @@ public class PostBatchWriter implements ItemWriter<Post> {
 
     private static final String INSERT_SQL = """
             INSERT INTO posts
-            (title, full_content, plain_content, company, url, published_at, crawled_at, tech_blog_id)
+            (title, full_content, plain_content, company, url, logo_url, published_at, crawled_at, tech_blog_id)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """;
 
@@ -44,9 +44,10 @@ public class PostBatchWriter implements ItemWriter<Post> {
             ps.setString(3, post.getPlainContent());
             ps.setString(4, post.getCompany());
             ps.setString(5, post.getUrl());
-            ps.setTimestamp(6, JdbcBulkInsert.toTimestamp(post.getPublishedAt()));
-            ps.setTimestamp(7, JdbcBulkInsert.toTimestamp(post.getCrawledAt()));
-            ps.setLong(8, post.getTechBlog().getId());
+            ps.setString(6, post.getLogoUrl());
+            ps.setTimestamp(7, JdbcBulkInsert.toTimestamp(post.getPublishedAt()));
+            ps.setTimestamp(8, JdbcBulkInsert.toTimestamp(post.getCrawledAt()));
+            ps.setLong(9, post.getTechBlog().getId());
         });
 
         log.info("{}개 게시글 Bulk Insert 완료", inserted);

--- a/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
+++ b/src/main/java/com/techfork/domain/source/batch/PostBatchWriter.java
@@ -26,8 +26,8 @@ public class PostBatchWriter implements ItemWriter<Post> {
 
     private static final String INSERT_SQL = """
             INSERT INTO posts
-            (title, full_content, plain_content, company, url, logo_url, published_at, crawled_at, tech_blog_id)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            (title, full_content, plain_content, company, url, logo_url, published_at, crawled_at, view_count, tech_blog_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """;
 
     @Override
@@ -47,7 +47,8 @@ public class PostBatchWriter implements ItemWriter<Post> {
             ps.setString(6, post.getLogoUrl());
             ps.setTimestamp(7, JdbcBulkInsert.toTimestamp(post.getPublishedAt()));
             ps.setTimestamp(8, JdbcBulkInsert.toTimestamp(post.getCrawledAt()));
-            ps.setLong(9, post.getTechBlog().getId());
+            ps.setLong(9, 0L);
+            ps.setLong(10, post.getTechBlog().getId());
         });
 
         log.info("{}개 게시글 Bulk Insert 완료", inserted);

--- a/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
+++ b/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
@@ -159,7 +159,6 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
      */
     private LocalDateTime convertToLocalDateTime(Date date) {
         if (date == null) {
-            log.debug("발행일이 없는 RSS 아이템 발견, 현재 시각 사용");
             return LocalDateTime.now();
         }
         return date.toInstant()

--- a/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
+++ b/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
@@ -134,6 +134,7 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
                 .plainContent(plainContent)
                 .publishedAt(publishedAt)
                 .company(techBlog.getCompanyName())
+                .logoUrl(techBlog.getLogoUrl())
                 .techBlogId(techBlog.getId())
                 .tags(tags)
                 .build();

--- a/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
+++ b/src/main/java/com/techfork/domain/source/batch/RssFeedReader.java
@@ -1,6 +1,5 @@
 package com.techfork.domain.source.batch;
 
-import com.rometools.rome.feed.synd.SyndCategory;
 import com.rometools.rome.feed.synd.SyndEntry;
 import com.rometools.rome.feed.synd.SyndFeed;
 import com.rometools.rome.io.SyndFeedInput;
@@ -20,9 +19,9 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.Date;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -124,9 +123,6 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
         // 발행일 변환
         LocalDateTime publishedAt = convertToLocalDateTime(entry.getPublishedDate());
 
-        // 태그 추출
-        String tags = extractTags(entry);
-
         return RssFeedItem.builder()
                 .title(entry.getTitle())
                 .url(entry.getLink())
@@ -136,7 +132,6 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
                 .company(techBlog.getCompanyName())
                 .logoUrl(techBlog.getLogoUrl())
                 .techBlogId(techBlog.getId())
-                .tags(tags)
                 .build();
     }
 
@@ -170,18 +165,5 @@ public class RssFeedReader implements ItemReader<RssFeedItem> {
         return date.toInstant()
                 .atZone(ZoneId.systemDefault())
                 .toLocalDateTime();
-    }
-
-    /**
-     * RSS entry에서 태그 추출
-     */
-    private String extractTags(SyndEntry entry) {
-        if (entry.getCategories() == null || entry.getCategories().isEmpty()) {
-            return "";
-        }
-
-        return entry.getCategories().stream()
-                .map(SyndCategory::getName)
-                .collect(Collectors.joining(","));
     }
 }

--- a/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
+++ b/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
@@ -1,11 +1,6 @@
 package com.techfork.domain.source.config;
 
-import com.techfork.domain.post.batch.PostEmbeddingProcessor;
-import com.techfork.domain.post.batch.PostEmbeddingReader;
-import com.techfork.domain.post.batch.PostEmbeddingWriter;
-import com.techfork.domain.post.batch.PostSummaryProcessor;
-import com.techfork.domain.post.batch.PostSummaryReader;
-import com.techfork.domain.post.batch.PostSummaryWriter;
+import com.techfork.domain.post.batch.*;
 import com.techfork.domain.post.document.PostDocument;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.source.batch.PostBatchWriter;
@@ -22,15 +17,8 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.retry.backoff.FixedBackOffPolicy;
-import org.springframework.retry.policy.SimpleRetryPolicy;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.transaction.PlatformTransactionManager;
-
-import java.net.SocketTimeoutException;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * RSS 크롤링 Job 설정

--- a/src/main/java/com/techfork/domain/source/dto/RssFeedItem.java
+++ b/src/main/java/com/techfork/domain/source/dto/RssFeedItem.java
@@ -13,7 +13,6 @@ public record RssFeedItem(
         String plainContent,
         LocalDateTime publishedAt,
         String company,
-        Long techBlogId,
-        String tags
+        Long techBlogId
 ) {
 }

--- a/src/main/java/com/techfork/domain/source/dto/RssFeedItem.java
+++ b/src/main/java/com/techfork/domain/source/dto/RssFeedItem.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 public record RssFeedItem(
         String title,
         String url,
+        String logoUrl,
         String content,
         String plainContent,
         LocalDateTime publishedAt,


### PR DESCRIPTION
## ❤️ 기능 설명
**TechBlog의 logoUrl을 Post 엔티티로 반정규화**

Post 조회 시 매번 TechBlog를 조인하지 않고 logoUrl을 바로 가져올 수 있도록 성능 개선을 진행했습니다.

### 주요 변경사항

1. **Post 엔티티에 logoUrl 필드 추가**
   - TechBlog의 logoUrl을 Post 테이블로 반정규화
   - `@Column(length = 500)` 추가

2. **RSS 크롤링 로직 수정**
   - `RssFeedItem`에 logoUrl 필드 추가
   - `RssFeedReader`에서 TechBlog의 logoUrl을 포함하여 크롤링
   - `PostBatchWriter`의 JDBC Bulk Insert 쿼리에 view_count, logoUrl 컬럼 추가

3. **Elasticsearch 검색 API 수정**
   - `PostDocument`에 logoUrl 필드 추가
   - `SearchServiceImpl.mapToSearchResult()`에서 logoUrl 매핑 추가
   - 검색 결과 응답에 logoUrl 포함

4. **데이터 마이그레이션 완료**
   - 기존 Post 레코드에 TechBlog의 logoUrl 업데이트 (MySQL)
   - Elasticsearch 인덱스에 logoUrl 필드 추가 및 업데이트

### 성능 개선 효과
- Post 조회 시 N+1 문제 없이 logoUrl을 바로 반환 가능
- 검색 API 응답에 logoUrl이 포함되어 프론트엔드에서 추가 요청 불필요

검색 시 logoUrl 반환 확인
<img width="2063" height="746" alt="image" src="https://github.com/user-attachments/assets/b4b38ac8-d57b-4768-9d89-df1bc41c8be9" />

반정규화
```
EXPLAIN ANALYZE
SELECT id, title, company, url, published_at
FROM posts
ORDER BY id DESC
LIMIT 30;
```

```
-> Limit: 30 row(s)  (cost=155 rows=30) (actual time=0.0745..0.142 rows=30 loops=1)
    -> Index scan on posts using PRIMARY (reverse)  (cost=155 rows=30) (actual time=0.0726..0.137 rows=30 loops=1)
```

<br>
정규화 (조인)

```
EXPLAIN ANALYZE
SELECT p.id, p.title, t.company_name, p.url, t.logo_url, p.published_at
FROM posts p
         JOIN tech_blogs t ON p.tech_blog_id = t.id
ORDER BY p.id DESC
LIMIT 30;
```

```
-> Limit: 30 row(s)  (actual time=2.34..2.34 rows=30 loops=1)
    -> Sort: p.id DESC, limit input to 30 row(s) per chunk  (actual time=2.34..2.34 rows=30 loops=1)
        -> Stream results  (cost=635 rows=602) (actual time=0.0672..2.06 rows=684 loops=1)
            -> Nested loop inner join  (cost=635 rows=602) (actual time=0.0629..1.52 rows=684 loops=1)
                -> Table scan on t  (cost=3.35 rows=31) (actual time=0.0264..0.0407 rows=27 loops=1)
                -> Index lookup on p using FKqirwl88w40kr6wpea76jf53i3 (tech_blog_id=t.id)  (cost=18.5 rows=19.4) (actual time=0.00871..0.0527 rows=25.3 loops=27)
```


<br>

## 연결된 issue

close #123

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
