### PR TITLE
[feat/#186] 개발자 토큰 API 구현

### DIFF
--- a/src/main/java/com/techfork/domain/admin/controller/AdminController.java
+++ b/src/main/java/com/techfork/domain/admin/controller/AdminController.java
@@ -1,0 +1,38 @@
+package com.techfork.domain.admin.controller;
+
+import com.techfork.domain.auth.dto.DeveloperTokenResponse;
+import com.techfork.domain.auth.service.AuthService;
+import com.techfork.global.common.code.SuccessCode;
+import com.techfork.global.response.BaseResponse;
+import com.techfork.global.security.oauth.UserPrincipal;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Admin", description = "관리자 API")
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/admin")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AuthService authService;
+
+    @Operation(
+            summary = "개발자 토큰 발급 (ADMIN 전용)",
+            description = "프론트엔드 개발/테스트용 장수명 액세스 토큰(30일)을 발급합니다. ADMIN 권한이 있는 사용자만 접근할 수 있습니다."
+    )
+    @PostMapping("/developer-token")
+    public ResponseEntity<BaseResponse<DeveloperTokenResponse>> generateDeveloperToken(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        DeveloperTokenResponse response = authService.generateDeveloperToken(userPrincipal.getId());
+        return BaseResponse.of(SuccessCode.OK, response);
+    }
+}

--- a/src/main/java/com/techfork/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/techfork/domain/auth/converter/AuthConverter.java
@@ -1,0 +1,14 @@
+package com.techfork.domain.auth.converter;
+
+import com.techfork.domain.auth.dto.DeveloperTokenResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthConverter {
+
+    public DeveloperTokenResponse toDeveloperTokenResponse(String token){
+        return DeveloperTokenResponse.builder()
+                .developerToken(token)
+                .build();
+    }
+}

