### PR TITLE
[improve/#167] 리프레시 토큰 검증 실패 시 세션 무효화 로직 추가 및 통합 테스트 구현

### DIFF
--- a/src/main/java/com/techfork/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/techfork/domain/auth/exception/AuthErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthErrorCode implements BaseCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_INVALID_REFRESH", "유효하지 않은 리프레시 토큰입니다."),
     REFRESH_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "AUTH401_REFRESH_MISSING", "리프레시 토큰이 제공되지 않았습니다."),
     REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH401_REFRESH_NOT_FOUND", "저장된 리프레시 토큰을 찾을 수 없습니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_REFRESH_MISMATCH", "리프레시 토큰이 일치하지 않습니다. 세션이 무효화되었습니다."),
     TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH400_TYPE_MISMATCH", "토큰 타입이 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH404_USER", "사용자를 찾을 수 없습니다.");
 

--- a/src/main/java/com/techfork/domain/auth/service/AuthService.java
+++ b/src/main/java/com/techfork/domain/auth/service/AuthService.java
@@ -76,7 +76,9 @@ public class AuthService {
 
     private void validateRefreshTokenInRedis(Long userId, String refreshToken) {
         if (!refreshTokenService.validateRefreshToken(userId, refreshToken)) {
-            throw new GeneralException(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+            refreshTokenService.deleteRefreshToken(userId);
+            log.warn("Refresh token mismatch detected for userId: {}. Session invalidated.", userId);
+            throw new GeneralException(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
         }
     }
 

--- a/src/test/java/com/techfork/domain/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/auth/controller/AuthControllerIntegrationTest.java
@@ -1,0 +1,197 @@
+package com.techfork.domain.auth.controller;
+
+import com.techfork.domain.auth.exception.AuthErrorCode;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.Role;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.configuration.MySQLTestConfig;
+import com.techfork.global.configuration.RedisTestConfig;
+import com.techfork.global.security.auth.service.RefreshTokenService;
+import com.techfork.global.security.jwt.JwtDTO;
+import com.techfork.global.security.jwt.JwtProperties;
+import com.techfork.global.security.jwt.JwtUtil;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * AuthController 통합 테스트
+ * - @SpringBootTest: 전체 애플리케이션 컨텍스트 로드
+ * - MySQLTestConfig, RedisTestConfig: 실제 MySQL, Redis 컨테이너로 통합 테스트
+ * - 모든 레이어(Controller, Service, Repository) 통합 테스트
+ * - MockMvc로 HTTP 요청/응답 테스트
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@Import({MySQLTestConfig.class, RedisTestConfig.class})
+@ActiveProfiles("integrationtest")
+class AuthControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @Autowired
+    private RefreshTokenService refreshTokenService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private User testUser;
+    private String validRefreshToken;
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자 생성
+        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com");
+        testUser = userRepository.save(testUser);
+        userId = testUser.getId();
+
+        // 리프레시 토큰 생성 및 Redis에 저장
+        JwtDTO tokens = jwtUtil.generateTokens(userId, Role.USER);
+        validRefreshToken = tokens.refreshToken();
+        long expiration = jwtProperties.getRefreshTokenExpiration();
+        refreshTokenService.saveRefreshToken(userId, validRefreshToken, expiration);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Redis 데이터 정리
+        redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
+        // DB 데이터 정리
+        userRepository.deleteAll();
+    }
+
+    // ===== 토큰 갱신 성공 테스트 =====
+
+    @Test
+    @DisplayName("토큰 갱신 성공 - 유효한 리프레시 토큰으로 새 액세스 토큰 발급")
+    void refreshToken_Success() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("refreshToken", validRefreshToken)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.accessToken").exists());
+    }
+
+    // ===== 토큰 불일치 시 세션 무효화 테스트 =====
+
+    @Test
+    @DisplayName("토큰 갱신 실패 - Redis 토큰과 불일치하여 세션 무효화")
+    void refreshToken_Fail_TokenMismatchAndSessionInvalidated() throws Exception {
+        // Given: Redis에 다른 토큰 저장 (토큰 불일치 상황 시뮬레이션)
+        String differentToken = "different.refresh.token";
+        JwtDTO differentTokens = jwtUtil.generateTokens(userId, Role.USER);
+        String requestToken = differentTokens.refreshToken();
+
+        refreshTokenService.saveRefreshToken(userId, differentToken, jwtProperties.getRefreshTokenExpiration());
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("refreshToken", requestToken)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.REFRESH_TOKEN_MISMATCH.getReason().code()))
+                .andExpect(jsonPath("$.message").value(AuthErrorCode.REFRESH_TOKEN_MISMATCH.getReason().message()));
+
+        // 세션이 무효화되었는지 검증 (Redis에서 토큰 삭제되었는지 확인)
+        boolean isTokenValid = refreshTokenService.validateRefreshToken(userId, differentToken);
+        assertThat(isTokenValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 실패 - Redis에 토큰이 없는 경우도 세션 무효화 처리")
+    void refreshToken_Fail_NoTokenInRedis() throws Exception {
+        // Given: Redis에서 토큰 삭제 (토큰 없는 상황 시뮬레이션)
+        refreshTokenService.deleteRefreshToken(userId);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("refreshToken", validRefreshToken)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.REFRESH_TOKEN_MISMATCH.getReason().code()));
+    }
+
+    // ===== 기타 실패 케이스 =====
+
+    @Test
+    @DisplayName("토큰 갱신 실패 - 리프레시 토큰이 없음")
+    void refreshToken_Fail_TokenMissing() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/refresh"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.REFRESH_TOKEN_MISSING.getReason().code()));
+    }
+
+    @Test
+    @DisplayName("토큰 갱신 실패 - 유효하지 않은 토큰 형식")
+    void refreshToken_Fail_InvalidTokenFormat() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/refresh")
+                        .cookie(new Cookie("refreshToken", "invalid.token.format")))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.INVALID_REFRESH_TOKEN.getReason().code()));
+    }
+
+    // ===== 로그아웃 테스트 =====
+
+    @Test
+    @DisplayName("로그아웃 성공 - Redis 토큰 삭제 및 쿠키 제거")
+    void logout_Success() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .cookie(new Cookie("refreshToken", validRefreshToken)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // Redis에서 토큰이 삭제되었는지 검증
+        boolean isTokenValid = refreshTokenService.validateRefreshToken(userId, validRefreshToken);
+        assertThat(isTokenValid).isFalse();
+    }
+
+    @Test
+    @DisplayName("로그아웃 실패 - 리프레시 토큰이 없음")
+    void logout_Fail_TokenMissing() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/logout"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.REFRESH_TOKEN_MISSING.getReason().code()));
+    }
+}

