### PR TITLE
[fix/#188] Nginx 프록시 환경에서 OAuth 리다이렉트 URL이 http로 생성되는 문제

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,6 +57,7 @@ jwt:
 
 server:
   domain: ${SERVER_DOMAIN:localhost}
+  forward-headers-strategy: native
 
 
 


### PR DESCRIPTION
## ❤️ 기능 설명
Nginx 리버스 프록시 환경에서 Spring Boot가 `X-Forwarded-*` 헤더를 올바르게 처리하도록 `server.forward-headers-strategy: native` 설정 추가

**변경 사항:**
- `application.yml`의 `server` 섹션에 `forward-headers-strategy: native` 추가
- 이를 통해 Nginx가 전달하는 `X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-Port` 헤더를 Spring Boot가 인식
- OAuth 리다이렉트 URI가 `https://`로 올바르게 생성됨

**영향 범위:**
- Kakao OAuth 로그인 리다이렉트 URL 생성
- `{baseUrl}` 플레이스홀더를 사용하는 모든 URL 생성 로직

관련 문서
https://docs.spring.io/spring-security/reference/6.5/servlet/oauth2/client/authorization-grants.html#oauth2-client-authorization-code-authorization-request


## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #188 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
