### PR TITLE
[feat/#178] iOS 전용 카카오 소셜 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 	testImplementation 'org.testcontainers:junit-jupiter:1.21.4'
 	testImplementation 'com.redis:testcontainers-redis:2.2.4'
 
+	// WireMock for API mocking
+	testImplementation 'org.wiremock:wiremock-standalone:3.9.2'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/src/main/java/com/techfork/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/techfork/domain/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.techfork.domain.auth.controller;
 
+import com.techfork.domain.auth.dto.KakaoLoginRequest;
+import com.techfork.domain.auth.dto.KakaoLoginResponse;
 import com.techfork.domain.auth.dto.TokenRefreshResponse;
 import com.techfork.domain.auth.service.AuthService;
 import com.techfork.global.common.code.SuccessCode;
@@ -7,6 +9,7 @@ import com.techfork.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +23,19 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final AuthService authService;
+
+    @Operation(
+            summary = "카카오 로그인",
+            description = "iOS 클라이언트에서 받은 카카오 액세스 토큰을 검증하고 자체 JWT 토큰을 발급합니다. 리프레시 토큰은 HttpOnly 쿠키로 설정됩니다."
+    )
+    @PostMapping("/kakao/login")
+    public ResponseEntity<BaseResponse<KakaoLoginResponse>> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequest request,
+            HttpServletResponse response
+    ) {
+        KakaoLoginResponse loginResponse = authService.kakaoLogin(request.accessToken(), response);
+        return BaseResponse.of(SuccessCode.OK, loginResponse);
+    }
 
     @Operation(
             summary = "토큰 갱신",

--- a/src/main/java/com/techfork/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/com/techfork/domain/auth/converter/AuthConverter.java
@@ -1,6 +1,8 @@
 package com.techfork.domain.auth.converter;
 
 import com.techfork.domain.auth.dto.DeveloperTokenResponse;
+import com.techfork.domain.auth.dto.KakaoLoginResponse;
+import com.techfork.domain.user.entity.User;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -9,6 +11,14 @@ public class AuthConverter {
     public DeveloperTokenResponse toDeveloperTokenResponse(String token){
         return DeveloperTokenResponse.builder()
                 .developerToken(token)
+                .build();
+    }
+
+    public KakaoLoginResponse toKakaoLoginResponse(String accessToken, User user) {
+        return KakaoLoginResponse.builder()
+                .accessToken(accessToken)
+                .userId(user.getId())
+                .isRegistered(user.isActive())
                 .build();
     }
 }

--- a/src/main/java/com/techfork/domain/auth/dto/KakaoLoginRequest.java
+++ b/src/main/java/com/techfork/domain/auth/dto/KakaoLoginRequest.java
@@ -1,0 +1,9 @@
+package com.techfork.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoLoginRequest(
+        @NotBlank(message = "카카오 액세스 토큰은 필수입니다.")
+        String accessToken
+) {
+}

--- a/src/main/java/com/techfork/domain/auth/dto/KakaoLoginResponse.java
+++ b/src/main/java/com/techfork/domain/auth/dto/KakaoLoginResponse.java
@@ -1,0 +1,11 @@
+package com.techfork.domain.auth.dto;
+
+import lombok.Builder;
+
+@Builder
+public record KakaoLoginResponse(
+        String accessToken,
+        Long userId,
+        Boolean isRegistered
+) {
+}

--- a/src/main/java/com/techfork/domain/auth/dto/kakao/KakaoUserInfoResponse.java
+++ b/src/main/java/com/techfork/domain/auth/dto/kakao/KakaoUserInfoResponse.java
@@ -1,0 +1,24 @@
+package com.techfork.domain.auth.dto.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoUserInfoResponse(
+        @JsonProperty("id")
+        Long id,
+
+        @JsonProperty("kakao_account")
+        KakaoAccount kakaoAccount
+) {
+    public record KakaoAccount(
+            @JsonProperty("email")
+            String email,
+
+            @JsonProperty("profile")
+            Profile profile
+    ) {}
+
+    public record Profile(
+            @JsonProperty("profile_image_url")
+            String profileImageUrl
+    ) {}
+}

--- a/src/main/java/com/techfork/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/techfork/domain/auth/exception/AuthErrorCode.java
@@ -18,7 +18,9 @@ public enum AuthErrorCode implements BaseCode {
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "AUTH401_REFRESH_MISMATCH", "리프레시 토큰이 일치하지 않습니다. 세션이 무효화되었습니다."),
     TOKEN_TYPE_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH400_TYPE_MISMATCH", "토큰 타입이 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH404_USER", "사용자를 찾을 수 없습니다."),
-    FORBIDDEN_INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "AUTH403_FORBIDDEN", "권한이 부족합니다.");
+    FORBIDDEN_INSUFFICIENT_PERMISSIONS(HttpStatus.FORBIDDEN, "AUTH403_FORBIDDEN", "권한이 부족합니다."),
+    INVALID_KAKAO_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH401_KAKAO_TOKEN", "유효하지 않은 카카오 액세스 토큰입니다."),
+    KAKAO_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH500_KAKAO_API", "카카오 API 호출 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/techfork/domain/auth/service/AuthService.java
+++ b/src/main/java/com/techfork/domain/auth/service/AuthService.java
@@ -2,10 +2,14 @@ package com.techfork.domain.auth.service;
 
 import com.techfork.domain.auth.converter.AuthConverter;
 import com.techfork.domain.auth.dto.DeveloperTokenResponse;