--- a/src/test/java/com/techfork/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/techfork/domain/auth/service/AuthServiceTest.java
@@ -131,8 +131,8 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("토큰 갱신 실패 - Redis에 토큰 없음")
-    void refreshToken_Fail_TokenNotFoundInRedis() {
+    @DisplayName("토큰 갱신 실패 - Redis에 저장된 토큰과 불일치하여 세션 무효화")
+    void refreshToken_Fail_TokenMismatchAndSessionInvalidated() {
         // Given
         given(jwtUtil.validateToken(validRefreshToken)).willReturn(true);
         given(jwtUtil.getUserIdFromToken(validRefreshToken)).willReturn(userId);
@@ -142,7 +142,10 @@ class AuthServiceTest {
         assertThatThrownBy(() -> authService.refreshToken(validRefreshToken, response))
                 .isInstanceOf(GeneralException.class)
                 .extracting(ex -> ((GeneralException) ex).getCode())
-                .isEqualTo(AuthErrorCode.REFRESH_TOKEN_NOT_FOUND);
+                .isEqualTo(AuthErrorCode.REFRESH_TOKEN_MISMATCH);
+
+        // 세션 무효화를 위해 Redis 토큰 삭제가 호출되었는지 검증
+        verify(refreshTokenService).deleteRefreshToken(userId);
     }
 
     @Test


### PR DESCRIPTION
## ❤️ 기능 설명
### 리프레시 토큰 검증 실패 시 세션 무효화 로직 추가

리프레시 토큰 재발급 시 Redis 저장 토큰과 요청 토큰이 일치하지 않을 경우, 보안 위협으로 간주하고 자동으로 세션을 무효화합니다.

#### 주요 변경 사항
1. **AuthErrorCode 추가**: `REFRESH_TOKEN_MISMATCH` 에러 코드 추가
   - 토큰 불일치 상황을 명확히 구분
   - 사용자에게 세션 무효화 사실 안내

2. **AuthService 개선**: `validateRefreshTokenInRedis()` 메서드 수정
   - 토큰 불일치 감지 시 Redis에서 토큰 삭제
   - 경고 로그 기록으로 보안 모니터링 강화
   - 새로운 에러 코드로 응답

#### 보안 개선 효과
- 토큰 탈취 시나리오에서 자동 세션 무효화
- 중복 로그인 시도 시 기존 세션 즉시 차단
- 비정상적인 토큰 사용 패턴 로그 추적 가능

### auth 도메인 통합 테스트 구현
기존에 리프레시 토큰 갱신 및 로그아웃 API에 통합 테스트가 구현되어 있지 않아 이를 구현했습니다.


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #167 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
