### PR TITLE
[improve/#139] Spring Batch Job Listener 도입으로 생명주기 관리 및 로깅 통합

### DIFF
--- a/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
+++ b/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
@@ -7,6 +7,7 @@ import com.techfork.domain.source.batch.PostBatchWriter;
 import com.techfork.domain.source.batch.RssFeedReader;
 import com.techfork.domain.source.batch.RssToPostProcessor;
 import com.techfork.domain.source.dto.RssFeedItem;
+import com.techfork.domain.source.listener.RssCrawlingJobListener;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
@@ -58,9 +59,12 @@ public class RssCrawlingJobConfig {
     private final PostEmbeddingProcessor postEmbeddingProcessor;
     private final PostEmbeddingWriter postEmbeddingWriter;
 
+    private final RssCrawlingJobListener rssCrawlingJobListener;
+
     @Bean
     public Job rssCrawlingJob() {
         return new JobBuilder("rssCrawlingJob", jobRepository)
+                .listener(rssCrawlingJobListener)
                 .start(fetchAndSaveRssStep())
                 .next(extractSummaryStep())
                 .next(embedAndIndexStep())

--- a/src/main/java/com/techfork/domain/source/controller/BatchController.java
+++ b/src/main/java/com/techfork/domain/source/controller/BatchController.java
@@ -1,48 +1,28 @@
 package com.techfork.domain.source.controller;
 
+import com.techfork.domain.source.service.CrawlingService;
 import com.techfork.global.common.code.SuccessCode;
 import com.techfork.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.batch.core.Job;
-import org.springframework.batch.core.JobParameters;
-import org.springframework.batch.core.JobParametersBuilder;
-import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.time.LocalDateTime;
-
 @Tag(name = "Batch", description = "배치 작업 API")
-@Slf4j
 @RestController
 @RequestMapping("/api/v1/batch")
 @RequiredArgsConstructor
 public class BatchController {
 
-    private final JobLauncher jobLauncher;
-    private final Job rssCrawlingJob;
+    private final CrawlingService crawlingService;
 
     @Operation(summary = "RSS 크롤링 실행", description = "모든 테크 블로그의 RSS를 크롤링하여 DB에 저장합니다.")
     @PostMapping("/crawl-rss")
     public ResponseEntity<BaseResponse<String>> crawlRss() {
-        try {
-            JobParameters jobParameters = new JobParametersBuilder()
-                    .addString("requestTime", LocalDateTime.now().toString())
-                    .toJobParameters();
-
-            jobLauncher.run(rssCrawlingJob, jobParameters);
-
-            log.info("RSS 크롤링 Job 실행 완료");
-            return BaseResponse.of(SuccessCode.OK, "RSS 크롤링이 성공적으로 시작되었습니다.");
-
-        } catch (Exception e) {
-            log.error("RSS 크롤링 Job 실행 실패", e);
-            return BaseResponse.of(SuccessCode.OK, "RSS 크롤링 실행 중 오류 발생: " + e.getMessage());
-        }
+        crawlingService.executeCrawling();
+        return BaseResponse.of(SuccessCode.OK, "RSS 크롤링이 성공적으로 시작되었습니다.");
     }
 }

--- a/src/main/java/com/techfork/domain/source/listener/RssCrawlingJobListener.java
+++ b/src/main/java/com/techfork/domain/source/listener/RssCrawlingJobListener.java
@@ -1,0 +1,95 @@
+package com.techfork.domain.source.listener;
+
+import com.techfork.domain.source.entity.CrawlingHistory;
+import com.techfork.domain.source.repository.CrawlingHistoryRepository;
+import com.techfork.domain.source.service.WebhookNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * RSS 크롤링 Job 실행 리스너
+ * - Job 시작 시: CrawlingHistory 생성 및 시작 로깅
+ * - Job 종료 시: 성공/실패 처리, 통계 로깅, Webhook 알림
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RssCrawlingJobListener implements JobExecutionListener {
+
+    private final CrawlingHistoryRepository crawlingHistoryRepository;
+    private final WebhookNotificationService webhookNotificationService;
+
+    @Override
+    @Transactional
+    public void beforeJob(JobExecution jobExecution) {
+        Long jobExecutionId = jobExecution.getId();
+        log.info("RSS crawling job started: jobExecutionId={}", jobExecutionId);
+
+        CrawlingHistory history = CrawlingHistory.createStarted(jobExecutionId);
+        crawlingHistoryRepository.save(history);
+    }
+
+    @Override
+    @Transactional
+    public void afterJob(JobExecution jobExecution) {
+        Long jobExecutionId = jobExecution.getId();
+        BatchStatus batchStatus = jobExecution.getStatus();
+
+        CrawlingHistory history = crawlingHistoryRepository
+                .findByJobExecutionId(jobExecutionId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "CrawlingHistory not found for jobExecutionId: " + jobExecutionId));
+
+        if (batchStatus == BatchStatus.COMPLETED) {
+            handleJobSuccess(history, jobExecution);
+        } else {
+            handleJobFailure(history, jobExecution, "Job failed with status: " + batchStatus);
+        }
+    }
+
+    /**
+     * Job 성공 처리
+     */
+    private void handleJobSuccess(CrawlingHistory history, JobExecution jobExecution) {
+        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
+
+        int readCount = (int) stepExecution.getReadCount();
+        int writeCount = (int) stepExecution.getWriteCount();
+        int skipCount = (int) stepExecution.getSkipCount();
+
+        history.complete(readCount, writeCount, skipCount);
+        crawlingHistoryRepository.save(history);
+
+        log.info("RSS crawling completed successfully: " +
+                        "total={}, success={}, failed={}",
+                readCount, writeCount, skipCount);
+    }
+
+    /**
+     * Job 실패 처리
+     */
+    private void handleJobFailure(CrawlingHistory history, JobExecution jobExecution, String errorMessage) {
+        history.fail(errorMessage);
+        crawlingHistoryRepository.save(history);
+
+        log.error("RSS crawling failed: {}", errorMessage);
+
+        // 실패 알림 전송
+        Map<String, Object> context = new HashMap<>();
+        context.put("errorMessage", errorMessage);
+        context.put("timestamp", LocalDateTime.now());
+        context.put("jobExecutionId", jobExecution.getId());
+
+        webhookNotificationService.sendCrawlingFailureNotification(context);
+    }
+}

--- a/src/main/java/com/techfork/domain/source/repository/CrawlingHistoryRepository.java
+++ b/src/main/java/com/techfork/domain/source/repository/CrawlingHistoryRepository.java
@@ -13,4 +13,6 @@ import java.util.Optional;
 public interface CrawlingHistoryRepository extends JpaRepository<CrawlingHistory, Long> {
 
     List<CrawlingHistory> findByStatusAndStartedAtBefore(ECrawlingStatus status, LocalDateTime dateTime);
+
+    Optional<CrawlingHistory> findByJobExecutionId(Long jobExecutionId);
 }

--- a/src/main/java/com/techfork/domain/source/service/CrawlingService.java
+++ b/src/main/java/com/techfork/domain/source/service/CrawlingService.java
@@ -1,7 +1,5 @@
 package com.techfork.domain.source.service;
 
-import com.techfork.domain.source.entity.CrawlingHistory;
-import com.techfork.domain.source.repository.CrawlingHistoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.*;
@@ -10,14 +8,11 @@ import org.springframework.batch.core.repository.JobExecutionAlreadyRunningExcep
 import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
 import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * RSS 크롤링 실행 서비스
+ * - Job 실행만 담당
+ * - Job 라이프사이클 이벤트(시작/종료)는 RssCrawlingJobListener에서 처리
  */
 @Slf4j
 @Service
@@ -26,115 +21,26 @@ public class CrawlingService {
 
     private final JobLauncher jobLauncher;
     private final Job rssCrawlingJob;
-    private final CrawlingHistoryRepository crawlingHistoryRepository;
-    private final WebhookNotificationService webhookNotificationService;
 
     public void executeCrawling() {
-        log.info("Starting RSS crawling job");
-
-        CrawlingHistory history = null;
-        JobExecution jobExecution = null;
-
         try {
             // Job 파라미터 생성 (매번 다른 파라미터로 실행)
             JobParameters jobParameters = new JobParametersBuilder()
                     .addLong("timestamp", System.currentTimeMillis())
                     .toJobParameters();
 
-            jobExecution = jobLauncher.run(rssCrawlingJob, jobParameters);
-            Long jobExecutionId = jobExecution.getId();
-
-            history = CrawlingHistory.createStarted(jobExecutionId);
-            crawlingHistoryRepository.save(history);
-
-            log.info("RSS crawling job started: jobExecutionId={}", jobExecutionId);
-
-            // Job 실행 완료 대기 및 결과 처리
-            waitForJobCompletion(jobExecution, history);
+            jobLauncher.run(rssCrawlingJob, jobParameters);
 
         } catch (JobExecutionAlreadyRunningException e) {
             log.warn("Job is already running", e);
-            if (history != null) {
-                history.fail("Job is already running");
-                crawlingHistoryRepository.save(history);
-            }
         } catch (JobRestartException e) {
             log.error("Job restart failed", e);
-            handleJobFailure(history, jobExecution, "Job restart failed: " + e.getMessage());
         } catch (JobInstanceAlreadyCompleteException e) {
             log.error("Job instance already complete", e);
-            handleJobFailure(history, jobExecution, "Job instance already complete: " + e.getMessage());
         } catch (JobParametersInvalidException e) {
             log.error("Invalid job parameters", e);
-            handleJobFailure(history, jobExecution, "Invalid job parameters: " + e.getMessage());
         } catch (Exception e) {
             log.error("Unexpected error during crawling", e);
-            handleJobFailure(history, jobExecution, "Unexpected error: " + e.getMessage());
         }
-    }
-
-    private void waitForJobCompletion(JobExecution jobExecution, CrawlingHistory history) {
-        BatchStatus batchStatus = jobExecution.getStatus();
-
-        while (batchStatus.isRunning()) {
-            try {
-                Thread.sleep(1000);
-                batchStatus = jobExecution.getStatus();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                log.error("Job execution monitoring interrupted", e);
-                break;
-            }
-        }
-
-        // Job 실행 결과 처리
-        if (batchStatus == BatchStatus.COMPLETED) {
-            handleJobSuccess(history, jobExecution);
-        } else {
-            handleJobFailure(history, jobExecution,
-                    "Job failed with status: " + batchStatus);
-        }
-    }
-
-    /**
-     * Job 성공 처리
-     */
-    @Transactional
-    public void handleJobSuccess(CrawlingHistory history, JobExecution jobExecution) {
-        StepExecution stepExecution = jobExecution.getStepExecutions().iterator().next();
-
-        int readCount = (int) stepExecution.getReadCount();
-        int writeCount = (int) stepExecution.getWriteCount();
-        int skipCount = (int) stepExecution.getSkipCount();
-
-        history.complete(readCount, writeCount, skipCount);
-        crawlingHistoryRepository.save(history);
-
-        log.info("RSS crawling completed successfully: " +
-                        "total={}, success={}, failed={}",
-                readCount, writeCount, skipCount);
-    }
-
-    /**
-     * Job 실패 처리
-     */
-    @Transactional
-    public void handleJobFailure(CrawlingHistory history, JobExecution jobExecution, String errorMessage) {
-        if (history != null) {
-            history.fail(errorMessage);
-            crawlingHistoryRepository.save(history);
-        }
-
-        log.error("RSS crawling failed: {}", errorMessage);
-
-        // 실패 알림 전송
-        Map<String, Object> context = new HashMap<>();
-        context.put("errorMessage", errorMessage);
-        context.put("timestamp", LocalDateTime.now());
-        if (jobExecution != null) {
-            context.put("jobExecutionId", jobExecution.getId());
-        }
-
-        webhookNotificationService.sendCrawlingFailureNotification(context);
     }
 }


### PR DESCRIPTION
 ## ❤️ 기능 설명
RSS 크롤링 로깅을 JobExecutionListener로 통합하여 관심사 분리 및 코드 간결화

### 주요 변경 사항

**1. RssCrawlingJobListener 생성**
- Spring Batch의 표준 패턴인 JobExecutionListener 구현
- beforeJob: CrawlingHistory 생성 및 시작 로깅
- afterJob: 성공/실패 처리, 통계 로깅, Webhook 알림

**2. CrawlingService 단순화**
- waitForJobCompletion() 폴링 로직 제거
- handleJobSuccess(), handleJobFailure() 메서드 제거 (Listener로 이동)
- Job 실행만 담당하도록 단순화 (143줄 → 46줄)

**3. BatchController 정리**
- CrawlingService 사용으로 통일
- 불필요한 로깅 제거 (JobExecutionListener가 담당)
- Controller는 순수하게 API 요청만 처리

**4. Repository 메서드 추가**
- CrawlingHistoryRepository에 findByJobExecutionId() 추가

### 개선 효과
- ✅ 관심사 분리: Scheduler(스케줄링+락) / Service(실행) / Listener(로깅+History+알림)
- ✅ Spring Batch 표준 패턴 준수
- ✅ 코드 간결화 및 유지보수성 향상
- ✅ 폴링 로직 제거로 성능 개선

swagger 테스트 성공 결과 스크린샷 첨부
<img width="2124" height="628" alt="image" src="https://github.com/user-attachments/assets/bbda7bd0-1124-4c87-9282-d39531af9660" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #139 
<br>
<br>


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
