### PR TITLE
[improve/#182] 테크블로그 크롤링 소스 다양화 (27개 -> 41개)

### DIFF
--- a/src/main/java/com/techfork/domain/source/entity/TechBlog.java
+++ b/src/main/java/com/techfork/domain/source/entity/TechBlog.java
@@ -44,7 +44,7 @@ public class TechBlog extends BaseTimeEntity {
         if (logoUrl != null) {
             this.logoUrl = logoUrl;
         } else {
-            this.logoUrl = String.format("https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=%s/&size=40", this.blogUrl);
+            this.logoUrl = String.format("https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=%s/&size=128", this.blogUrl);
         }
     }
 

--- a/src/main/java/com/techfork/global/config/InitialDataConfig.java
+++ b/src/main/java/com/techfork/global/config/InitialDataConfig.java
@@ -30,7 +30,7 @@ public class InitialDataConfig {
             log.info("TechBlog 초기 데이터 삽입 시작...");
 
             List<TechBlog> techBlogs = List.of(
-                    TechBlog.create("무신사", "https://medium.com/musinsa-tech", "https://medium.com/feed/musinsa-tech", "https://miro.medium.com/v2/resize:fill:160:160/1*Qs-0adxK8doDYyzZXMXkmg.png"),
+                    TechBlog.create("무신사", "https://medium.com/musinsa-tech", "https://medium.com/feed/musinsa-tech", "https://miro.medium.com/v2/resize:fill:128:128/1*Qs-0adxK8doDYyzZXMXkmg.png"),
                     TechBlog.create("HYPERCONNECT", "https://hyperconnect.github.io", "https://hyperconnect.github.io/feed.xml", null),
                     TechBlog.create("여기어때", "https://techblog.gccompany.co.kr", "https://techblog.gccompany.co.kr/rss", "https://miro.medium.com/v2/resize:fill:128:128/1*rGdUGkMoxT5SfrVKVAqbEw.png"),
                     TechBlog.create("인프랩", "https://tech.inflab.com", "https://tech.inflab.com/rss.xml", null),
@@ -46,16 +46,33 @@ public class InitialDataConfig {
                     TechBlog.create("토스", "https://toss.tech", "https://toss.tech/rss.xml", null),
                     TechBlog.create("리디", "https://www.ridicorp.com/story-category/tech-blog/", "https://www.ridicorp.com/story-category/tech-blog/feed/", null),
 
-                    TechBlog.create("SK C&C", "https://engineering-skcc.github.io", "https://engineering-skcc.github.io/feed.xml", "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://skax.co.kr&size=40"),
+                    TechBlog.create("카카오", "https://tech.kakao.com/blog", "https://tech.kakao.com/feed", null),
+                    TechBlog.create("카카오페이", "https://tech.kakaopay.com/", "https://tech.kakaopay.com/rss", null),
                     TechBlog.create("카카오엔터프라이즈", "https://tech.kakaoenterprise.com", "https://tech.kakaoenterprise.com/feed", null),
+                    TechBlog.create("라인", "https://techblog.lycorp.co.jp/ko", "https://techblog.lycorp.co.jp/ko/feed/index.xml", null),
+                    TechBlog.create("야놀자", "https://medium.com/@nol.tech", "https://medium.com/feed/@nol.tech", "https://miro.medium.com/v2/resize:fill:128:128/1*XYs4nb7sSKMrf_wEU0jTxg.png"),
+
+                    TechBlog.create("SK C&C", "https://engineering-skcc.github.io", "https://engineering-skcc.github.io/feed.xml", "https://t1.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://skax.co.kr&size=40"),
+                    TechBlog.create("SK 플래닛", "https://techtopic.skplanet.com/", "https://techtopic.skplanet.com/rss", null),
+                    TechBlog.create("데보션", "https://devocean.sk.com/blog/index.do", "https://devocean.sk.com/blog/rss.do", null),
+                    TechBlog.create("KT 클라우드", "https://tech.ktcloud.com/category/Tech%20Story", "https://tech.ktcloud.com/rss", null),
+
                     TechBlog.create("NHN", "https://meetup.nhncloud.com", "https://meetup.nhncloud.com/rss", null),
                     TechBlog.create("원티드", "https://medium.com/wantedjobs", "https://medium.com/feed/wantedjobs", "https://miro.medium.com/v2/resize:fill:128:128/1*FJkqW-xbLo_-zwoSzR1C6Q.jpeg"),
                     TechBlog.create("SSG", "https://medium.com/ssgtech", "https://medium.com/feed/ssgtech", "https://miro.medium.com/v2/resize:fill:128:128/1*IFPbUqRn__nXbkPrxhi38A.png"),
 
                     TechBlog.create("왓챠", "https://medium.com/watcha", "https://medium.com/feed/watcha", "https://miro.medium.com/v2/resize:fill:128:128/1*3YwZ4pRivcBi8nWl7u98gA.png"),
                     TechBlog.create("롯데ON", "https://techblog.lotteon.com", "https://techblog.lotteon.com/feed", "https://miro.medium.com/v2/resize:fill:128:128/1*_xLrBUD-sQT0-URzwwZcAA.png"),
+                    TechBlog.create("컬리", "https://helloworld.kurly.com/", "https://helloworld.kurly.com/feed.xml", null),
+                    TechBlog.create("뱅크샐러드", "https://blog.banksalad.com/tech/", "https://blog.banksalad.com/rss.xml", null),
+                    TechBlog.create("네이버페이", "https://medium.com/naverfinancial", "https://medium.com/feed/naverfinancial", "https://miro.medium.com/v2/resize:fill:128:128/1*igCXQtsphxUzkR8Vw5JcHg.png"),
                     TechBlog.create("네이버 플레이스", "https://medium.com/naver-place-dev", "https://medium.com/feed/naver-place-dev", "https://miro.medium.com/v2/resize:fill:128:128/1*eQjirn85ojpPPzCAw9fU1g.png"),
+                    TechBlog.create("크림", "https://medium.com/kream-%EA%B8%B0%EC%88%A0-%EB%B8%94%EB%A1%9C%EA%B7%B8/", "https://medium.com/feed/kream-%EA%B8%B0%EC%88%A0-%EB%B8%94%EB%A1%9C%EA%B7%B8", "https://miro.medium.com/v2/resize:fill:128:128/1*qI4UU92oN36TWf2cNBWF8A.png"),
+                    TechBlog.create("마이리얼트립", "https://medium.com/myrealtrip-product", "https://medium.com/feed/myrealtrip-product", "https://miro.medium.com/v2/resize:fill:128:128/1*mZgzkdMgnMjJ6dQQXeNXSA.png"),
+
+                    TechBlog.create("삼성전자", "https://techblog.samsung.com/", "https://techblog.samsung.com/rss", null),
                     TechBlog.create("데브시스터즈", "https://tech.devsisters.com", "https://tech.devsisters.com/rss.xml", null),
+                    TechBlog.create("컴투스", "https://on.com2us.com/tag/%EA%B8%B0%EC%88%A0%EB%B8%94%EB%A1%9C%EA%B7%B8/", "https://on.com2us.com/tag/%EA%B8%B0%EC%88%A0%EB%B8%94%EB%A1%9C%EA%B7%B8/feed/", null),
 
                     TechBlog.create("지마켓", "https://dev.gmarket.com", "https://dev.gmarket.com/rss", null),
                     TechBlog.create("번개장터", "https://medium.com/bunjang-tech-blog", "https://medium.com/feed/bunjang-tech-blog", "https://miro.medium.com/v2/resize:fill:128:128/1*XQ-7fuly8bBP4EVwj3ESbA.jpeg"),


### PR DESCRIPTION
## ❤️ 기능 설명
크롤링 대상 테크블로그를 27개에서 41개로 확장했습니다.

### 추가된 테크블로그 (14개)
- 카카오 (tech.kakao.com)
- 카카오페이 (tech.kakaopay.com)
- 라인 (techblog.lycorp.co.jp/ko)
- 야놀자
- SK 플래닛
- 데보션 (SK Devocean)
- KT 클라우드
- 컬리
- 뱅크샐러드
- 네이버페이
- 크림 (KREAM)
- 삼성전자
- 컴투스
- 마이리얼트립

### 기타 개선사항
- Medium 블로그 로고 이미지 사이즈를 128x128로 통일 (무신사 160→128, 야놀자 96→128)

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #182 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
