### PR TITLE
[improve/#147] Resilience4j 설정 최적화 및 Rate Limiter 분리

### DIFF
--- a/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
+++ b/src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java
@@ -169,9 +169,9 @@ public class RssCrawlingJobConfig {
     @Bean
     public TaskExecutor embeddingTaskExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(3);
-        executor.setMaxPoolSize(5);
-        executor.setQueueCapacity(20);
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(50);
         executor.setThreadNamePrefix("embedding-");
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(60);

--- a/src/main/java/com/techfork/global/llm/exception/LlmException.java
+++ b/src/main/java/com/techfork/global/llm/exception/LlmException.java
@@ -1,0 +1,16 @@
+package com.techfork.global.llm.exception;
+
+/**
+ * LLM API 호출 중 발생하는 일반 예외
+ * 서킷 브레이커에 카운트되어 실패율에 영향을 줌
+ */
+public class LlmException extends RuntimeException {
+
+    public LlmException(String message) {
+        super(message);
+    }
+
+    public LlmException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/techfork/global/llm/exception/LlmNetworkException.java
+++ b/src/main/java/com/techfork/global/llm/exception/LlmNetworkException.java
@@ -1,0 +1,17 @@
+package com.techfork.global.llm.exception;
+
+/**
+ * LLM API 네트워크 연결 예외
+ * Timeout, Connection Refused 등 네트워크 문제 발생 시
+ * 서킷 브레이커에서 무시되지만 재시도는 수행됨
+ */
+public class LlmNetworkException extends RuntimeException {
+
+    public LlmNetworkException(String message) {
+        super(message);
+    }
+
+    public LlmNetworkException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/techfork/global/llm/exception/LlmRateLimitException.java
+++ b/src/main/java/com/techfork/global/llm/exception/LlmRateLimitException.java
@@ -1,0 +1,17 @@
+package com.techfork.global.llm.exception;
+
+/**
+ * LLM API Rate Limit 초과 예외
+ * 429 Too Many Requests 응답 시 발생
+ * 서킷 브레이커에서 무시되어 서킷이 열리지 않음
+ */
+public class LlmRateLimitException extends RuntimeException {
+
+    public LlmRateLimitException(String message) {
+        super(message);
+    }
+
+    public LlmRateLimitException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/techfork/global/llm/impl/AnthropicLlmClient.java
+++ b/src/main/java/com/techfork/global/llm/impl/AnthropicLlmClient.java
@@ -34,7 +34,7 @@ public class AnthropicLlmClient implements LlmClient {
     @Override
     @Retry(name = "llmApi")
     @CircuitBreaker(name = "llmApi")
-    @RateLimiter(name = "llmApi")
+    @RateLimiter(name = "llmSummary")
     public String call(String systemPrompt, String userPrompt) {
         try {
             Prompt prompt = new Prompt(List.of(

--- a/src/main/java/com/techfork/global/llm/impl/AnthropicLlmClient.java
+++ b/src/main/java/com/techfork/global/llm/impl/AnthropicLlmClient.java
@@ -1,6 +1,9 @@
 package com.techfork.global.llm.impl;
 
 import com.techfork.global.llm.LlmClient;
+import com.techfork.global.llm.exception.LlmException;
+import com.techfork.global.llm.exception.LlmNetworkException;
+import com.techfork.global.llm.exception.LlmRateLimitException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.github.resilience4j.retry.annotation.Retry;
@@ -10,7 +13,10 @@ import org.springframework.ai.anthropic.AnthropicChatModel;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.util.List;
 
@@ -30,10 +36,25 @@ public class AnthropicLlmClient implements LlmClient {
     @CircuitBreaker(name = "llmApi")
     @RateLimiter(name = "llmApi")
     public String call(String systemPrompt, String userPrompt) {
-        Prompt prompt = new Prompt(List.of(
-                new SystemMessage(systemPrompt),
-                new UserMessage(userPrompt)
-        ));
-        return chatModel.call(prompt).getResult().getOutput().getText();
+        try {
+            Prompt prompt = new Prompt(List.of(
+                    new SystemMessage(systemPrompt),
+                    new UserMessage(userPrompt)
+            ));
+            return chatModel.call(prompt).getResult().getOutput().getText();
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                log.warn("Anthropic API Rate Limit exceeded: {}", e.getMessage());
+                throw new LlmRateLimitException("Anthropic API rate limit exceeded", e);
+            }
+            log.error("Anthropic API client error: {}", e.getMessage());
+            throw new LlmException("Anthropic API client error: " + e.getStatusCode(), e);
+        } catch (ResourceAccessException e) {
+            log.warn("Anthropic API network error: {}", e.getMessage());
+            throw new LlmNetworkException("Anthropic API network error", e);
+        } catch (Exception e) {
+            log.error("Anthropic API unexpected error: {}", e.getMessage(), e);
+            throw new LlmException("Anthropic API unexpected error", e);
+        }
     }
 }

--- a/src/main/java/com/techfork/global/llm/impl/OpenAiEmbeddingClient.java
+++ b/src/main/java/com/techfork/global/llm/impl/OpenAiEmbeddingClient.java
@@ -32,12 +32,10 @@ public class OpenAiEmbeddingClient implements EmbeddingClient {
 
     private final OpenAiEmbeddingModel embeddingModel;
 
-    private static final int EMBEDDING_DIMENSIONS = 3072;
-
     @Override
     @Retry(name = "llmApi")
     @CircuitBreaker(name = "llmApi")
-    @RateLimiter(name = "llmApi")
+    @RateLimiter(name = "llmEmbedding")
     public List<Float> embed(String text) {
         if (text == null || text.isBlank()) {
             throw new IllegalArgumentException("텍스트가 비어있습니다");
@@ -73,7 +71,7 @@ public class OpenAiEmbeddingClient implements EmbeddingClient {
     @Override
     @Retry(name = "llmApi")
     @CircuitBreaker(name = "llmApi")
-    @RateLimiter(name = "llmApi")
+    @RateLimiter(name = "llmEmbedding")  // Embedding 생성용 Rate Limiter (28 req/min)
     public List<List<Float>> embedBatch(List<String> texts) {
         if (texts == null || texts.isEmpty()) {
             throw new IllegalArgumentException("텍스트 리스트가 비어있습니다");

--- a/src/main/java/com/techfork/global/llm/impl/OpenAiEmbeddingClient.java
+++ b/src/main/java/com/techfork/global/llm/impl/OpenAiEmbeddingClient.java
@@ -1,6 +1,9 @@
 package com.techfork.global.llm.impl;
 
 import com.techfork.global.llm.EmbeddingClient;
+import com.techfork.global.llm.exception.LlmException;
+import com.techfork.global.llm.exception.LlmNetworkException;
+import com.techfork.global.llm.exception.LlmRateLimitException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.github.resilience4j.retry.annotation.Retry;
@@ -9,7 +12,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.ai.openai.OpenAiEmbeddingModel;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,14 +43,31 @@ public class OpenAiEmbeddingClient implements EmbeddingClient {
             throw new IllegalArgumentException("텍스트가 비어있습니다");
         }
 
-        EmbeddingResponse response = embeddingModel.embedForResponse(List.of(text));
+        try {
+            EmbeddingResponse response = embeddingModel.embedForResponse(List.of(text));
 
-        if (response.getResults().isEmpty()) {
-            throw new RuntimeException("임베딩 응답이 비어있습니다");
+            if (response.getResults().isEmpty()) {
+                throw new RuntimeException("임베딩 응답이 비어있습니다");
+            }
+
+            float[] embedding = response.getResults().get(0).getOutput();
+            return convertToFloatList(embedding);
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                log.warn("OpenAI Embedding API Rate Limit exceeded: {}", e.getMessage());
+                throw new LlmRateLimitException("OpenAI Embedding API rate limit exceeded", e);
+            }
+            log.error("OpenAI Embedding API client error: {}", e.getMessage());
+            throw new LlmException("OpenAI Embedding API client error: " + e.getStatusCode(), e);
+        } catch (ResourceAccessException e) {
+            log.warn("OpenAI Embedding API network error: {}", e.getMessage());
+            throw new LlmNetworkException("OpenAI Embedding API network error", e);
+        } catch (IllegalArgumentException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("OpenAI Embedding API unexpected error: {}", e.getMessage(), e);
+            throw new LlmException("OpenAI Embedding API unexpected error", e);
         }
-
-        float[] embedding = response.getResults().get(0).getOutput();
-        return convertToFloatList(embedding);
     }
 
     @Override
@@ -56,15 +79,37 @@ public class OpenAiEmbeddingClient implements EmbeddingClient {
             throw new IllegalArgumentException("텍스트 리스트가 비어있습니다");
         }
 
-        EmbeddingResponse response = embeddingModel.embedForResponse(texts);
+        try {
+            EmbeddingResponse response = embeddingModel.embedForResponse(texts);
 
-        List<List<Float>> embeddings = new ArrayList<>();
-        for (var result : response.getResults()) {
-            float[] embedding = result.getOutput();
-            embeddings.add(convertToFloatList(embedding));
+            List<List<Float>> embeddings = new ArrayList<>();
+            for (var result : response.getResults()) {
+                float[] embedding = result.getOutput();
+                embeddings.add(convertToFloatList(embedding));
+            }
+
+            return embeddings;
+        } catch (HttpClientErrorException e) {
+            // 429 Too Many Requests: Rate Limit 예외로 변환 (서킷 브레이커에서 무시됨)
+            if (e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                log.warn("OpenAI Embedding API Rate Limit exceeded (batch): {}", e.getMessage());
+                throw new LlmRateLimitException("OpenAI Embedding API rate limit exceeded", e);
+            }
+            // 기타 4xx 에러는 일반 LLM 예외로 변환
+            log.error("OpenAI Embedding API client error (batch): {}", e.getMessage());
+            throw new LlmException("OpenAI Embedding API client error: " + e.getStatusCode(), e);
+        } catch (ResourceAccessException e) {
+            // 네트워크 에러: 타임아웃, 연결 실패 등 (서킷 브레이커에서 무시되지만 재시도됨)
+            log.warn("OpenAI Embedding API network error (batch): {}", e.getMessage());
+            throw new LlmNetworkException("OpenAI Embedding API network error", e);
+        } catch (IllegalArgumentException e) {
+            // validation 예외는 그대로 전파
+            throw e;
+        } catch (Exception e) {
+            // 기타 모든 예외는 일반 LLM 예외로 변환
+            log.error("OpenAI Embedding API unexpected error (batch): {}", e.getMessage(), e);
+            throw new LlmException("OpenAI Embedding API unexpected error", e);
         }
-
-        return embeddings;
     }
 
     /**

--- a/src/main/java/com/techfork/global/llm/impl/OpenAiLlmClient.java
+++ b/src/main/java/com/techfork/global/llm/impl/OpenAiLlmClient.java
@@ -36,7 +36,7 @@ public class OpenAiLlmClient implements LlmClient {
     @Override
     @Retry(name = "llmApi")
     @CircuitBreaker(name = "llmApi")
-    @RateLimiter(name = "llmApi")
+    @RateLimiter(name = "llmSummary")
     public String call(String systemPrompt, String userPrompt) {
         try {
             Prompt prompt = new Prompt(List.of(

--- a/src/main/java/com/techfork/global/llm/impl/OpenAiLlmClient.java
+++ b/src/main/java/com/techfork/global/llm/impl/OpenAiLlmClient.java
@@ -1,6 +1,9 @@
 package com.techfork.global.llm.impl;
 
 import com.techfork.global.llm.LlmClient;
+import com.techfork.global.llm.exception.LlmException;
+import com.techfork.global.llm.exception.LlmNetworkException;
+import com.techfork.global.llm.exception.LlmRateLimitException;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.github.resilience4j.retry.annotation.Retry;
@@ -11,7 +14,10 @@ import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.prompt.Prompt;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.context.annotation.Primary;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
 
 import java.util.List;
 
@@ -32,10 +38,25 @@ public class OpenAiLlmClient implements LlmClient {
     @CircuitBreaker(name = "llmApi")
     @RateLimiter(name = "llmApi")
     public String call(String systemPrompt, String userPrompt) {
-        Prompt prompt = new Prompt(List.of(
-                new SystemMessage(systemPrompt),
-                new UserMessage(userPrompt)
-        ));
-        return chatModel.call(prompt).getResult().getOutput().getText();
+        try {
+            Prompt prompt = new Prompt(List.of(
+                    new SystemMessage(systemPrompt),
+                    new UserMessage(userPrompt)
+            ));
+            return chatModel.call(prompt).getResult().getOutput().getText();
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+                log.warn("OpenAI API Rate Limit exceeded: {}", e.getMessage());
+                throw new LlmRateLimitException("OpenAI API rate limit exceeded", e);
+            }
+            log.error("OpenAI API client error: {}", e.getMessage());
+            throw new LlmException("OpenAI API client error: " + e.getStatusCode(), e);
+        } catch (ResourceAccessException e) {
+            log.warn("OpenAI API network error: {}", e.getMessage());
+            throw new LlmNetworkException("OpenAI API network error", e);
+        } catch (Exception e) {
+            log.error("OpenAI API unexpected error: {}", e.getMessage(), e);
+            throw new LlmException("OpenAI API unexpected error", e);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,10 +17,10 @@ resilience4j:
         permitted-number-of-calls-in-half-open-state: 3
         automatic-transition-from-open-to-half-open-enabled: true
         record-exceptions:
-          - java.net.ConnectException
-          - java.net.SocketTimeoutException
-          - java.io.IOException
-          - org.springframework.web.client.ResourceAccessException
+          - com.techfork.global.llm.exception.LlmException
+        ignore-exceptions:
+          - com.techfork.global.llm.exception.LlmNetworkException
+          - com.techfork.global.llm.exception.LlmRateLimitException
 
   ratelimiter:
     configs:
@@ -38,10 +38,8 @@ resilience4j:
         exponential-backoff-multiplier: 2
         exponential-max-wait-duration: 10s
         retry-exceptions:
-          - java.net.ConnectException
-          - java.net.SocketTimeoutException
-          - java.io.IOException
-          - org.springframework.web.client.ResourceAccessException
+          - com.techfork.global.llm.exception.LlmNetworkException
+          - com.techfork.global.llm.exception.LlmRateLimitException
 
 ---
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,9 +25,26 @@ resilience4j:
   ratelimiter:
     configs:
       default:
-        limit-for-period: 15
+        limit-for-period: 37
         limit-refresh-period: 1m
         timeout-duration: 10s
+    instances:
+      llmSummary:
+        base-config: default
+        # OpenAI gpt-4o-mini: 500 RPM, 200k TPM
+        # Summary: 평균 4350 tokens/req → ~46 req/min
+        # 안전 마진 20% 적용: 37 req/min
+        limit-for-period: 37
+        limit-refresh-period: 1m
+        timeout-duration: 15s
+      llmEmbedding:
+        base-config: default
+        # OpenAI text-embedding-3-large: 3k RPM, 1M TPM
+        # 계산: 1,000,000 / 1350 ≈ 740 req/min
+        # 안전 마진 20% 적용: 590 req/min
+        limit-for-period: 590
+        limit-refresh-period: 1m
+        timeout-duration: 5s
 
   retry:
     configs:

--- a/src/test/java/com/techfork/es-check.http
+++ b/src/test/java/com/techfork/es-check.http
@@ -28,6 +28,9 @@ Content-Type: application/json
   }
 }
 
+### 5. 게시글 전체 인덱싱 삭제
+DELETE http://localhost:9200/posts
+
 ### 일반 검색 테스트
 GET http://localhost:8080/api/v1/search/general?query=spring
 Content-Type: application/json


### PR DESCRIPTION
## ❤️ 기능 설명

외부 LLM API 호출의 안정성과 처리 성능을 대폭 개선하기 위해 Resilience4j 설정을 최적화하고, 각 API의 실제 제한에 맞춰 Rate Limiter를 분리했습니다.

### 주요 변경사항

#### 1. Circuit Breaker 예외 처리 개선 (f138de3)
**파일**: `src/main/java/com/techfork/global/llm/exception/*`, `application.yml`

- **문제**: 일시적인 네트워크 오류나 Rate Limit 초과 시에도 Circuit이 열려 정상 요청까지 차단
- **해결**:
  - 커스텀 예외 계층 도입 (`LlmException`, `LlmNetworkException`, `LlmRateLimitException`)
  - Circuit Breaker는 `LlmException`만 기록, 네트워크/Rate Limit 예외는 무시
  - Retry는 네트워크/Rate Limit 예외만 재시도

**Before**:
```yaml
record-exceptions:
  - java.net.ConnectException
  - java.net.SocketTimeoutException
  # 일시적 문제로도 Circuit 열림
```

**After**:
```yaml
record-exceptions:
  - com.techfork.global.llm.exception.LlmException
ignore-exceptions:
  - com.techfork.global.llm.exception.LlmNetworkException
  - com.techfork.global.llm.exception.LlmRateLimitException
# 일시적 문제는 Circuit 영향 없음
```

#### 2. Rate Limiter 분리 (5c0bd38)
파일: src/main/java/com/techfork/global/llm/impl/*, application.yml

- 문제: gpt-4o-mini(500 RPM)와 text-embedding-3-large(3k RPM)가 동일한 15 req/min 제한 사용
- 해결:
  - llmSummary: 37 req/min (gpt-4o-mini용, 안전 마진 20%)
  - llmEmbedding: 590 req/min (text-embedding-3-large용, 안전 마진 20%)

| API                    | 실제 제한             | 이론값          | 설정값 (80%)   | 기존 대비 |
|------------------------|-------------------|--------------|-------------|-------|
| gpt-4o-mini            | 500 RPM, 200k TPM | ~46 req/min  | 37 req/min  | 2.5배  |
| text-embedding-3-large | 3k RPM, 1M TPM    | ~740 req/min | 590 req/min | 39배   |

3. TaskExecutor 확장 (34020d7)

파일: src/main/java/com/techfork/domain/source/config/RssCrawlingJobConfig.java:172

- Embedding Rate Limit 증가에 따라 스레드 풀 확장:
  - CorePoolSize: 3 → 10 (3.3배)
  - MaxPoolSize: 5 → 20 (4배)
  - QueueCapacity: 20 → 50 (2.5배)

성능 개선 효과

100개 게시글 처리 시나리오:
- 기존: 15 req/min 제한 → 약 13.3분 소요
- 개선:
  - Summary: 37 req/min → 약 2.7분
  - Embedding: 590 req/min → 약 10초
  - 총 약 3분 소요 (77% 단축)

안정성 향상:
- 일시적 네트워크 장애 시 Circuit 열리지 않음
- Rate Limit 초과 시 재시도로 처리 (Circuit 영향 없음)
- 실제 API 오류만 Circuit 상태에 영향
## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #147 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
