### PR TITLE
[refactor/#153] 엔티티 생성 성능 최적화를 위한 @PersistenceCreator 적용

### DIFF
--- a/src/main/java/com/techfork/domain/activity/entity/ReadPost.java
+++ b/src/main/java/com/techfork/domain/activity/entity/ReadPost.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.LocalDateTime;
 
@@ -35,8 +36,9 @@ public class ReadPost extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @PersistenceCreator
     @Builder
-    private ReadPost(User user, Post post, LocalDateTime readAt, Integer readDurationSeconds) {
+    ReadPost(User user, Post post, LocalDateTime readAt, Integer readDurationSeconds) {
         this.user = user;
         this.post = post;
         this.readAt = readAt;

--- a/src/main/java/com/techfork/domain/activity/entity/ScrabPost.java
+++ b/src/main/java/com/techfork/domain/activity/entity/ScrabPost.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.LocalDateTime;
 
@@ -32,8 +33,9 @@ public class ScrabPost extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @PersistenceCreator
     @Builder
-    private ScrabPost(User user, Post post, LocalDateTime scrappedAt) {
+    ScrabPost(User user, Post post, LocalDateTime scrappedAt) {
         this.user = user;
         this.post = post;
         this.scrappedAt = scrappedAt;

--- a/src/main/java/com/techfork/domain/activity/entity/SearchHistory.java
+++ b/src/main/java/com/techfork/domain/activity/entity/SearchHistory.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.LocalDateTime;
 
@@ -25,8 +26,9 @@ public class SearchHistory extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @PersistenceCreator
     @Builder
-    private SearchHistory(User user, String searchWord, LocalDateTime searchedAt) {
+    SearchHistory(User user, String searchWord, LocalDateTime searchedAt) {
         this.user = user;
         this.searchWord = searchWord;
         this.searchedAt = searchedAt;

--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.BatchSize;
+import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -61,9 +62,10 @@ public class Post extends BaseEntity {
     @BatchSize(size = 100)
     private List<PostKeyword> keywords = new ArrayList<>();
 
+    @PersistenceCreator
     @Builder
-    private Post(String title, String fullContent, String plainContent, String company, String logoUrl, String url,
-                 LocalDateTime publishedAt, LocalDateTime crawledAt, TechBlog techBlog) {
+    Post(String title, String fullContent, String plainContent, String company, String logoUrl, String url,
+                 LocalDateTime publishedAt, LocalDateTime crawledAt, LocalDateTime embeddedAt, TechBlog techBlog) {
         this.title = title;
         this.fullContent = fullContent;
         this.plainContent = plainContent;
@@ -72,6 +74,7 @@ public class Post extends BaseEntity {
         this.url = url;
         this.publishedAt = publishedAt;
         this.crawledAt = crawledAt;
+        this.embeddedAt = embeddedAt;
         this.techBlog = techBlog;
     }
 

--- a/src/main/java/com/techfork/domain/post/entity/PostKeyword.java
+++ b/src/main/java/com/techfork/domain/post/entity/PostKeyword.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 @Entity
 @Table(name = "post_keywords")
@@ -20,8 +21,9 @@ public class PostKeyword extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @PersistenceCreator
     @Builder
-    private PostKeyword(String keyword, Post post) {
+    PostKeyword(String keyword, Post post) {
         this.keyword = keyword;
         this.post = post;
     }

--- a/src/main/java/com/techfork/domain/recommendation/entity/RecommendationHistory.java
+++ b/src/main/java/com/techfork/domain/recommendation/entity/RecommendationHistory.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.LocalDateTime;
 
@@ -52,8 +53,9 @@ public class RecommendationHistory extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @PersistenceCreator
     @Builder
-    private RecommendationHistory(User user, Post post, Double similarityScore,
+    RecommendationHistory(User user, Post post, Double similarityScore,
                                    Double mmrScore, Integer rankOrder, LocalDateTime recommendedAt) {
         this.user = user;
         this.post = post;

--- a/src/main/java/com/techfork/domain/recommendation/entity/RecommendedPost.java
+++ b/src/main/java/com/techfork/domain/recommendation/entity/RecommendedPost.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.LocalDateTime;
 
@@ -45,8 +46,9 @@ public class RecommendedPost extends BaseEntity {
     @JoinColumn(name = "post_id", nullable = false)
     private Post post;
 
+    @PersistenceCreator
     @Builder
-    private RecommendedPost(User user, Post post, Double similarityScore,
+    RecommendedPost(User user, Post post, Double similarityScore,
                            Double mmrScore, Integer rankOrder, LocalDateTime recommendedAt) {
         this.user = user;
         this.post = post;

--- a/src/main/java/com/techfork/domain/source/entity/TechBlog.java
+++ b/src/main/java/com/techfork/domain/source/entity/TechBlog.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 import java.time.LocalDateTime;
 
@@ -31,11 +32,14 @@ public class TechBlog extends BaseTimeEntity {
 
     private LocalDateTime lastCrawledAt;
 
+    @PersistenceCreator
     @Builder
-    private TechBlog(String companyName, String blogUrl, String rssUrl, String logoUrl) {
+    TechBlog(String companyName, String blogUrl, String rssUrl,
+                     String logoUrl, LocalDateTime lastCrawledAt) {
         this.companyName = companyName;
         this.blogUrl = blogUrl;
         this.rssUrl = rssUrl;
+        this.lastCrawledAt = lastCrawledAt;
 
         if (logoUrl != null) {
             this.logoUrl = logoUrl;

--- a/src/main/java/com/techfork/domain/user/entity/User.java
+++ b/src/main/java/com/techfork/domain/user/entity/User.java
@@ -29,7 +29,7 @@ public class User extends BaseTimeEntity {
 
     @PersistenceCreator
     @Builder
-    private User(String nickName, String email, String description) {
+    User(String nickName, String email, String description) {
         this.nickName = nickName;
         this.email = email;
         this.description = description;

--- a/src/main/java/com/techfork/domain/user/entity/UserInterestCategory.java
+++ b/src/main/java/com/techfork/domain/user/entity/UserInterestCategory.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +29,9 @@ public class UserInterestCategory extends BaseEntity {
     @OneToMany(mappedBy = "userInterestCategory", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserInterestKeyword> keywords = new ArrayList<>();
 
+    @PersistenceCreator
     @Builder
-    private UserInterestCategory(User user, EInterestCategory category) {
+    UserInterestCategory(User user, EInterestCategory category) {
         this.user = user;
         this.category = category;
     }

--- a/src/main/java/com/techfork/domain/user/entity/UserInterestKeyword.java
+++ b/src/main/java/com/techfork/domain/user/entity/UserInterestKeyword.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.PersistenceCreator;
 
 @Entity
 @Table(name = "user_interest_keywords")
@@ -22,8 +23,9 @@ public class UserInterestKeyword extends BaseEntity {
     @Column(nullable = false, length = 50)
     private EInterestKeyword keyword;
 
+    @PersistenceCreator
     @Builder
-    private UserInterestKeyword(UserInterestCategory userInterestCategory, EInterestKeyword keyword) {
+    UserInterestKeyword(UserInterestCategory userInterestCategory, EInterestKeyword keyword) {
         this.userInterestCategory = userInterestCategory;
         this.keyword = keyword;
     }


### PR DESCRIPTION
## ❤️ 기능 설명
현재 생성자가 전체 파라미터를 받지 않고있었고, 접근제어자가 `private`이었습니다.
이는 객체지향적인 관점에서 설계한 것이었지만 스프링 공식문서를 읽어보니 이는 리플렉션을 초래해 성능상 단점이 있습니다.

이를 전체 파라미터를 받도록 개선하고, 접근제어자를 `package-private`로 바꾸고
`PersistenceCreator` 어노테이션을 통해 이 생성자로 객체 생성을 매핑하였습니다.

문서상으로 이는 JPA의 엔티티 생성 성능을 약 30% 향상시키는 방법입니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #153 

## 🩷 Approve 하기 전 확인해주세요!

- [ ] https://docs.spring.io/spring-data/jpa/reference/data-commons/3.5/object-mapping.html
- [ ] 위의 공식문서를 참고했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