--- a/src/main/java/com/techfork/domain/auth/dto/DeveloperTokenResponse.java
+++ b/src/main/java/com/techfork/domain/auth/dto/DeveloperTokenResponse.java
@@ -1,0 +1,12 @@
+package com.techfork.domain.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "개발자 토큰 발급 응답")
+public record DeveloperTokenResponse(
+        @Schema(description = "개발자 토큰 (만료 기간: 30일)", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+        String developerToken
+) {
+}

--- a/src/main/java/com/techfork/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/techfork/domain/auth/exception/AuthErrorCode.java
@@ -17,7 +17,8 @@ public enum AuthErrorCode implements BaseCode {
     REFRESH_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "AUTH401_REFRESH_MISSING", "리프레시 토큰이 제공되지 않았습니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_REFRESH_MISMATCH", "리프레시 토큰이 일치하지 않습니다. 세션이 무효화되었습니다."),
     TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH400_TYPE_MISMATCH", "토큰 타입이 일치하지 않습니다."),
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH404_USER", "사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH404_USER", "사용자를 찾을 수 없습니다."),
+    FORBIDDEN_INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "AUTH403_FORBIDDEN", "권한이 부족합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/techfork/domain/auth/service/AuthService.java
+++ b/src/main/java/com/techfork/domain/auth/service/AuthService.java
@@ -1,8 +1,11 @@
 package com.techfork.domain.auth.service;
 
+import com.techfork.domain.auth.converter.AuthConverter;
+import com.techfork.domain.auth.dto.DeveloperTokenResponse;
 import com.techfork.domain.auth.dto.TokenRefreshResponse;
 import com.techfork.domain.auth.exception.AuthErrorCode;
 import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.Role;
 import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.exception.GeneralException;
 import com.techfork.global.security.auth.service.RefreshTokenService;
@@ -10,6 +13,7 @@ import com.techfork.global.security.jwt.JwtDTO;
 import com.techfork.global.security.jwt.JwtProperties;
 import com.techfork.global.security.jwt.JwtUtil;
 import com.techfork.global.util.CookieUtil;
+import jakarta.security.auth.message.config.AuthConfig;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,18 +26,18 @@ import static com.techfork.global.security.jwt.JwtConstants.TOKEN_TYPE_REFRESH;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional
 public class AuthService {
 
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
     private final UserRepository userRepository;
     private final JwtProperties jwtProperties;
+    private final AuthConverter authConverter;
 
     @Value("${server.domain}")
     private String domain;
 
-    @Transactional
     public TokenRefreshResponse refreshToken(String refreshToken, HttpServletResponse response) {
         validateRefreshTokenRequest(refreshToken);
 
@@ -54,7 +58,6 @@ public class AuthService {
                 .build();
     }
 
-    @Transactional
     public void logout(String refreshToken, HttpServletResponse response) {
         validateRefreshTokenRequest(refreshToken);
 
@@ -62,6 +65,21 @@ public class AuthService {
         deleteRefreshToken(response, userId);
 
         log.info("User logged out - userId: {}", userId);
+    }
+
+    public DeveloperTokenResponse generateDeveloperToken(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(AuthErrorCode.USER_NOT_FOUND));
+
+        if (user.getRole() != Role.ADMIN) {
+            throw new GeneralException(AuthErrorCode.FORBIDDEN_INSUFFICIENT_PERMISSIONS);
+        }
+
+        String longLivedAccessToken = jwtUtil.generateLongLivedAccessToken(userId, user.getRole());
+
+        log.info("Developer token (long-lived access token) generated for admin userId: {}", userId);
+
+        return authConverter.toDeveloperTokenResponse(longLivedAccessToken);
     }
 
     private void validateRefreshTokenRequest(String refreshToken) {

--- a/src/main/java/com/techfork/global/constant/Constants.java
+++ b/src/main/java/com/techfork/global/constant/Constants.java
@@ -27,6 +27,7 @@ public final class Constants {
 
     public static final String[] ADMIN_ENDPOINTS = {
             "/api/v1/batch/**",
+            "/api/v1/admin/**"
     };
 
 }

--- a/src/main/java/com/techfork/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/techfork/global/security/config/SecurityConfig.java
@@ -46,8 +46,8 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers(Constants.PUBLIC_ENDPOINTS).permitAll()
                         .requestMatchers(Constants.ADMIN_ENDPOINTS).hasRole("ADMIN")
+                        .requestMatchers(Constants.PUBLIC_ENDPOINTS).permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/techfork/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/techfork/global/security/jwt/JwtUtil.java
@@ -29,6 +29,12 @@ public class JwtUtil {
         );
     }
 
+    public String generateLongLivedAccessToken(Long userId, Role role) {
+        // 30일 = 30일 * 24시간 * 60분 * 60초 * 1000밀리초
+        long longLivedTokenExpiration = 30L * 24 * 60 * 60 * 1000;
+        return generateToken(userId, role, longLivedTokenExpiration, TOKEN_TYPE_ACCESS);
+    }
+
     private String generateToken(Long userId, Role role, long expiration, String tokenType) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + expiration);

--- a/src/test/java/com/techfork/domain/admin/controller/AdminControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/admin/controller/AdminControllerIntegrationTest.java
@@ -1,0 +1,167 @@
+package com.techfork.domain.admin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techfork.domain.auth.exception.AuthErrorCode;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.Role;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.common.IntegrationTestBase;
+import com.techfork.global.security.jwt.JwtDTO;
+import com.techfork.global.security.jwt.JwtUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * AdminController 통합 테스트
+ * - 개발자 토큰 발급 API 테스트
+ * - ADMIN 권한 검증
+ * - 실제 JWT 토큰 사용으로 전체 인증 흐름 테스트
+ */
+class AdminControllerIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    private User adminUser;
+    private User normalUser;
+    private String adminAccessToken;
+    private String normalUserAccessToken;
+
+    @BeforeEach
+    void setUp() {
+        // 관리자 사용자 생성
+        adminUser = User.builder()
+                .socialType(SocialType.KAKAO)
+                .socialId("adminSocialId")
+                .email("admin@example.com")
+                .role(Role.ADMIN)
+                .build();
+        adminUser = userRepository.save(adminUser);
+
+        JwtDTO adminTokens = jwtUtil.generateTokens(adminUser.getId(), Role.ADMIN);
+        adminAccessToken = adminTokens.accessToken();
+
+        // 일반 사용자 생성
+        normalUser = User.createSocialUser(SocialType.KAKAO, "userSocialId", "user@example.com");
+        normalUser = userRepository.save(normalUser);
+
+        JwtDTO userTokens = jwtUtil.generateTokens(normalUser.getId(), Role.USER);
+        normalUserAccessToken = userTokens.accessToken();
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    // ===== 개발자 토큰 발급 성공 테스트 =====
+
+    @Test
+    @DisplayName("개발자 토큰 발급 성공 - ADMIN 권한으로 30일 만료 토큰 발급")
+    void generateDeveloperToken_Success_AdminUser() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/v1/admin/developer-token")
+                        .header("Authorization", "Bearer " + adminAccessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.developerToken").value(notNullValue()))
+                .andExpect(jsonPath("$.data.developerToken").isString());
+    }
+
+    @Test
+    @DisplayName("개발자 토큰 발급 성공 - 발급된 토큰이 유효한 액세스 토큰인지 검증 (실제 JWT 검증)")
+    void generateDeveloperToken_Success_TokenIsValid() throws Exception {
+        // Given - 실제 JWT 토큰으로 개발자 토큰 발급
+        JwtDTO adminTokens = jwtUtil.generateTokens(adminUser.getId(), Role.ADMIN);
+
+        // When
+        String responseBody = mockMvc.perform(post("/api/v1/admin/developer-token")
+                        .header("Authorization", "Bearer " + adminTokens.accessToken()))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        // Then - 발급된 토큰이 유효한 액세스 토큰인지 검증
+        ObjectMapper objectMapper = new ObjectMapper();
+        String developerToken = objectMapper.readTree(responseBody)
+                .path("data")
+                .path("developerToken")
+                .asText();
+
+        // 토큰이 유효하고 타입이 access인지 검증
+        assertThat(jwtUtil.isValidToken(developerToken)).isTrue();
+        assertThat(jwtUtil.getTokenType(developerToken)).isEqualTo("access");
+    }
+
+    // ===== 개발자 토큰 발급 실패 테스트 =====
+
+    @Test
+    @DisplayName("개발자 토큰 발급 실패 - 일반 사용자 권한으로 접근 시 403 Forbidden")
+    void generateDeveloperToken_Fail_NormalUserForbidden() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/v1/admin/developer-token")
+                        .header("Authorization", "Bearer " + normalUserAccessToken))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON403"));
+    }
+
+    @Test
+    @DisplayName("개발자 토큰 발급 실패 - 인증 없이 접근 시 401 Unauthorized")
+    void generateDeveloperToken_Fail_NoAuthenticationUnauthorized() throws Exception {
+        // When & Then
+        mockMvc.perform(post("/api/v1/admin/developer-token"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("COMMON401"));
+    }
+
+    @Test
+    @DisplayName("개발자 토큰 발급 실패 - 유효하지 않은 토큰으로 접근 (실제 JWT 검증)")
+    void generateDeveloperToken_Fail_InvalidToken() throws Exception {
+        // When & Then - 실제 JWT 필터를 통과해야 하므로 실제 토큰 사용
+        mockMvc.perform(post("/api/v1/admin/developer-token")
+                        .header("Authorization", "Bearer invalid.token.here"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("AUTH401_MALFORMED"));
+    }
+
+    @Test
+    @DisplayName("개발자 토큰 발급 실패 - 존재하지 않는 사용자")
+    void generateDeveloperToken_Fail_UserNotFound() throws Exception {
+        // Given - 존재하지 않는 사용자 ID로 토큰 생성
+        JwtDTO fakeAdminTokens = jwtUtil.generateTokens(999999L, Role.ADMIN);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/admin/developer-token")
+                        .header("Authorization", "Bearer " + fakeAdminTokens.accessToken()))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.USER_NOT_FOUND.getReason().code()));
+    }
+}

