### PR TITLE
[fix/#176] 유저 리포지토리 테스트에서 포스트를 만들 때 System.currentTimeMills()로 인한 중복 url 문제 해결

### DIFF
--- a/src/test/java/com/techfork/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/user/repository/UserRepositoryTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -250,7 +251,7 @@ class UserRepositoryTest {
                 .fullContent("내용")
                 .plainContent("내용")
                 .company("테스트 회사")
-                .url("https://test.com/post/" + System.currentTimeMillis())
+                .url("https://test.com/post/" + UUID.randomUUID())
                 .publishedAt(LocalDateTime.now())
                 .crawledAt(LocalDateTime.now())
                 .techBlog(testTechBlog)


### PR DESCRIPTION
## ❤️ 기능 설명
단위 테스트에서 Post 엔티티의 url에 unique 속성이
System.currentMils() 함수를 통해 보장하려고 할 경우 같은 시간에 생성되어 제대로 구현되지 않았습니다.
 
이를 UUID 사용으로 UNIQUE 속성을 보장합니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #176 
<br>
<br>
