### PR TITLE
[test/#197] 유저 활동 도메인 테스트 코드 작성

### DIFF
--- a/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
@@ -1,0 +1,479 @@
+package com.techfork.domain.activity.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.techfork.domain.activity.dto.BookmarkRequest;
+import com.techfork.domain.activity.dto.ReadPostRequest;
+import com.techfork.domain.activity.dto.SearchHistoryRequest;
+import com.techfork.domain.activity.entity.ReadPost;
+import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.SearchHistory;
+import com.techfork.domain.activity.repository.ReadPostRepository;
+import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.SearchHistoryRepository;
+import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.repository.PostRepository;
+import com.techfork.domain.source.entity.TechBlog;
+import com.techfork.domain.source.repository.TechBlogRepository;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.Role;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.common.IntegrationTestBase;
+import com.techfork.global.security.jwt.JwtDTO;
+import com.techfork.global.security.jwt.JwtUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * ActivityController 통합 테스트
+ */
+class ActivityControllerIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private TechBlogRepository techBlogRepository;
+
+    @Autowired
+    private ReadPostRepository readPostRepository;
+
+    @Autowired
+    private SearchHistoryRepository searchHistoryRepository;
+
+    @Autowired
+    private ScrabPostRepository scrabPostRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    private User testUser;
+    private String accessToken;
+    private Post testPost1;
+    private Post testPost2;
+    private TechBlog testBlog;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자 생성
+        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
+        testUser.updateUser("테스트유저", "test@example.com", "백엔드 개발자입니다.");
+        testUser = userRepository.save(testUser);
+
+        // JWT 토큰 생성
+        JwtDTO tokens = jwtUtil.generateTokens(testUser.getId(), Role.USER);
+        accessToken = tokens.accessToken();
+
+        // 테스트 블로그 생성
+        testBlog = TechBlog.builder()
+                .companyName("테스트회사")
+                .blogUrl("https://test.com")
+                .rssUrl("https://test.com/rss")
+                .logoUrl("https://test.com/logo.png")
+                .build();
+        testBlog = techBlogRepository.save(testBlog);
+
+        // 테스트 게시글 생성
+        testPost1 = Post.builder()
+                .title("테스트 게시글 1")
+                .fullContent("게시글 1의 전체 내용입니다.")
+                .plainContent("게시글 1의 내용")
+                .company("테스트회사")
+                .url("https://test.com/post/1")
+                .publishedAt(LocalDateTime.now().minusDays(1))
+                .crawledAt(LocalDateTime.now())
+                .techBlog(testBlog)
+                .build();
+        testPost1 = postRepository.save(testPost1);
+
+        testPost2 = Post.builder()
+                .title("테스트 게시글 2")
+                .fullContent("게시글 2의 전체 내용입니다.")
+                .plainContent("게시글 2의 내용")
+                .company("테스트회사")
+                .url("https://test.com/post/2")
+                .publishedAt(LocalDateTime.now().minusDays(2))
+                .crawledAt(LocalDateTime.now())
+                .techBlog(testBlog)
+                .build();
+        testPost2 = postRepository.save(testPost2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        readPostRepository.deleteAll();
+        searchHistoryRepository.deleteAll();
+        scrabPostRepository.deleteAll();
+        postRepository.deleteAll();
+        techBlogRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    // ===== 읽은 게시글 저장 테스트 =====
+
+    @Test
+    @DisplayName("읽은 게시글 저장 성공 - 처음 읽는 경우 조회수 증가")
+    void saveReadPost_Success_FirstRead() throws Exception {
+        // Given
+        Long initialViewCount = testPost1.getViewCount();
+        ReadPostRequest request = new ReadPostRequest(
+                testPost1.getId(),
+                LocalDateTime.now(),
+                300
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB 검증
+        List<ReadPost> readPosts = readPostRepository.findAll();
+        assertThat(readPosts).hasSize(1);
+        assertThat(readPosts.get(0).getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(readPosts.get(0).getPost().getId()).isEqualTo(testPost1.getId());
+        assertThat(readPosts.get(0).getReadDurationSeconds()).isEqualTo(300);
+
+        // 조회수 증가 확인
+        Post updatedPost = postRepository.findById(testPost1.getId()).orElseThrow();
+        assertThat(updatedPost.getViewCount()).isEqualTo(initialViewCount + 1);
+    }
+
+    // TODO: unique 제약조건 제거 후 활성화
+    // ReadPost 엔티티의 unique 제약조건(user_id, post_id)으로 인해 중복 저장 불가
+    // 제약조건 제거 이슈: feat/#164
+//    @Test
+//    @DisplayName("읽은 게시글 저장 성공 - 이미 읽은 경우 조회수 증가하지 않음")
+//    void saveReadPost_Success_AlreadyRead() throws Exception {
+//        // Given - 이미 읽은 기록 생성
+//        ReadPost existingReadPost = ReadPost.create(testUser, testPost1, LocalDateTime.now().minusHours(1), 200);
+//        readPostRepository.save(existingReadPost);
+//
+//        Long currentViewCount = testPost1.getViewCount();
+//        ReadPostRequest request = new ReadPostRequest(
+//                testPost1.getId(),
+//                LocalDateTime.now(),
+//                400
+//        );
+//
+//        // When & Then
+//        mockMvc.perform(post("/api/v1/activities/read-posts")
+//                        .header("Authorization", "Bearer " + accessToken)
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(objectMapper.writeValueAsString(request)))
+//                .andDo(print())
+//                .andExpect(status().isCreated())
+//                .andExpect(jsonPath("$.isSuccess").value(true));
+//
+//        // DB 검증 - 읽은 기록은 추가되지만 조회수는 증가하지 않음
+//        List<ReadPost> readPosts = readPostRepository.findAll();
+//        assertThat(readPosts).hasSize(2);
+//
+//        Post updatedPost = postRepository.findById(testPost1.getId()).orElseThrow();
+//        assertThat(updatedPost.getViewCount()).isEqualTo(currentViewCount);
+//    }
+
+    @Test
+    @DisplayName("읽은 게시글 저장 실패 - 존재하지 않는 게시글")
+    void saveReadPost_Fail_PostNotFound() throws Exception {
+        // Given
+        ReadPostRequest request = new ReadPostRequest(
+                99999L,
+                LocalDateTime.now(),
+                300
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    // ===== 검색 히스토리 저장 테스트 =====
+
+    @Test
+    @DisplayName("검색 히스토리 저장 성공")
+    void saveSearchHistory_Success() throws Exception {
+        // Given
+        SearchHistoryRequest request = new SearchHistoryRequest(
+                "Spring Boot",
+                LocalDateTime.now()
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/searches")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB 검증
+        List<SearchHistory> searchHistories = searchHistoryRepository.findAll();
+        assertThat(searchHistories).hasSize(1);
+        assertThat(searchHistories.get(0).getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(searchHistories.get(0).getSearchWord()).isEqualTo("Spring Boot");
+    }
+
+    @Test
+    @DisplayName("검색 히스토리 저장 성공 - 여러 개 저장")
+    void saveSearchHistory_Success_Multiple() throws Exception {
+        // Given
+        SearchHistoryRequest request1 = new SearchHistoryRequest("Spring Boot", LocalDateTime.now());
+        SearchHistoryRequest request2 = new SearchHistoryRequest("Java", LocalDateTime.now());
+        SearchHistoryRequest request3 = new SearchHistoryRequest("Kotlin", LocalDateTime.now());
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/searches")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request1)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/activities/searches")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request2)))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/activities/searches")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request3)))
+                .andExpect(status().isCreated());
+
+        // DB 검증
+        List<SearchHistory> searchHistories = searchHistoryRepository.findAll();
+        assertThat(searchHistories).hasSize(3);
+    }
+
+    // ===== 북마크 추가 테스트 =====
+
+    @Test
+    @DisplayName("북마크 추가 성공")
+    void addBookmark_Success() throws Exception {
+        // Given
+        BookmarkRequest request = new BookmarkRequest(testPost1.getId());
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB 검증
+        List<ScrabPost> bookmarks = scrabPostRepository.findAll();
+        assertThat(bookmarks).hasSize(1);
+        assertThat(bookmarks.get(0).getUser().getId()).isEqualTo(testUser.getId());
+        assertThat(bookmarks.get(0).getPost().getId()).isEqualTo(testPost1.getId());
+    }
+
+    @Test
+    @DisplayName("북마크 추가 실패 - 이미 북마크한 게시글")
+    void addBookmark_Fail_AlreadyExists() throws Exception {
+        // Given - 이미 북마크 생성
+        ScrabPost existingBookmark = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
+        scrabPostRepository.save(existingBookmark);
+
+        BookmarkRequest request = new BookmarkRequest(testPost1.getId());
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("ACTIVITY409_1"));
+    }
+
+    @Test
+    @DisplayName("북마크 추가 실패 - 존재하지 않는 게시글")
+    void addBookmark_Fail_PostNotFound() throws Exception {
+        // Given
+        BookmarkRequest request = new BookmarkRequest(99999L);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    // ===== 북마크 삭제 테스트 =====
+
+    @Test
+    @DisplayName("북마크 삭제 성공")
+    void deleteBookmark_Success() throws Exception {
+        // Given - 북마크 생성
+        ScrabPost bookmark = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
+        scrabPostRepository.save(bookmark);
+
+        BookmarkRequest request = new BookmarkRequest(testPost1.getId());
+
+        // When & Then
+        mockMvc.perform(delete("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB 검증 - 삭제되었는지 확인
+        List<ScrabPost> bookmarks = scrabPostRepository.findAll();
+        assertThat(bookmarks).isEmpty();
+    }
+
+    @Test
+    @DisplayName("북마크 삭제 실패 - 북마크가 존재하지 않음")
+    void deleteBookmark_Fail_NotFound() throws Exception {
+        // Given - 북마크 없음
+        BookmarkRequest request = new BookmarkRequest(testPost1.getId());
+
+        // When & Then
+        mockMvc.perform(delete("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.code").value("ACTIVITY404_1"));
+    }
+
+    // ===== 북마크 목록 조회 테스트 =====
+
+    @Test
+    @DisplayName("북마크 목록 조회 성공 - 빈 목록")
+    void getBookmarks_Success_Empty() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.bookmarks").isArray())
+                .andExpect(jsonPath("$.data.bookmarks").isEmpty())
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("북마크 목록 조회 성공 - 여러 개")
+    void getBookmarks_Success_Multiple() throws Exception {
+        // Given - 여러 개의 북마크 생성
+        ScrabPost bookmark1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now().minusHours(1));
+        ScrabPost bookmark2 = ScrabPost.create(testUser, testPost2, LocalDateTime.now());
+        scrabPostRepository.save(bookmark1);
+        scrabPostRepository.save(bookmark2);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.bookmarks").isArray())
+                .andExpect(jsonPath("$.data.bookmarks.length()").value(2))
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("북마크 목록 조회 성공 - 커서 기반 페이징")
+    void getBookmarks_Success_WithCursor() throws Exception {
+        // Given - 여러 개의 북마크 생성
+        ScrabPost bookmark1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now().minusHours(2));
+        ScrabPost bookmark2 = ScrabPost.create(testUser, testPost2, LocalDateTime.now().minusHours(1));
+        scrabPostRepository.save(bookmark1);
+        scrabPostRepository.save(bookmark2);
+
+        // When & Then - 첫 페이지 조회
+        mockMvc.perform(get("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "1"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.bookmarks.length()").value(1))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.lastBookmarkId").exists());
+    }
+
+    // ===== 통합 시나리오 테스트 =====
+
+    @Test
+    @DisplayName("통합 시나리오 - 북마크 추가 후 조회 후 삭제")
+    void integrationScenario_AddGetDeleteBookmark() throws Exception {
+        // 1. 북마크 추가
+        BookmarkRequest addRequest = new BookmarkRequest(testPost1.getId());
+        mockMvc.perform(post("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(addRequest)))
+                .andExpect(status().isCreated());
+
+        // 2. 북마크 목록 조회
+        mockMvc.perform(get("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bookmarks.length()").value(1))
+                .andExpect(jsonPath("$.data.bookmarks[0].postId").value(testPost1.getId()));
+
+        // 3. 북마크 삭제
+        BookmarkRequest deleteRequest = new BookmarkRequest(testPost1.getId());
+        mockMvc.perform(delete("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(deleteRequest)))
+                .andExpect(status().isOk());
+
+        // 4. 삭제 후 목록 조회 - 빈 목록
+        mockMvc.perform(get("/api/v1/activities/bookmarks")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.bookmarks").isEmpty());
+    }
+}

--- a/src/test/java/com/techfork/domain/activity/repository/ReadPostRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/activity/repository/ReadPostRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.techfork.domain.activity.repository;
+
+import com.techfork.domain.activity.entity.ReadPost;
+import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.repository.PostRepository;
+import com.techfork.domain.source.entity.TechBlog;
+import com.techfork.domain.source.repository.TechBlogRepository;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ReadPostRepositoryTest {
+
+    @Autowired
+    private ReadPostRepository readPostRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private TechBlogRepository techBlogRepository;
+
+    private User testUser;
+    private Post testPost1;
+    private Post testPost2;
+    private TechBlog testBlog;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
+        testUser = userRepository.save(testUser);
+
+        testBlog = TechBlog.builder()
+                .companyName("테스트회사")
+                .blogUrl("https://test.com")
+                .rssUrl("https://test.com/rss")
+                .build();
+        testBlog = techBlogRepository.save(testBlog);
+
+        testPost1 = Post.builder()
+                .title("테스트 게시글 1")
+                .fullContent("전체 내용")
+                .plainContent("내용")
+                .company("테스트회사")
+                .url("https://test.com/post/1")
+                .publishedAt(LocalDateTime.now())
+                .crawledAt(LocalDateTime.now())
+                .techBlog(testBlog)
+                .build();
+        testPost1 = postRepository.save(testPost1);
+
+        testPost2 = Post.builder()
+                .title("테스트 게시글 2")
+                .fullContent("전체 내용 2")
+                .plainContent("내용 2")
+                .company("테스트회사")
+                .url("https://test.com/post/2")
+                .publishedAt(LocalDateTime.now())
+                .crawledAt(LocalDateTime.now())
+                .techBlog(testBlog)
+                .build();
+        testPost2 = postRepository.save(testPost2);
+    }
+
+    @AfterEach
+    void tearDown() {
+        readPostRepository.deleteAll();
+        postRepository.deleteAll();
+        techBlogRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("최근 읽은 게시글 조회 - readDurationSeconds 10초 초과 필터링")
+    void findRecentReadPostsByUserIdWithMinDuration() {
+        // Given
+        ReadPost readPost1 = ReadPost.create(testUser, testPost1, LocalDateTime.now().minusHours(2), 5);
+        ReadPost readPost2 = ReadPost.create(testUser, testPost2, LocalDateTime.now(), null);
+        readPostRepository.saveAll(List.of(readPost1, readPost2));
+
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        // When
+        List<ReadPost> result = readPostRepository.findRecentReadPostsByUserIdWithMinDuration(testUser.getId(), pageRequest);
+
+        // Then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getReadDurationSeconds()).isNull();
+    }
+}

--- a/src/test/java/com/techfork/domain/activity/repository/ScrabPostRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/activity/repository/ScrabPostRepositoryTest.java
@@ -1,0 +1,137 @@
+package com.techfork.domain.activity.repository;
+
+import com.techfork.domain.activity.dto.BookmarkDto;
+import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.repository.PostRepository;
+import com.techfork.domain.source.entity.TechBlog;
+import com.techfork.domain.source.repository.TechBlogRepository;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class ScrabPostRepositoryTest {
+
+    @Autowired
+    private ScrabPostRepository scrabPostRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private TechBlogRepository techBlogRepository;
+
+    private User testUser;
+    private Post testPost1;
+    private Post testPost2;
+    private Post testPost3;
+    private TechBlog testBlog;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
+        testUser = userRepository.save(testUser);
+
+        testBlog = TechBlog.builder()
+                .companyName("테스트회사")
+                .blogUrl("https://test.com")
+                .rssUrl("https://test.com/rss")
+                .logoUrl("https://test.com/logo.png")
+                .build();
+        testBlog = techBlogRepository.save(testBlog);
+
+        testPost1 = Post.builder()
+                .title("게시글 1")
+                .fullContent("내용 1")
+                .plainContent("내용 1")
+                .company("테스트회사")
+                .url("https://test.com/post/1")
+                .publishedAt(LocalDateTime.now().minusDays(3))
+                .crawledAt(LocalDateTime.now())
+                .techBlog(testBlog)
+                .build();
+        testPost1 = postRepository.save(testPost1);
+
+        testPost2 = Post.builder()
+                .title("게시글 2")
+                .fullContent("내용 2")
+                .plainContent("내용 2")
+                .company("테스트회사")
+                .url("https://test.com/post/2")
+                .publishedAt(LocalDateTime.now().minusDays(2))
+                .crawledAt(LocalDateTime.now())
+                .techBlog(testBlog)
+                .build();
+        testPost2 = postRepository.save(testPost2);
+
+        testPost3 = Post.builder()
+                .title("게시글 3")
+                .fullContent("내용 3")
+                .plainContent("내용 3")
+                .company("테스트회사")
+                .url("https://test.com/post/3")
+                .publishedAt(LocalDateTime.now().minusDays(1))
+                .crawledAt(LocalDateTime.now())
+                .techBlog(testBlog)
+                .build();
+        testPost3 = postRepository.save(testPost3);
+    }
+
+    @AfterEach
+    void tearDown() {
+        scrabPostRepository.deleteAll();
+        postRepository.deleteAll();
+        techBlogRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("북마크 목록 조회 - 커서 기반 페이징")
+    void findBookmarksWithCursor() {
+        // Given
+        ScrabPost scrab1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now().minusHours(3));
+        ScrabPost scrab2 = ScrabPost.create(testUser, testPost2, LocalDateTime.now().minusHours(2));
+        ScrabPost scrab3 = ScrabPost.create(testUser, testPost3, LocalDateTime.now().minusHours(1));
+        scrab1 = scrabPostRepository.save(scrab1);
+        scrab2 = scrabPostRepository.save(scrab2);
+        scrab3 = scrabPostRepository.save(scrab3);
+
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        // When - 커서 없이 첫 페이지
+        List<BookmarkDto> firstPage = scrabPostRepository.findBookmarksWithCursor(testUser, null, pageRequest);
+
+        // Then
+        assertThat(firstPage).hasSize(3);
+        assertThat(firstPage.get(0).postId()).isEqualTo(testPost3.getId());
+        assertThat(firstPage.get(1).postId()).isEqualTo(testPost2.getId());
+        assertThat(firstPage.get(2).postId()).isEqualTo(testPost1.getId());
+
+        // When - 커서를 사용한 다음 페이지
+        Long lastBookmarkId = scrab3.getId();
+        List<BookmarkDto> nextPage = scrabPostRepository.findBookmarksWithCursor(testUser, lastBookmarkId, pageRequest);
+
+        // Then
+        assertThat(nextPage).hasSize(2);
+        assertThat(nextPage.get(0).postId()).isEqualTo(testPost2.getId());
+        assertThat(nextPage.get(1).postId()).isEqualTo(testPost1.getId());
+    }
+}

--- a/src/test/java/com/techfork/domain/activity/repository/SearchHistoryRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/activity/repository/SearchHistoryRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.techfork.domain.activity.repository;
+
+import com.techfork.domain.activity.entity.SearchHistory;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles("test")
+class SearchHistoryRepositoryTest {
+
+    @Autowired
+    private SearchHistoryRepository searchHistoryRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
+        testUser = userRepository.save(testUser);
+    }
+
+    @AfterEach
+    void tearDown() {
+        searchHistoryRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("최근 검색 히스토리 조회 - 최근 순 정렬")
+    void findRecentSearchHistoriesByUserId() {
+        // Given
+        SearchHistory history1 = SearchHistory.create(testUser, "Spring Boot", LocalDateTime.now().minusHours(3));
+        SearchHistory history2 = SearchHistory.create(testUser, "Java", LocalDateTime.now().minusHours(2));
+        SearchHistory history3 = SearchHistory.create(testUser, "Kotlin", LocalDateTime.now().minusHours(1));
+        searchHistoryRepository.saveAll(List.of(history1, history2, history3));
+
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        // When
+        List<SearchHistory> result = searchHistoryRepository.findRecentSearchHistoriesByUserId(testUser.getId(), pageRequest);
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getSearchWord()).isEqualTo("Kotlin");
+        assertThat(result.get(1).getSearchWord()).isEqualTo("Java");
+        assertThat(result.get(2).getSearchWord()).isEqualTo("Spring Boot");
+    }
+}

--- a/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
@@ -1,13 +1,19 @@
 package com.techfork.domain.activity.service;
 
+import com.techfork.domain.activity.dto.BookmarkRequest;
 import com.techfork.domain.activity.dto.ReadPostRequest;
 import com.techfork.domain.activity.entity.ReadPost;
+import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.exception.ActivityErrorCode;
 import com.techfork.domain.activity.repository.ReadPostRepository;
+import com.techfork.domain.activity.repository.ScrabPostRepository;
 import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.exception.PostErrorCode;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.user.entity.User;
 import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.exception.GeneralException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,15 +25,11 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
-/**
- * ActivityCommandService 단위 테스트
- * - Mockito를 사용해서 의존성을 Mock으로 대체
- * - 실제 DB 없이 빠르게 테스트
- */
 @ExtendWith(MockitoExtension.class)
 class ActivityCommandServiceTest {
 
@@ -39,6 +41,9 @@ class ActivityCommandServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ScrabPostRepository scrabPostRepository;
 
     @InjectMocks
     private ActivityCommandService activityCommandService;
@@ -138,5 +143,91 @@ class ActivityCommandServiceTest {
 
         // 하지만 ReadPost는 저장됨 (읽은 기록은 매번 저장)
         verify(readPostRepository, times(1)).save(any(ReadPost.class));
+    }
+
+    // ===== 북마크 추가 테스트 =====
+
+    @Test
+    @DisplayName("북마크 추가 성공")
+    void addBookmark_Success() {
+        // Given
+        Long userId = 1L;
+        Long postId = 100L;
+        BookmarkRequest request = new BookmarkRequest(postId);
+
+        User mockUser = mock(User.class);
+        TechBlog mockTechBlog = TechBlog.builder()
+                .companyName("테스트회사")
+                .blogUrl("https://test.com")
+                .rssUrl("https://test.com/rss")
+                .build();
+
+        Post mockPost = Post.builder()
+                .title("테스트 제목")
+                .fullContent("내용")
+                .plainContent("내용")
+                .company("테스트회사")
+                .url("https://test.com/post/1")
+                .publishedAt(LocalDateTime.now())
+                .crawledAt(LocalDateTime.now())
+                .techBlog(mockTechBlog)
+                .build();
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(postRepository.findById(postId)).willReturn(Optional.of(mockPost));
+        given(scrabPostRepository.existsByUserAndPost(mockUser, mockPost)).willReturn(false);
+        given(scrabPostRepository.save(any(ScrabPost.class))).willReturn(mock(ScrabPost.class));
+
+        // When
+        activityCommandService.addBookmark(userId, request);
+
+        // Then
+        verify(userRepository, times(1)).findById(userId);
+        verify(postRepository, times(1)).findById(postId);
+        verify(scrabPostRepository, times(1)).existsByUserAndPost(mockUser, mockPost);
+        verify(scrabPostRepository, times(1)).save(any(ScrabPost.class));
+    }
+
+    @Test
+    @DisplayName("북마크 추가 실패 - 이미 북마크한 게시글")
+    void addBookmark_Fail_AlreadyExists() {
+        // Given
+        Long userId = 1L;
+        Long postId = 100L;
+        BookmarkRequest request = new BookmarkRequest(postId);
+
+        User mockUser = mock(User.class);
+        Post mockPost = mock(Post.class);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(postRepository.findById(postId)).willReturn(Optional.of(mockPost));
+        given(scrabPostRepository.existsByUserAndPost(mockUser, mockPost)).willReturn(true);
+
+        // When & Then
+        assertThatThrownBy(() -> activityCommandService.addBookmark(userId, request))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", ActivityErrorCode.BOOKMARK_ALREADY_EXISTS);
+
+        verify(scrabPostRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("북마크 추가 실패 - 존재하지 않는 게시글")
+    void addBookmark_Fail_PostNotFound() {
+        // Given
+        Long userId = 1L;
+        Long postId = 999L;
+        BookmarkRequest request = new BookmarkRequest(postId);
+
+        User mockUser = mock(User.class);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(postRepository.findById(postId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> activityCommandService.addBookmark(userId, request))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", PostErrorCode.POST_NOT_FOUND);
+
+        verify(scrabPostRepository, never()).save(any());
     }
 }

--- a/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
@@ -300,4 +300,45 @@ class ActivityCommandServiceTest {
 
         verify(scrabPostRepository, never()).delete(any());
     }
+
+    @Test
+    @DisplayName("읽은 게시글 저장 실패 - 존재하지 않는 사용자")
+    void saveReadPost_Fail_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        Long postId = 100L;
+        ReadPostRequest request = new ReadPostRequest(postId, LocalDateTime.now(), 300);
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> activityCommandService.saveReadPost(userId, request))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(postRepository, never()).findById(any());
+        verify(readPostRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("읽은 게시글 저장 실패 - 존재하지 않는 게시글")
+    void saveReadPost_Fail_PostNotFound() {
+        // Given
+        Long userId = 1L;
+        Long postId = 999L;
+        User mockUser = mock(User.class);
+        ReadPostRequest request = new ReadPostRequest(postId, LocalDateTime.now(), 300);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(postRepository.findById(postId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> activityCommandService.saveReadPost(userId, request))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", PostErrorCode.POST_NOT_FOUND);
+
+        verify(postRepository, times(1)).findById(postId);
+        verify(readPostRepository, never()).save(any());
+    }
 }

--- a/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
@@ -2,11 +2,14 @@ package com.techfork.domain.activity.service;
 
 import com.techfork.domain.activity.dto.BookmarkRequest;
 import com.techfork.domain.activity.dto.ReadPostRequest;
+import com.techfork.domain.activity.dto.SearchHistoryRequest;
 import com.techfork.domain.activity.entity.ReadPost;
 import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.SearchHistory;
 import com.techfork.domain.activity.exception.ActivityErrorCode;
 import com.techfork.domain.activity.repository.ReadPostRepository;
 import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.SearchHistoryRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.exception.PostErrorCode;
 import com.techfork.domain.post.repository.PostRepository;
@@ -45,6 +48,9 @@ class ActivityCommandServiceTest {
 
     @Mock
     private ScrabPostRepository scrabPostRepository;
+
+    @Mock
+    private SearchHistoryRepository searchHistoryRepository;
 
     @InjectMocks
     private ActivityCommandService activityCommandService;
@@ -341,4 +347,45 @@ class ActivityCommandServiceTest {
         verify(postRepository, times(1)).findById(postId);
         verify(readPostRepository, never()).save(any());
     }
+
+    // ===== 검색 히스토리 테스트 =====
+
+    @Test
+    @DisplayName("검색 히스토리 저장 성공")
+    void saveSearchHistory_Success() {
+        // Given
+        Long userId = 1L;
+        String searchWord = "Spring Boot";
+        LocalDateTime searchedAt = LocalDateTime.now();
+        SearchHistoryRequest request = new SearchHistoryRequest(searchWord, searchedAt);
+
+        User mockUser = mock(User.class);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(searchHistoryRepository.save(any(SearchHistory.class))).willReturn(mock(SearchHistory.class));
+
+        // When
+        activityCommandService.saveSearchHistory(userId, request);
+
+        // Then
+        verify(userRepository, times(1)).findById(userId);
+        verify(searchHistoryRepository, times(1)).save(any(SearchHistory.class));
+    }
+
+    @Test
+    @DisplayName("검색 히스토리 저장 실패 - 존재하지 않는 사용자")
+    void saveSearchHistory_Fail_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        SearchHistoryRequest request = new SearchHistoryRequest("Spring Boot", LocalDateTime.now());
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> activityCommandService.saveSearchHistory(userId, request))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
+
+        verify(searchHistoryRepository, never()).save(any());
+    }
+
 }

--- a/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
@@ -12,6 +12,7 @@ import com.techfork.domain.post.exception.PostErrorCode;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.exception.UserErrorCode;
 import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.exception.GeneralException;
 import org.junit.jupiter.api.DisplayName;
@@ -229,5 +230,74 @@ class ActivityCommandServiceTest {
                 .hasFieldOrPropertyWithValue("code", PostErrorCode.POST_NOT_FOUND);
 
         verify(scrabPostRepository, never()).save(any());
+    }
+
+    // ===== 북마크 삭제 테스트 =====
+
+    @Test
+    @DisplayName("북마크 삭제 성공")
+    void deleteBookmark_Success() {
+        // Given
+        Long userId = 1L;
+        Long postId = 100L;
+        BookmarkRequest request = new BookmarkRequest(postId);
+
+        User mockUser = mock(User.class);
+        Post mockPost = mock(Post.class);
+        ScrabPost mockScrabPost = mock(ScrabPost.class);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(postRepository.findById(postId)).willReturn(Optional.of(mockPost));
+        given(scrabPostRepository.findByUserAndPost(mockUser, mockPost)).willReturn(Optional.of(mockScrabPost));
+
+        // When
+        activityCommandService.deleteBookmark(userId, request);
+
+        // Then
+        verify(userRepository, times(1)).findById(userId);
+        verify(postRepository, times(1)).findById(postId);
+        verify(scrabPostRepository, times(1)).findByUserAndPost(mockUser, mockPost);
+        verify(scrabPostRepository, times(1)).delete(mockScrabPost);
+    }
+
+    @Test
+    @DisplayName("북마크 삭제 실패 - 북마크가 존재하지 않음")
+    void deleteBookmark_Fail_NotFound() {
+        // Given
+        Long userId = 1L;
+        Long postId = 100L;
+        BookmarkRequest request = new BookmarkRequest(postId);
+
+        User mockUser = mock(User.class);
+        Post mockPost = mock(Post.class);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+        given(postRepository.findById(postId)).willReturn(Optional.of(mockPost));
+        given(scrabPostRepository.findByUserAndPost(mockUser, mockPost)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> activityCommandService.deleteBookmark(userId, request))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", ActivityErrorCode.BOOKMARK_NOT_FOUND);
+
+        verify(scrabPostRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("북마크 삭제 실패 - 존재하지 않는 사용자")
+    void deleteBookmark_Fail_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        Long postId = 100L;
+        BookmarkRequest request = new BookmarkRequest(postId);
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> activityCommandService.deleteBookmark(userId, request))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
+
+        verify(scrabPostRepository, never()).delete(any());
     }
 }

--- a/src/test/java/com/techfork/domain/activity/service/ActivityQueryServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityQueryServiceTest.java
@@ -1,0 +1,163 @@
+package com.techfork.domain.activity.service;
+
+import com.techfork.domain.activity.converter.ActivityConverter;
+import com.techfork.domain.activity.dto.BookmarkDto;
+import com.techfork.domain.activity.dto.BookmarkListResponse;
+import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.exception.UserErrorCode;
+import com.techfork.domain.user.repository.UserRepository;
+import com.techfork.global.exception.GeneralException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ActivityQueryServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ScrabPostRepository scrabPostRepository;
+
+    @Mock
+    private ActivityConverter activityConverter;
+
+    @InjectMocks
+    private ActivityQueryService activityQueryService;
+
+    @Test
+    @DisplayName("북마크 목록 조회 성공 - 첫 페이지")
+    void getBookmarks_Success_FirstPage() {
+        // Given
+        Long userId = 1L;
+        Long lastBookmarkId = null;
+        int size = 20;
+
+        User mockUser = mock(User.class);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
+        List<BookmarkDto> mockBookmarks = Arrays.asList(
+                new BookmarkDto(3L, 103L, "게시글3", "https://test.com/3", "회사A", "logo.png", LocalDateTime.now()),
+                new BookmarkDto(2L, 102L, "게시글2", "https://test.com/2", "회사B", "logo.png", LocalDateTime.now()),
+                new BookmarkDto(1L, 101L, "게시글1", "https://test.com/1", "회사C", "logo.png", LocalDateTime.now())
+        );
+        given(scrabPostRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
+                .willReturn(mockBookmarks);
+
+        BookmarkListResponse expectedResponse = new BookmarkListResponse(mockBookmarks, 2L, true);
+        given(activityConverter.toBookmarkListResponse(mockBookmarks, size)).willReturn(expectedResponse);
+
+        // When
+        BookmarkListResponse response = activityQueryService.getBookmarks(userId, lastBookmarkId, size);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.bookmarks()).hasSize(3);
+        assertThat(response.lastBookmarkId()).isEqualTo(2L);
+        assertThat(response.hasNext()).isTrue();
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(scrabPostRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
+        verify(activityConverter, times(1)).toBookmarkListResponse(mockBookmarks, size);
+    }
+
+    @Test
+    @DisplayName("북마크 목록 조회 성공 - 커서 기반 페이징")
+    void getBookmarks_Success_WithCursor() {
+        // Given
+        Long userId = 1L;
+        Long lastBookmarkId = 10L;
+        int size = 20;
+
+        User mockUser = mock(User.class);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
+        List<BookmarkDto> mockBookmarks = Arrays.asList(
+                new BookmarkDto(9L, 109L, "게시글9", "https://test.com/9", "회사A", "logo.png", LocalDateTime.now()),
+                new BookmarkDto(8L, 108L, "게시글8", "https://test.com/8", "회사B", "logo.png", LocalDateTime.now())
+        );
+        given(scrabPostRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
+                .willReturn(mockBookmarks);
+
+        BookmarkListResponse expectedResponse = new BookmarkListResponse(mockBookmarks, null, false);
+        given(activityConverter.toBookmarkListResponse(mockBookmarks, size)).willReturn(expectedResponse);
+
+        // When
+        BookmarkListResponse response = activityQueryService.getBookmarks(userId, lastBookmarkId, size);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.bookmarks()).hasSize(2);
+        assertThat(response.lastBookmarkId()).isNull();
+        assertThat(response.hasNext()).isFalse();
+
+        verify(scrabPostRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
+    }
+
+    @Test
+    @DisplayName("북마크 목록 조회 실패 - 존재하지 않는 사용자")
+    void getBookmarks_Fail_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        Long lastBookmarkId = null;
+        int size = 20;
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // When & Then
+        assertThatThrownBy(() -> activityQueryService.getBookmarks(userId, lastBookmarkId, size))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
+
+        verify(userRepository, times(1)).findById(userId);
+        verify(scrabPostRepository, never()).findBookmarksWithCursor(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("북마크 목록 조회 성공 - 빈 목록")
+    void getBookmarks_Success_EmptyList() {
+        // Given
+        Long userId = 1L;
+        Long lastBookmarkId = null;
+        int size = 20;
+
+        User mockUser = mock(User.class);
+        given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
+        List<BookmarkDto> emptyBookmarks = List.of();
+        given(scrabPostRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
+                .willReturn(emptyBookmarks);
+
+        BookmarkListResponse expectedResponse = new BookmarkListResponse(emptyBookmarks, null, false);
+        given(activityConverter.toBookmarkListResponse(emptyBookmarks, size)).willReturn(expectedResponse);
+
+        // When
+        BookmarkListResponse response = activityQueryService.getBookmarks(userId, lastBookmarkId, size);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.bookmarks()).isEmpty();
+        assertThat(response.lastBookmarkId()).isNull();
+        assertThat(response.hasNext()).isFalse();
+
+        verify(scrabPostRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
Activity 도메인의 테스트 코드를 작성했습니다.

### 작성한 테스트

#### 1. 서비스 단위 테스트 (총 17개)
**ActivityQueryServiceTest** (4개)
- 북마크 목록 조회 (첫 페이지, 커서 페이징, 빈 목록, 사용자 없음 예외)

**ActivityCommandServiceTest** (13개)
- 읽은 게시글 저장 (첫 읽기/조회수 증가, 이미 읽음, 예외 처리 2개)
- 검색 히스토리 저장 (성공, 예외 처리)
- 북마크 추가 (성공, 중복 예외, 게시글 없음 예외)
- 북마크 삭제 (성공, 북마크 없음 예외, 사용자 없음 예외)

#### 2. 리포지토리 테스트 (총 3개, 커스텀 쿼리만)
**ReadPostRepositoryTest** (1개)
- `findRecentReadPostsByUserIdWithMinDuration`: 10초 초과 필터링 + null 허용 복잡한 조건

**SearchHistoryRepositoryTest** (1개)
- `findRecentSearchHistoriesByUserId`: 최근 순 정렬 확인

**ScrabPostRepositoryTest** (1개)
- `findBookmarksWithCursor`: DTO 프로젝션 + 커서 기반 페이징 (첫 페이지, 다음 페이지)

#### 3. 통합 테스트 (총 10개)
**ActivityControllerIntegrationTest**
- 읽은 게시글 저장 (첫 읽기 시 조회수 증가, 게시글 없음 예외)
- 검색 히스토리 저장 (성공, 여러 개)
- 북마크 추가 (성공, 중복 예외, 게시글 없음 예외)
- 북마크 삭제 (성공, 북마크 없음 예외)
- 북마크 목록 조회 (빈 목록, 여러 개, 커서 페이징)
- 통합 시나리오 (추가→조회→삭제)

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #197 
<br>
<br>


## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