+import com.techfork.domain.auth.dto.KakaoLoginResponse;
 import com.techfork.domain.auth.dto.TokenRefreshResponse;
+import com.techfork.domain.auth.dto.kakao.KakaoUserInfoResponse;
 import com.techfork.domain.auth.exception.AuthErrorCode;
 import com.techfork.domain.user.entity.User;
 import com.techfork.domain.user.enums.Role;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.enums.UserStatus;
 import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.exception.GeneralException;
 import com.techfork.global.security.auth.service.RefreshTokenService;
@@ -34,6 +38,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtProperties jwtProperties;
     private final AuthConverter authConverter;
+    private final KakaoOAuthService kakaoOAuthService;
 
     @Value("${server.domain}")
     private String domain;
@@ -80,6 +85,28 @@ public class AuthService {
         log.info("Developer token (long-lived access token) generated for admin userId: {}", userId);
 
         return authConverter.toDeveloperTokenResponse(longLivedAccessToken);
+    }
+
+    public KakaoLoginResponse kakaoLogin(String kakaoAccessToken, HttpServletResponse response) {
+        KakaoUserInfoResponse kakaoUserInfo = kakaoOAuthService.getUserInfo(kakaoAccessToken);
+
+        String socialId = kakaoUserInfo.id().toString();
+        String email = kakaoUserInfo.kakaoAccount().email();
+        String profileImageUrl = kakaoUserInfo.kakaoAccount().profile().profileImageUrl();
+
+        User user = userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, socialId)
+                .orElseGet(() -> {
+                    User newUser = User.createSocialUser(SocialType.KAKAO, socialId, email, profileImageUrl);
+                    return userRepository.save(newUser);
+                });
+
+        JwtDTO tokens = jwtUtil.generateTokens(user.getId(), user.getRole());
+        long expiration = jwtProperties.getRefreshTokenExpiration();
+        saveAndSetRefreshToken(response, user.getId(), tokens.refreshToken(), expiration);
+
+        log.info("Kakao login successful - userId: {}, isRegistered: {}", user.getId(), user.isActive());
+
+        return authConverter.toKakaoLoginResponse(tokens.accessToken(), user);
     }
 
     private void validateRefreshTokenRequest(String refreshToken) {

--- a/src/main/java/com/techfork/domain/auth/service/KakaoOAuthService.java
+++ b/src/main/java/com/techfork/domain/auth/service/KakaoOAuthService.java
@@ -1,0 +1,41 @@
+package com.techfork.domain.auth.service;
+
+import com.techfork.domain.auth.dto.kakao.KakaoUserInfoResponse;
+import com.techfork.domain.auth.exception.AuthErrorCode;
+import com.techfork.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService {
+
+    @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+    private String userInfoUrl;
+
+    private final WebClient.Builder webClientBuilder;
+
+    public KakaoUserInfoResponse getUserInfo(String accessToken) {
+        try {
+            return webClientBuilder.build()
+                    .get()
+                    .uri(userInfoUrl)
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .bodyToMono(KakaoUserInfoResponse.class)
+                    .block();
+        } catch (WebClientResponseException e) {
+            log.error("Failed to get Kakao user info. Status: {}, Response: {}",
+                    e.getStatusCode(), e.getResponseBodyAsString());
+            throw new GeneralException(AuthErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+        } catch (Exception e) {
+            log.error("Unexpected error while getting Kakao user info", e);
+            throw new GeneralException(AuthErrorCode.KAKAO_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/techfork/domain/user/entity/User.java
+++ b/src/main/java/com/techfork/domain/user/entity/User.java
@@ -77,4 +77,8 @@ public class User extends BaseTimeEntity {
         this.description = description;
         this.status = UserStatus.ACTIVE;
     }
+
+    public boolean isActive() {
+        return status == UserStatus.ACTIVE;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,6 +46,7 @@ spring:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
             token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
             jwk-set-uri: https://kauth.kakao.com/.well-known/jwks.json
             user-name-attribute: sub
 

--- a/src/test/java/com/techfork/domain/auth/controller/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/auth/controller/AuthControllerIntegrationTest.java
@@ -1,9 +1,14 @@
 package com.techfork.domain.auth.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.techfork.domain.auth.dto.KakaoLoginRequest;
 import com.techfork.domain.auth.exception.AuthErrorCode;
 import com.techfork.domain.user.entity.User;
 import com.techfork.domain.user.enums.Role;
 import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.enums.UserStatus;
 import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.common.IntegrationTestBase;
 import com.techfork.global.security.auth.service.RefreshTokenService;
@@ -14,8 +19,12 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -28,8 +37,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * - @Tag("integration") 자동 적용
  * - 모든 레이어(Controller, Service, Repository) 통합 테스트
  * - MockMvc로 HTTP 요청/응답 테스트
+ * - WireMock으로 카카오 API 모킹
  */
 class AuthControllerIntegrationTest extends IntegrationTestBase {
+
+    private static WireMockServer wireMockServer;
 
     @Autowired
     private MockMvc mockMvc;
@@ -49,9 +61,30 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
     @Autowired
     private StringRedisTemplate redisTemplate;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     private User testUser;
     private String validRefreshToken;
     private Long userId;
+
+    @BeforeAll
+    static void beforeAll() {
+        wireMockServer = new WireMockServer(8089);
+        wireMockServer.start();
+        WireMock.configureFor("localhost", 8089);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        wireMockServer.stop();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.security.oauth2.client.provider.kakao.user-info-uri",
+                () -> "http://localhost:8089/v2/user/me");
+    }
 
     @BeforeEach
     void setUp() {
@@ -69,6 +102,8 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
 
     @AfterEach
     void tearDown() {
+        // WireMock 스텁 초기화
+        wireMockServer.resetAll();
         // Redis 데이터 정리
         redisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
         // DB 데이터 정리
@@ -181,5 +216,160 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.isSuccess").value(false))
                 .andExpect(jsonPath("$.code").value(AuthErrorCode.REFRESH_TOKEN_MISSING.getReason().code()));
+    }
+
+    // ===== 카카오 로그인 iOS 테스트 =====
+
+    @Test
+    @DisplayName("카카오 로그인 성공 - 신규 회원 가입")
+    void kakaoLogin_Success_NewUser() throws Exception {
+        // Given: WireMock으로 카카오 API 응답 모킹
+        String kakaoAccessToken = "valid.kakao.access.token";
+        String kakaoApiResponse = """
+                {
+                    "id": 12345,
+                    "kakao_account": {
+                        "email": "newuser@kakao.com",
+                        "profile": {
+                            "profile_image_url": "https://example.com/profile.jpg"
+                        }
+                    }
+                }
+                """;
+
+        stubFor(get(urlEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer " + kakaoAccessToken))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(kakaoApiResponse)));
+
+        KakaoLoginRequest request = new KakaoLoginRequest(kakaoAccessToken);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/kakao/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.userId").exists())
+                .andExpect(jsonPath("$.data.isRegistered").value(false)); // 신규 가입
+
+        // DB에 사용자가 생성되었는지 검증
+        User savedUser = userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, "12345")
+                .orElseThrow();
+        assertThat(savedUser.getEmail()).isEqualTo("newuser@kakao.com");
+        assertThat(savedUser.getStatus()).isEqualTo(UserStatus.PENDING);
+
+        // WireMock 호출 검증
+        verify(getRequestedFor(urlEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer " + kakaoAccessToken)));
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 성공 - 기존 회원 로그인")
+    void kakaoLogin_Success_ExistingUser() throws Exception {
+        // Given: 기존 사용자 생성
+        User existingUser = User.createSocialUser(SocialType.KAKAO, "12345", "existing@kakao.com", "test.png");
+        existingUser.updateUser("테스트", "existing@kakao.com", "테스트 사용자입니다.");
+        userRepository.save(existingUser);
+
+        // WireMock으로 카카오 API 응답 모킹
+        String kakaoAccessToken = "valid.kakao.access.token";
+        String kakaoApiResponse = """
+                {
+                    "id": 12345,
+                    "kakao_account": {
+                        "email": "existing@kakao.com",
+                        "profile": {
+                            "profile_image_url": "https://example.com/profile.jpg"
+                        }
+                    }
+                }
+                """;
+
+        stubFor(get(urlEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer " + kakaoAccessToken))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(kakaoApiResponse)));
+
+        KakaoLoginRequest request = new KakaoLoginRequest(kakaoAccessToken);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/kakao/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.accessToken").exists())
+                .andExpect(jsonPath("$.data.userId").exists())
+                .andExpect(jsonPath("$.data.isRegistered").value(true)); // 기존 회원
+
+        // WireMock 호출 검증
+        verify(getRequestedFor(urlEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer " + kakaoAccessToken)));
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 실패 - 잘못된 액세스 토큰")
+    void kakaoLogin_Fail_InvalidAccessToken() throws Exception {
+        // Given: WireMock으로 카카오 API 에러 응답 모킹
+        String invalidAccessToken = "invalid.kakao.access.token";
+
+        stubFor(get(urlEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer " + invalidAccessToken))
+                .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"msg\":\"Invalid access token\"}")));
+
+        KakaoLoginRequest request = new KakaoLoginRequest(invalidAccessToken);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/kakao/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.INVALID_KAKAO_ACCESS_TOKEN.getReason().code()));
+
+        // WireMock 호출 검증
+        verify(getRequestedFor(urlEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer " + invalidAccessToken)));
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 실패 - 카카오 API 장애")
+    void kakaoLogin_Fail_KakaoApiError() throws Exception {
+        // Given: WireMock으로 카카오 API 장애 응답 모킹
+        String kakaoAccessToken = "valid.kakao.access.token";
+
+        stubFor(get(urlEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer " + kakaoAccessToken))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"msg\":\"Internal server error\"}")));
+
+        KakaoLoginRequest request = new KakaoLoginRequest(kakaoAccessToken);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/auth/kakao/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value(AuthErrorCode.INVALID_KAKAO_ACCESS_TOKEN.getReason().code()));
+
+        // WireMock 호출 검증
+        verify(getRequestedFor(urlEqualTo("/v2/user/me"))
+                .withHeader("Authorization", equalTo("Bearer " + kakaoAccessToken)));
     }
 }

--- a/src/test/java/com/techfork/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/techfork/domain/auth/service/AuthServiceTest.java
@@ -2,11 +2,14 @@ package com.techfork.domain.auth.service;
 
 import com.techfork.domain.auth.converter.AuthConverter;
 import com.techfork.domain.auth.dto.DeveloperTokenResponse;
+import com.techfork.domain.auth.dto.KakaoLoginResponse;
 import com.techfork.domain.auth.dto.TokenRefreshResponse;
+import com.techfork.domain.auth.dto.kakao.KakaoUserInfoResponse;
 import com.techfork.domain.auth.exception.AuthErrorCode;
 import com.techfork.domain.user.entity.User;
 import com.techfork.domain.user.enums.Role;
 import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.enums.UserStatus;
 import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.exception.GeneralException;
 import com.techfork.global.security.auth.service.RefreshTokenService;
@@ -53,6 +56,9 @@ class AuthServiceTest {
 
     @Mock
     private AuthConverter authConverter;
+
+    @Mock
+    private KakaoOAuthService kakaoOAuthService;
 
     @InjectMocks
     private AuthService authService;
@@ -287,5 +293,101 @@ class AuthServiceTest {
 
         verify(userRepository).findById(userId);
         verify(jwtUtil, never()).generateLongLivedAccessToken(anyLong(), any(Role.class));
+    }
+
+    // ===== 카카오 로그인 테스트 =====
+
+    @Test
+    @DisplayName("카카오 로그인 성공 - 신규 회원 가입")
+    void kakaoLogin_Success_NewUser() {
+        // Given
+        String kakaoAccessToken = "kakao.access.token";
+        String socialId = "12345";
+        String email = "newuser@kakao.com";
+        String profileImageUrl = "test.png";
+
+        KakaoUserInfoResponse.Profile profile = new KakaoUserInfoResponse.Profile("https://example.com/profile.jpg");
+        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount(email, profile);
+        KakaoUserInfoResponse kakaoUserInfo = new KakaoUserInfoResponse(12345L, kakaoAccount);
+
+        User newUser = User.createSocialUser(SocialType.KAKAO, socialId, email, profileImageUrl);
+        ReflectionTestUtils.setField(newUser, "id", userId);
+
+        JwtDTO tokens = JwtDTO.of(newAccessToken, newRefreshToken);
+        KakaoLoginResponse expectedResponse = KakaoLoginResponse.builder()
+                .accessToken(newAccessToken)
+                .userId(userId)
+                .isRegistered(false)
+                .build();
+
+        given(kakaoOAuthService.getUserInfo(kakaoAccessToken)).willReturn(kakaoUserInfo);
+        given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, socialId)).willReturn(Optional.empty());
+        given(userRepository.save(any(User.class))).willReturn(newUser);
+        given(jwtUtil.generateTokens(userId, Role.USER)).willReturn(tokens);
+        given(jwtProperties.getRefreshTokenExpiration()).willReturn(900000L);
+        given(authConverter.toKakaoLoginResponse(newAccessToken, newUser)).willReturn(expectedResponse);
+
+        // When
+        KakaoLoginResponse result = authService.kakaoLogin(kakaoAccessToken, response);
+
+        // Then
+        assertThat(result.accessToken()).isEqualTo(newAccessToken);
+        assertThat(result.userId()).isEqualTo(userId);
+        assertThat(result.isRegistered()).isFalse(); // 신규 가입이므로 PENDING 상태
+
+        verify(kakaoOAuthService).getUserInfo(kakaoAccessToken);
+        verify(userRepository).findBySocialTypeAndSocialId(SocialType.KAKAO, socialId);
+        verify(userRepository).save(any(User.class));
+        verify(jwtUtil).generateTokens(userId, Role.USER);
+        verify(refreshTokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyLong());
+        verify(response).addCookie(any(Cookie.class));
+        verify(authConverter).toKakaoLoginResponse(newAccessToken, newUser);
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 성공 - 기존 회원 로그인")
+    void kakaoLogin_Success_ExistingUser() {
+        // Given
+        String kakaoAccessToken = "kakao.access.token";
+        String socialId = "12345";
+        String email = "existinguser@kakao.com";
+        String profileImageUrl = "test.png";
+
+        KakaoUserInfoResponse.Profile profile = new KakaoUserInfoResponse.Profile("https://example.com/profile.jpg");
+        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount(email, profile);
+        KakaoUserInfoResponse kakaoUserInfo = new KakaoUserInfoResponse(12345L, kakaoAccount);
+
+        User existingUser = User.createSocialUser(SocialType.KAKAO, socialId, email, profileImageUrl);
+        ReflectionTestUtils.setField(existingUser, "id", userId);
+        ReflectionTestUtils.setField(existingUser, "status", UserStatus.ACTIVE);
+
+        JwtDTO tokens = JwtDTO.of(newAccessToken, newRefreshToken);
+        KakaoLoginResponse expectedResponse = KakaoLoginResponse.builder()
+                .accessToken(newAccessToken)
+                .userId(userId)
+                .isRegistered(true)
+                .build();
+
+        given(kakaoOAuthService.getUserInfo(kakaoAccessToken)).willReturn(kakaoUserInfo);
+        given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, socialId)).willReturn(Optional.of(existingUser));
+        given(jwtUtil.generateTokens(userId, Role.USER)).willReturn(tokens);
+        given(jwtProperties.getRefreshTokenExpiration()).willReturn(900000L);
+        given(authConverter.toKakaoLoginResponse(newAccessToken, existingUser)).willReturn(expectedResponse);
+
+        // When
+        KakaoLoginResponse result = authService.kakaoLogin(kakaoAccessToken, response);
+
+        // Then
+        assertThat(result.accessToken()).isEqualTo(newAccessToken);
+        assertThat(result.userId()).isEqualTo(userId);
+        assertThat(result.isRegistered()).isTrue(); // 기존 회원이므로 ACTIVE 상태
+
+        verify(kakaoOAuthService).getUserInfo(kakaoAccessToken);
+        verify(userRepository).findBySocialTypeAndSocialId(SocialType.KAKAO, socialId);
+        verify(userRepository, never()).save(any(User.class)); // 기존 회원이므로 save 호출 안됨
+        verify(jwtUtil).generateTokens(userId, Role.USER);
+        verify(refreshTokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyLong());
+        verify(response).addCookie(any(Cookie.class));
+        verify(authConverter).toKakaoLoginResponse(newAccessToken, existingUser);
     }
 }

--- a/src/test/java/com/techfork/domain/auth/service/KakaoOAuthServiceTest.java
+++ b/src/test/java/com/techfork/domain/auth/service/KakaoOAuthServiceTest.java
@@ -1,0 +1,154 @@
+package com.techfork.domain.auth.service;
+
+import com.techfork.domain.auth.dto.kakao.KakaoUserInfoResponse;
+import com.techfork.domain.auth.exception.AuthErrorCode;
+import com.techfork.global.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.core.publisher.Mono;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoOAuthServiceTest {
+
+    @Mock
+    private WebClient.Builder webClientBuilder;
+
+    @Mock
+    private WebClient webClient;
+
+    @Mock
+    private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private WebClient.ResponseSpec responseSpec;
+
+    @InjectMocks
+    private KakaoOAuthService kakaoOAuthService;
+
+    private String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+    private String validAccessToken = "valid.kakao.access.token";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(kakaoOAuthService, "userInfoUrl", userInfoUrl);
+
+        // WebClient 체이닝 모킹
+        given(webClientBuilder.build()).willReturn(webClient);
+        given(webClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri(anyString())).willReturn(requestHeadersSpec);
+        given(requestHeadersSpec.header(anyString(), anyString())).willReturn(requestHeadersSpec);
+        given(requestHeadersSpec.retrieve()).willReturn(responseSpec);
+    }
+
+    @Test
+    @DisplayName("카카오 사용자 정보 조회 성공")
+    void getUserInfo_Success() {
+        // Given
+        KakaoUserInfoResponse.Profile profile = new KakaoUserInfoResponse.Profile("https://example.com/profile.jpg");
+        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount("test@kakao.com", profile);
+        KakaoUserInfoResponse expectedResponse = new KakaoUserInfoResponse(12345L, kakaoAccount);
+
+        given(responseSpec.bodyToMono(KakaoUserInfoResponse.class))
+                .willReturn(Mono.just(expectedResponse));
+
+        // When
+        KakaoUserInfoResponse result = kakaoOAuthService.getUserInfo(validAccessToken);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(12345L);
+        assertThat(result.id().toString()).isEqualTo("12345");
+        assertThat(result.kakaoAccount().email()).isEqualTo("test@kakao.com");
+        assertThat(result.kakaoAccount().profile().profileImageUrl()).isEqualTo("https://example.com/profile.jpg");
+
+        verify(webClientBuilder).build();
+        verify(webClient).get();
+        verify(requestHeadersUriSpec).uri(userInfoUrl);
+        verify(requestHeadersSpec).header("Authorization", "Bearer " + validAccessToken);
+        verify(requestHeadersSpec).retrieve();
+    }
+
+    @Test
+    @DisplayName("카카오 사용자 정보 조회 실패 - 잘못된 액세스 토큰 (401)")
+    void getUserInfo_Fail_InvalidAccessToken() {
+        // Given
+        WebClientResponseException exception = WebClientResponseException.create(
+                401,
+                "Unauthorized",
+                null,
+                null,
+                null
+        );
+
+        given(responseSpec.bodyToMono(KakaoUserInfoResponse.class))
+                .willReturn(Mono.error(exception));
+
+        // When & Then
+        assertThatThrownBy(() -> kakaoOAuthService.getUserInfo(validAccessToken))
+                .isInstanceOf(GeneralException.class)
+                .extracting(ex -> ((GeneralException) ex).getCode())
+                .isEqualTo(AuthErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+
+        verify(webClientBuilder).build();
+        verify(webClient).get();
+    }
+
+    @Test
+    @DisplayName("카카오 사용자 정보 조회 실패 - 카카오 API 에러 (500)")
+    void getUserInfo_Fail_KakaoApiError() {
+        // Given
+        WebClientResponseException exception = WebClientResponseException.create(
+                500,
+                "Internal Server Error",
+                null,
+                null,
+                null
+        );
+
+        given(responseSpec.bodyToMono(KakaoUserInfoResponse.class))
+                .willReturn(Mono.error(exception));
+
+        // When & Then
+        assertThatThrownBy(() -> kakaoOAuthService.getUserInfo(validAccessToken))
+                .isInstanceOf(GeneralException.class)
+                .extracting(ex -> ((GeneralException) ex).getCode())
+                .isEqualTo(AuthErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+
+        verify(webClientBuilder).build();
+        verify(webClient).get();
+    }
+
+    @Test
+    @DisplayName("카카오 사용자 정보 조회 실패 - 예상치 못한 에러")
+    void getUserInfo_Fail_UnexpectedError() {
+        // Given
+        given(responseSpec.bodyToMono(KakaoUserInfoResponse.class))
+                .willReturn(Mono.error(new RuntimeException("Unexpected error")));
+
+        // When & Then
+        assertThatThrownBy(() -> kakaoOAuthService.getUserInfo(validAccessToken))
+                .isInstanceOf(GeneralException.class)
+                .extracting(ex -> ((GeneralException) ex).getCode())
+                .isEqualTo(AuthErrorCode.KAKAO_API_ERROR);
+
+        verify(webClientBuilder).build();
+        verify(webClient).get();
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
iOS 카카오 로그인 API 구현 및 테스트 코드 작성

**주요 변경사항:**
- 카카오 액세스 토큰을 받아 사용자 정보를 조회하고 로그인 처리하는 API 구현
- KakaoOAuthService: 카카오 사용자 정보 API 호출 서비스
- AuthService: 카카오 로그인 로직 추가
- AuthConverter: 카카오 로그인 응답 변환 메서드 추가
- application.yml: 카카오 API URL 설정 외부화

**테스트 코드:**
- KakaoOAuthServiceTest: WebClient mocking을 통한 단위 테스트
- AuthServiceTest: 카카오 로그인 신규/기존 회원 테스트 추가
- AuthControllerIntegrationTest: WireMock을 사용한 통합 테스트 (정상 케이스, 에러 케이스)

**API 엔드포인트:**
POST /api/v1/auth/kakao/login
Request: { "kakaoAccessToken": "..." }
Response: { "accessToken": "...", "userId": 1, "isRegistered": true/false }

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #178 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
