### PR TITLE
[chore/#127] 네이버 D2 로고 이미지 및 SK C&C url 추가

### DIFF
--- a/src/main/java/com/techfork/domain/source/entity/TechBlog.java
+++ b/src/main/java/com/techfork/domain/source/entity/TechBlog.java
@@ -37,7 +37,7 @@ public class TechBlog extends BaseTimeEntity {
         this.blogUrl = blogUrl;
         this.rssUrl = rssUrl;
 
-        if (this.logoUrl != null) {
+        if (logoUrl != null) {
             this.logoUrl = logoUrl;
         } else {
             this.logoUrl = String.format("https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=%s/&size=40", this.blogUrl);

--- a/src/main/java/com/techfork/global/config/InitialDataConfig.java
+++ b/src/main/java/com/techfork/global/config/InitialDataConfig.java
@@ -35,7 +35,7 @@ public class InitialDataConfig {
                     TechBlog.create("여기어때", "https://techblog.gccompany.co.kr", "https://techblog.gccompany.co.kr/rss", "https://miro.medium.com/v2/resize:fill:128:128/1*rGdUGkMoxT5SfrVKVAqbEw.png"),
                     TechBlog.create("인프랩", "https://tech.inflab.com", "https://tech.inflab.com/rss.xml", null),
 
-                    TechBlog.create("네이버D2", "https://d2.naver.com/home", "https://d2.naver.com/d2.atom", " "),
+                    TechBlog.create("네이버D2", "https://d2.naver.com/home", "https://d2.naver.com/d2.atom", "https://d2.naver.com/favicon.ico"),
                     TechBlog.create("요기요", "https://techblog.yogiyo.co.kr", "https://techblog.yogiyo.co.kr/feed", "https://miro.medium.com/v2/resize:fill:128:128/1*yMAs19hb_LGVSSVcalnkHw.jpeg"),
                     TechBlog.create("올리브영", "https://oliveyoung.tech", "https://oliveyoung.tech/rss.xml", null),
                     TechBlog.create("쏘카", "https://tech.socarcorp.kr/", "https://tech.socarcorp.kr/feed", null),
@@ -46,7 +46,7 @@ public class InitialDataConfig {
                     TechBlog.create("토스", "https://toss.tech", "https://toss.tech/rss.xml", null),
                     TechBlog.create("리디", "https://www.ridicorp.com/story-category/tech-blog/", "https://www.ridicorp.com/story-category/tech-blog/feed/", null),
 
-                    TechBlog.create("SK C&C", "https://engineering-skcc.github.io", "https://engineering-skcc.github.io/feed.xml", " "),
+                    TechBlog.create("SK C&C", "https://engineering-skcc.github.io", "https://engineering-skcc.github.io/feed.xml", "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://skax.co.kr&size=40"),
                     TechBlog.create("카카오엔터프라이즈", "https://tech.kakaoenterprise.com", "https://tech.kakaoenterprise.com/feed", null),
                     TechBlog.create("NHN", "https://meetup.nhncloud.com", "https://meetup.nhncloud.com/rss", null),
                     TechBlog.create("원티드", "https://medium.com/wantedjobs", "https://medium.com/feed/wantedjobs", "https://miro.medium.com/v2/resize:fill:128:128/1*FJkqW-xbLo_-zwoSzR1C6Q.jpeg"),


### PR DESCRIPTION
## ❤️ 기능 설명
### 버그 수정: TechBlog logoUrl 조건문 오류 수정

**문제:**
- `TechBlog` 생성자에서 logoUrl을 파라미터로 받았으나, 조건문에서 `this.logoUrl`을 체크하여 항상 null로 판단되는 버그
- 이로 인해 logoUrl을 명시적으로 전달해도 무시되고 항상 Google Favicon API를 사용하는 문제 발생

**해결:**
- `TechBlog.java:40` - 조건문을 `if (this.logoUrl != null)` → `if (logoUrl != null)`로 수정하여 파라미터 값을 올바르게 체크하도록 수정
- `InitialDataConfig.java` - 네이버D2와 SK C&C의 logoUrl을 빈 문자열(" ")에서 실제 로고 URL로 변경

**변경 파일:**
- `src/main/java/com/techfork/domain/source/entity/TechBlog.java`
- `src/main/java/com/techfork/global/config/InitialDataConfig.java`

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #127 
<br>
<br>


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
