### PR TITLE
[feat/#179] 유저 프로필 API 구현

### DIFF
--- a/src/main/java/com/techfork/domain/user/controller/UserController.java
+++ b/src/main/java/com/techfork/domain/user/controller/UserController.java
@@ -1,10 +1,12 @@
 package com.techfork.domain.user.controller;
 
 import com.techfork.domain.user.dto.SaveInterestRequest;
+import com.techfork.domain.user.dto.UpdateUserProfileRequest;
 import com.techfork.domain.user.dto.UserInterestResponse;
 import com.techfork.domain.user.dto.UserProfileResponse;
 import com.techfork.domain.user.service.InterestCommandService;
 import com.techfork.domain.user.service.InterestQueryService;
+import com.techfork.domain.user.service.UserCommandService;
 import com.techfork.domain.user.service.UserQueryService;
 import com.techfork.global.common.code.SuccessCode;
 import com.techfork.global.response.BaseResponse;
@@ -27,6 +29,7 @@ public class UserController {
 
     private final InterestCommandService interestCommandService;
     private final InterestQueryService interestQueryService;
+    private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
 
     @Operation(
@@ -52,6 +55,19 @@ public class UserController {
     ) {
         UserInterestResponse response = interestQueryService.getUserInterests(userPrincipal.getId());
         return BaseResponse.of(SuccessCode.OK, response);
+    }
+
+    @Operation(
+            summary = "내 프로필 수정",
+            description = "현재 로그인한 사용자의 프로필 정보를 수정합니다. 닉네임과 자기소개를 선택적으로 수정할 수 있습니다."
+    )
+    @PatchMapping("/me/profile")
+    public ResponseEntity<BaseResponse<Void>> updateMyProfile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestBody UpdateUserProfileRequest request
+    ) {
+        userCommandService.updateUserProfile(userPrincipal.getId(), request);
+        return BaseResponse.of(SuccessCode.OK);
     }
 
     @Operation(

--- a/src/main/java/com/techfork/domain/user/controller/UserController.java
+++ b/src/main/java/com/techfork/domain/user/controller/UserController.java
@@ -2,8 +2,10 @@ package com.techfork.domain.user.controller;
 
 import com.techfork.domain.user.dto.SaveInterestRequest;
 import com.techfork.domain.user.dto.UserInterestResponse;
+import com.techfork.domain.user.dto.UserProfileResponse;
 import com.techfork.domain.user.service.InterestCommandService;
 import com.techfork.domain.user.service.InterestQueryService;
+import com.techfork.domain.user.service.UserQueryService;
 import com.techfork.global.common.code.SuccessCode;
 import com.techfork.global.response.BaseResponse;
 import com.techfork.global.security.oauth.UserPrincipal;
@@ -25,6 +27,7 @@ public class UserController {
 
     private final InterestCommandService interestCommandService;
     private final InterestQueryService interestQueryService;
+    private final UserQueryService userQueryService;
 
     @Operation(
             summary = "내 관심사 수정",
@@ -48,6 +51,18 @@ public class UserController {
             @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
         UserInterestResponse response = interestQueryService.getUserInterests(userPrincipal.getId());
+        return BaseResponse.of(SuccessCode.OK, response);
+    }
+
+    @Operation(
+            summary = "내 프로필 조회",
+            description = "현재 로그인한 사용자의 프로필 정보를 조회합니다. (프로필 이미지, 닉네임, 이메일, 자기소개)"
+    )
+    @GetMapping("/me/profile")
+    public ResponseEntity<BaseResponse<UserProfileResponse>> getMyProfile(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        UserProfileResponse response = userQueryService.getUserProfile(userPrincipal.getId());
         return BaseResponse.of(SuccessCode.OK, response);
     }
 }

--- a/src/main/java/com/techfork/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/techfork/domain/user/converter/UserConverter.java
@@ -1,0 +1,18 @@
+package com.techfork.domain.user.converter;
+
+import com.techfork.domain.user.dto.UserProfileResponse;
+import com.techfork.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserConverter {
+
+    public UserProfileResponse toUserProfileResponse(User user) {
+        return UserProfileResponse.builder()
+                .profileImage(user.getProfileImage())
+                .nickName(user.getNickName())
+                .email(user.getEmail())
+                .description(user.getDescription())
+                .build();
+    }
+}

--- a/src/main/java/com/techfork/domain/user/dto/UpdateUserProfileRequest.java
+++ b/src/main/java/com/techfork/domain/user/dto/UpdateUserProfileRequest.java
@@ -1,0 +1,13 @@
+package com.techfork.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 프로필 수정 요청")
+public record UpdateUserProfileRequest(
+        @Schema(description = "닉네임 (선택적)", example = "테크러버")
+        String nickName,
+
+        @Schema(description = "자기소개 (선택적)", example = "백엔드 개발자입니다.")
+        String description
+) {
+}

--- a/src/main/java/com/techfork/domain/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/techfork/domain/user/dto/UserProfileResponse.java
@@ -1,0 +1,12 @@
+package com.techfork.domain.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserProfileResponse(
+        String profileImage,
+        String nickName,
+        String email,
+        String description
+) {
+}

--- a/src/main/java/com/techfork/domain/user/entity/User.java
+++ b/src/main/java/com/techfork/domain/user/entity/User.java
@@ -78,6 +78,15 @@ public class User extends BaseTimeEntity {
         this.status = UserStatus.ACTIVE;
     }
 
+    public void updateProfile(String nickName, String description) {
+        if (nickName != null) {
+            this.nickName = nickName;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+    }
+
     public boolean isActive() {
         return status == UserStatus.ACTIVE;
     }

--- a/src/main/java/com/techfork/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/techfork/domain/user/service/UserCommandService.java
@@ -2,6 +2,7 @@ package com.techfork.domain.user.service;
 
 import com.techfork.domain.user.dto.OnboardingRequest;
 import com.techfork.domain.user.dto.SaveInterestRequest;
+import com.techfork.domain.user.dto.UpdateUserProfileRequest;
 import com.techfork.domain.user.entity.User;
 import com.techfork.domain.user.exception.UserErrorCode;
 import com.techfork.domain.user.repository.UserRepository;
@@ -19,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserCommandService {
 
     private final InterestCommandService interestCommandService;
-
     private final UserRepository userRepository;
 
     public void completeOnboarding(Long userId, @Valid OnboardingRequest request) {
@@ -29,5 +29,17 @@ public class UserCommandService {
         user.updateUser(request.nickname(), request.email(), request.description());
 
         interestCommandService.saveUserInterests(user, new SaveInterestRequest(request.interests()));
+    }
+
+    public void updateUserProfile(Long userId, UpdateUserProfileRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        user.updateProfile(request.nickName(), request.description());
+
+        log.info("User profile updated for userId: {} - nickName: {}, description: {}",
+                userId,
+                request.nickName() != null ? "updated" : "unchanged",
+                request.description() != null ? "updated" : "unchanged");
     }
 }

--- a/src/main/java/com/techfork/domain/user/service/UserQueryService.java
+++ b/src/main/java/com/techfork/domain/user/service/UserQueryService.java
@@ -1,0 +1,31 @@
+package com.techfork.domain.user.service;
+
+import com.techfork.domain.user.converter.UserConverter;
+import com.techfork.domain.user.dto.UserProfileResponse;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.exception.UserErrorCode;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserQueryService {
+
+    private final UserRepository userRepository;
+    private final UserConverter userConverter;
+
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
+
+        log.info("User profile retrieved for userId: {}", userId);
+
+        return userConverter.toUserProfileResponse(user);
+    }
+}

--- a/src/test/java/com/techfork/domain/user/controller/UserControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/user/controller/UserControllerIntegrationTest.java
@@ -1,0 +1,241 @@
+package com.techfork.domain.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techfork.domain.user.dto.UpdateUserProfileRequest;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.Role;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.enums.UserStatus;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.common.IntegrationTestBase;
+import com.techfork.global.security.jwt.JwtDTO;
+import com.techfork.global.security.jwt.JwtUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * UserController 통합 테스트
+ */
+class UserControllerIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    private User testUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        // ACTIVE 상태의 테스트 사용자 생성
+        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
+        testUser.updateUser("테스트유저", "test@example.com", "백엔드 개발자입니다.");
+        testUser = userRepository.save(testUser);
+
+        // JWT 토큰 생성
+        JwtDTO tokens = jwtUtil.generateTokens(testUser.getId(), Role.USER);
+        accessToken = tokens.accessToken();
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    // ===== 프로필 조회 테스트 =====
+
+    @Test
+    @DisplayName("내 프로필 조회 성공")
+    void getMyProfile_Success() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.profileImage").value("profile.jpg"))
+                .andExpect(jsonPath("$.data.nickName").value("테스트유저"))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                .andExpect(jsonPath("$.data.description").value("백엔드 개발자입니다."));
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회 실패 - 인증 토큰 없음")
+    void getMyProfile_Fail_NoAuthToken() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/v1/users/me/profile"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("내 프로필 조회 실패 - 유효하지 않은 토큰")
+    void getMyProfile_Fail_InvalidToken() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer invalid.token.here"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    // ===== 프로필 수정 테스트 =====
+
+    @Test
+    @DisplayName("내 프로필 수정 성공 - 닉네임만 수정")
+    void updateMyProfile_Success_OnlyNickName() throws Exception {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest("새로운닉네임", null);
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB에서 변경사항 확인
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getNickName()).isEqualTo("새로운닉네임");
+        assertThat(updatedUser.getDescription()).isEqualTo("백엔드 개발자입니다."); // 변경되지 않음
+    }
+
+    @Test
+    @DisplayName("내 프로필 수정 성공 - 자기소개만 수정")
+    void updateMyProfile_Success_OnlyDescription() throws Exception {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest(null, "프론트엔드 개발자로 전향했습니다.");
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB에서 변경사항 확인
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getNickName()).isEqualTo("테스트유저"); // 변경되지 않음
+        assertThat(updatedUser.getDescription()).isEqualTo("프론트엔드 개발자로 전향했습니다.");
+    }
+
+    @Test
+    @DisplayName("내 프로필 수정 성공 - 닉네임과 자기소개 모두 수정")
+    void updateMyProfile_Success_BothFields() throws Exception {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest("풀스택개발자", "백엔드와 프론트엔드 모두 합니다.");
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB에서 변경사항 확인
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getNickName()).isEqualTo("풀스택개발자");
+        assertThat(updatedUser.getDescription()).isEqualTo("백엔드와 프론트엔드 모두 합니다.");
+    }
+
+    @Test
+    @DisplayName("내 프로필 수정 성공 - 빈 요청 (아무것도 수정하지 않음)")
+    void updateMyProfile_Success_EmptyRequest() throws Exception {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest(null, null);
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB에서 변경사항 확인 (아무것도 변경되지 않음)
+        User updatedUser = userRepository.findById(testUser.getId()).orElseThrow();
+        assertThat(updatedUser.getNickName()).isEqualTo("테스트유저");
+        assertThat(updatedUser.getDescription()).isEqualTo("백엔드 개발자입니다.");
+    }
+
+    @Test
+    @DisplayName("내 프로필 수정 실패 - 인증 토큰 없음")
+    void updateMyProfile_Fail_NoAuthToken() throws Exception {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest("새닉네임", "새 소개");
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("내 프로필 수정 실패 - 유효하지 않은 토큰")
+    void updateMyProfile_Fail_InvalidToken() throws Exception {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest("새닉네임", "새 소개");
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer invalid.token.here")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("프로필 수정 후 조회 - 변경사항 반영 확인")
+    void updateAndGetProfile_Success() throws Exception {
+        // Given
+        UpdateUserProfileRequest updateRequest = new UpdateUserProfileRequest("변경된닉네임", "변경된 자기소개");
+
+        // When - 프로필 수정
+        mockMvc.perform(patch("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk());
+
+        // Then - 프로필 조회로 변경사항 확인
+        mockMvc.perform(get("/api/v1/users/me/profile")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.nickName").value("변경된닉네임"))
+                .andExpect(jsonPath("$.data.description").value("변경된 자기소개"))
+                .andExpect(jsonPath("$.data.email").value("test@example.com")) // 변경되지 않음
+                .andExpect(jsonPath("$.data.profileImage").value("profile.jpg")); // 변경되지 않음
+    }
+}

--- a/src/test/java/com/techfork/domain/user/service/UserCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/user/service/UserCommandServiceTest.java
@@ -2,18 +2,21 @@ package com.techfork.domain.user.service;
 
 import com.techfork.domain.user.dto.OnboardingRequest;
 import com.techfork.domain.user.dto.SaveInterestRequest;
+import com.techfork.domain.user.dto.UpdateUserProfileRequest;
 import com.techfork.domain.user.dto.UserInterestDto;
 import com.techfork.domain.user.entity.User;
 import com.techfork.domain.user.enums.SocialType;
 import com.techfork.domain.user.exception.UserErrorCode;
 import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -179,5 +182,102 @@ class UserCommandServiceTest {
         // Then
         assertThat(mockUser.getNickName()).isEqualTo("풀스택개발자");
         verify(interestCommandService, times(1)).saveUserInterests(eq(mockUser), any(SaveInterestRequest.class));
+    }
+
+    // ===== 프로필 수정 테스트 =====
+
+    private User testUser;
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = 1L;
+        testUser = User.createSocialUser(SocialType.KAKAO, "socialId123", "test@example.com", "profile.jpg");
+        testUser.updateUser("테스트유저", "test@example.com", "백엔드 개발자입니다.");
+        ReflectionTestUtils.setField(testUser, "id", userId);
+    }
+
+    @Test
+    @DisplayName("프로필 수정 성공 - 닉네임만 수정")
+    void updateUserProfile_Success_OnlyNickName() {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest("새로운닉네임", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+        // When
+        userCommandService.updateUserProfile(userId, request);
+
+        // Then
+        assertThat(testUser.getNickName()).isEqualTo("새로운닉네임");
+        assertThat(testUser.getDescription()).isEqualTo("백엔드 개발자입니다."); // 변경되지 않음
+
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    @DisplayName("프로필 수정 성공 - 자기소개만 수정")
+    void updateUserProfile_Success_OnlyDescription() {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest(null, "새로운 자기소개");
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+        // When
+        userCommandService.updateUserProfile(userId, request);
+
+        // Then
+        assertThat(testUser.getNickName()).isEqualTo("테스트유저"); // 변경되지 않음
+        assertThat(testUser.getDescription()).isEqualTo("새로운 자기소개");
+
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    @DisplayName("프로필 수정 성공 - 닉네임과 자기소개 모두 수정")
+    void updateUserProfile_Success_BothFields() {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest("새닉네임", "새 자기소개");
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+        // When
+        userCommandService.updateUserProfile(userId, request);
+
+        // Then
+        assertThat(testUser.getNickName()).isEqualTo("새닉네임");
+        assertThat(testUser.getDescription()).isEqualTo("새 자기소개");
+
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    @DisplayName("프로필 수정 성공 - 아무것도 수정하지 않음")
+    void updateUserProfile_Success_NoChanges() {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest(null, null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+
+        // When
+        userCommandService.updateUserProfile(userId, request);
+
+        // Then
+        assertThat(testUser.getNickName()).isEqualTo("테스트유저"); // 변경되지 않음
+        assertThat(testUser.getDescription()).isEqualTo("백엔드 개발자입니다."); // 변경되지 않음
+
+        verify(userRepository).findById(userId);
+    }
+
+    @Test
+    @DisplayName("프로필 수정 실패 - 사용자를 찾을 수 없음")
+    void updateUserProfile_Fail_UserNotFound() {
+        // Given
+        UpdateUserProfileRequest request = new UpdateUserProfileRequest("새닉네임", "새 자기소개");
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> userCommandService.updateUserProfile(userId, request))
+                .isInstanceOf(GeneralException.class)
+                .extracting(ex -> ((GeneralException) ex).getCode())
+                .isEqualTo(UserErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository).findById(userId);
     }
 }

--- a/src/test/java/com/techfork/domain/user/service/UserQueryServiceTest.java
+++ b/src/test/java/com/techfork/domain/user/service/UserQueryServiceTest.java
@@ -1,0 +1,91 @@
+package com.techfork.domain.user.service;
+
+import com.techfork.domain.user.converter.UserConverter;
+import com.techfork.domain.user.dto.UserProfileResponse;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.exception.UserErrorCode;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.exception.GeneralException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserQueryServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserConverter userConverter;
+
+    @InjectMocks
+    private UserQueryService userQueryService;
+
+    private User testUser;
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = 1L;
+        testUser = User.createSocialUser(SocialType.KAKAO, "socialId123", "test@example.com", "profile.jpg");
+        testUser.updateUser("테스트유저", "test@example.com", "백엔드 개발자입니다.");
+        ReflectionTestUtils.setField(testUser, "id", userId);
+    }
+
+    @Test
+    @DisplayName("프로필 조회 성공")
+    void getUserProfile_Success() {
+        // Given
+        UserProfileResponse expectedResponse = UserProfileResponse.builder()
+                .profileImage("profile.jpg")
+                .nickName("테스트유저")
+                .email("test@example.com")
+                .description("백엔드 개발자입니다.")
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+        given(userConverter.toUserProfileResponse(testUser)).willReturn(expectedResponse);
+
+        // When
+        UserProfileResponse result = userQueryService.getUserProfile(userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.profileImage()).isEqualTo("profile.jpg");
+        assertThat(result.nickName()).isEqualTo("테스트유저");
+        assertThat(result.email()).isEqualTo("test@example.com");
+        assertThat(result.description()).isEqualTo("백엔드 개발자입니다.");
+
+        verify(userRepository).findById(userId);
+        verify(userConverter).toUserProfileResponse(testUser);
+    }
+
+    @Test
+    @DisplayName("프로필 조회 실패 - 사용자를 찾을 수 없음")
+    void getUserProfile_Fail_UserNotFound() {
+        // Given
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> userQueryService.getUserProfile(userId))
+                .isInstanceOf(GeneralException.class)
+                .extracting(ex -> ((GeneralException) ex).getCode())
+                .isEqualTo(UserErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository).findById(userId);
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
사용자 프로필 조회 및 수정 API 구현

**주요 변경사항:**

### API 엔드포인트
1. **프로필 조회**
   GET /api/v1/users/me/profile
   Response: {
     "profileImage": "profile.jpg",
     "nickName": "테크러버",
     "email": "user@example.com",
     "description": "백엔드 개발자입니다."
   }

2. **프로필 수정**
   PATCH /api/v1/users/me/profile
   Request: {
     "nickName": "새닉네임",      // 선택적
     "description": "새 자기소개"  // 선택적
   }

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #179 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