--- a/src/test/java/com/techfork/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/techfork/domain/auth/service/AuthServiceTest.java
@@ -1,5 +1,7 @@
 package com.techfork.domain.auth.service;
 
+import com.techfork.domain.auth.converter.AuthConverter;
+import com.techfork.domain.auth.dto.DeveloperTokenResponse;
 import com.techfork.domain.auth.dto.TokenRefreshResponse;
 import com.techfork.domain.auth.exception.AuthErrorCode;
 import com.techfork.domain.user.entity.User;
@@ -48,6 +50,9 @@ class AuthServiceTest {
 
     @Mock
     private HttpServletResponse response;
+
+    @Mock
+    private AuthConverter authConverter;
 
     @InjectMocks
     private AuthService authService;
@@ -214,5 +219,73 @@ class AuthServiceTest {
                 .isInstanceOf(GeneralException.class)
                 .extracting(ex -> ((GeneralException) ex).getCode())
                 .isEqualTo(AuthErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    // ===== 개발자 토큰 발급 테스트 =====
+
+    @Test
+    @DisplayName("개발자 토큰 발급 성공 - ADMIN 권한으로 30일 만료 토큰 발급")
+    void generateDeveloperToken_Success() {
+        // Given
+        User adminUser = User.builder()
+                .socialType(SocialType.KAKAO)
+                .socialId("adminSocialId")
+                .email("admin@example.com")
+                .role(Role.ADMIN)
+                .build();
+        ReflectionTestUtils.setField(adminUser, "id", userId);
+
+        String developerToken = "long.lived.access.token";
+        DeveloperTokenResponse expectedResponse = DeveloperTokenResponse.builder()
+                .developerToken(developerToken)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(adminUser));
+        given(jwtUtil.generateLongLivedAccessToken(userId, Role.ADMIN)).willReturn(developerToken);
+        given(authConverter.toDeveloperTokenResponse(developerToken)).willReturn(expectedResponse);
+
+        // When
+        DeveloperTokenResponse result = authService.generateDeveloperToken(userId);
+
+        // Then
+        assertThat(result.developerToken()).isEqualTo(developerToken);
+        verify(userRepository).findById(userId);
+        verify(jwtUtil).generateLongLivedAccessToken(userId, Role.ADMIN);
+        verify(authConverter).toDeveloperTokenResponse(developerToken);
+    }
+
+    @Test
+    @DisplayName("개발자 토큰 발급 실패 - 사용자를 찾을 수 없음")
+    void generateDeveloperToken_Fail_UserNotFound() {
+        // Given
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> authService.generateDeveloperToken(userId))
+                .isInstanceOf(GeneralException.class)
+                .extracting(ex -> ((GeneralException) ex).getCode())
+                .isEqualTo(AuthErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository).findById(userId);
+        verify(jwtUtil, never()).generateLongLivedAccessToken(anyLong(), any(Role.class));
+    }
+
+    @Test
+    @DisplayName("개발자 토큰 발급 실패 - ADMIN 권한이 아닌 사용자")
+    void generateDeveloperToken_Fail_InsufficientPermissions() {
+        // Given - 일반 사용자
+        User normalUser = User.createSocialUser(SocialType.KAKAO, "userSocialId", "user@example.com");
+        ReflectionTestUtils.setField(normalUser, "id", userId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(normalUser));
+
+        // When & Then
+        assertThatThrownBy(() -> authService.generateDeveloperToken(userId))
+                .isInstanceOf(GeneralException.class)
+                .extracting(ex -> ((GeneralException) ex).getCode())
+                .isEqualTo(AuthErrorCode.FORBIDDEN_INSUFFICIENT_PERMISSIONS);
+
+        verify(userRepository).findById(userId);
+        verify(jwtUtil, never()).generateLongLivedAccessToken(anyLong(), any(Role.class));
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
프론트엔드 개발자가 API 연동 테스트 시 짧은 만료 시간의 액세스 토큰으로 인해 반복적으로 토큰을 재발급받아야 하는 불편함을 해소하기 위한 개발자 토큰 발급 API를 구현합니다.

### 주요 변경사항

#### 1. 도메인 구조
- `domain/admin` 패키지 생성하여 관리자 기능 분리
- `AdminController`: 관리자 전용 엔드포인트 관리

#### 2. 토큰 발급 로직
- `JwtUtil.generateLongLivedAccessToken()`: 30일 만료 액세스 토큰 생성
- `AuthService.generateDeveloperToken()`: ADMIN 권한 검증 및 토큰 발급
- `AuthConverter.toDeveloperTokenResponse()`: DTO 변환

#### 3. 보안 설정
- `/api/v1/admin/**` 경로를 ADMIN 권한 필수로 설정
- `SecurityConfig`에서 ADMIN_ENDPOINTS가 PUBLIC_ENDPOINTS보다 먼저 평가되도록 순서 조정

#### 4. 테스트
- **단위 테스트** (`AuthServiceTest`):
  - ADMIN 권한으로 토큰 발급 성공
  - 일반 사용자 권한 시 403 에러
  - 존재하지 않는 사용자 404 에러

- **통합 테스트** (`AdminControllerIntegrationTest`):
  - 실제 JWT 토큰으로 전체 인증 흐름 검증
  - 발급된 개발자 토큰의 유효성 및 타입 검증
  - 권한 부족 시 403, 인증 없이 접근 시 401 검증

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #186 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
