### PR TITLE
[improve/#192] 검색 API 컨트롤러 통합

### DIFF
--- a/src/main/java/com/techfork/domain/search/controller/SearchController.java
+++ b/src/main/java/com/techfork/domain/search/controller/SearchController.java
@@ -44,22 +44,24 @@ public class SearchController {
     }
 
 
-    @Operation(summary = "1단계 검색(BM25 + 시맨틱)", description = "검색어를 기반으로 BM25 + k-NN 하이브리드 검색을 수행하고 합산하여 상위 결과를 반환합니다. (개인화 미적용)")
-    @GetMapping("/general")
-    public BaseResponse<List<SearchResult>> searchGeneral(
-            @RequestParam @Parameter(description = "검색어", required = true) String query
-    ) {
-        List<SearchResult> results = searchService.searchGeneral(query);
-        return BaseResponse.of(SuccessCode.OK, results).getBody();
-    }
-
-    @Operation(summary = "2단계 검색(1단계 검색 후보군 추출 -> 순위 조정", description = "검색어를 기반으로 1차 검색(BM25 + k-NN)을 수행한 후보군을 개인화 리랭킹 적용합니다.")
-    @GetMapping("/personalized")
-    public BaseResponse<List<SearchResult>> searchPersonalized(
+    @Operation(
+            summary = "통합 검색",
+            description = "검색어를 기반으로 하이브리드 검색(BM25 + k-NN)을 수행합니다. " +
+                    "인증된 사용자의 경우 개인화 리랭킹이 적용되고, 비인증 사용자는 일반 검색 결과를 반환합니다."
+    )
+    @GetMapping
+    public BaseResponse<List<SearchResult>> search(
             @RequestParam @Parameter(description = "검색어", required = true) String query,
-            @AuthenticationPrincipal UserPrincipal userPrincipal
+            @Parameter(hidden = true) @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-       List<SearchResult> results = searchService.searchPersonalized(query, userPrincipal.getId()) ;
-       return BaseResponse.of(SuccessCode.OK, results).getBody();
+        List<SearchResult> results;
+
+        if (userPrincipal != null) {
+            results = searchService.searchPersonalized(query, userPrincipal.getId());
+        } else {
+            results = searchService.searchGeneral(query);
+        }
+
+        return BaseResponse.of(SuccessCode.OK, results).getBody();
     }
 }

--- a/src/main/java/com/techfork/global/constant/Constants.java
+++ b/src/main/java/com/techfork/global/constant/Constants.java
@@ -21,7 +21,7 @@ public final class Constants {
             "/api/v1/recommendations",
             "/api/v2/posts/**",
             "/api/v1/posts/**",
-            "/api/v1/search/general",
+            "/api/v1/search/**",
             "/api/v1/onboarding/interests"
     };
 


### PR DESCRIPTION
## ❤️ 기능 설명
단순 하이브리드 서치와 사용자 프로필 리랭킹까지 진행하는 서치를
엔드포인트로 구분하는 대신 UserPrinciple의 유무로 구분하였습니다.

이를 통해 프론트에서는 API 하나만 연동해도 2개의 검색을 모두 연동할 수 있습니다.

swagger 테스트 성공 결과 스크린샷 첨부
인증없이 시도 - general 서치
<img width="1341" height="47" alt="image" src="https://github.com/user-attachments/assets/b7d21562-cc10-4850-9131-f6f84ce3dbef" />

인증 포함 시도 - personalized 서치
<img width="1757" height="102" alt="image" src="https://github.com/user-attachments/assets/a03d559b-e27c-470d-8fc5-5522972f1372" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #192 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 프론트의 편의와 명확성을 위해 엔드포인트를 통합하였습니다!

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
