### PR TITLE
[improve/#201] ReadPost 엔티티 {user_id, post_id} 유니크 제약 제거

### DIFF
--- a/src/main/java/com/techfork/domain/activity/entity/ReadPost.java
+++ b/src/main/java/com/techfork/domain/activity/entity/ReadPost.java
@@ -13,12 +13,7 @@ import org.springframework.data.annotation.PersistenceCreator;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(
-        name = "read_posts",
-        uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "post_id"})
-        }
-)
+@Table(name = "read_posts")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ReadPost extends BaseEntity {

--- a/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
@@ -166,39 +166,36 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
         assertThat(updatedPost.getViewCount()).isEqualTo(initialViewCount + 1);
     }
 
-    // TODO: unique 제약조건 제거 후 활성화
-    // ReadPost 엔티티의 unique 제약조건(user_id, post_id)으로 인해 중복 저장 불가
-    // 제약조건 제거 이슈: feat/#164
-//    @Test
-//    @DisplayName("읽은 게시글 저장 성공 - 이미 읽은 경우 조회수 증가하지 않음")
-//    void saveReadPost_Success_AlreadyRead() throws Exception {
-//        // Given - 이미 읽은 기록 생성
-//        ReadPost existingReadPost = ReadPost.create(testUser, testPost1, LocalDateTime.now().minusHours(1), 200);
-//        readPostRepository.save(existingReadPost);
-//
-//        Long currentViewCount = testPost1.getViewCount();
-//        ReadPostRequest request = new ReadPostRequest(
-//                testPost1.getId(),
-//                LocalDateTime.now(),
-//                400
-//        );
-//
-//        // When & Then
-//        mockMvc.perform(post("/api/v1/activities/read-posts")
-//                        .header("Authorization", "Bearer " + accessToken)
-//                        .contentType(MediaType.APPLICATION_JSON)
-//                        .content(objectMapper.writeValueAsString(request)))
-//                .andDo(print())
-//                .andExpect(status().isCreated())
-//                .andExpect(jsonPath("$.isSuccess").value(true));
-//
-//        // DB 검증 - 읽은 기록은 추가되지만 조회수는 증가하지 않음
-//        List<ReadPost> readPosts = readPostRepository.findAll();
-//        assertThat(readPosts).hasSize(2);
-//
-//        Post updatedPost = postRepository.findById(testPost1.getId()).orElseThrow();
-//        assertThat(updatedPost.getViewCount()).isEqualTo(currentViewCount);
-//    }
+    @Test
+    @DisplayName("읽은 게시글 저장 성공 - 이미 읽은 경우 조회수 증가하지 않음")
+    void saveReadPost_Success_AlreadyRead() throws Exception {
+        // Given - 이미 읽은 기록 생성
+        ReadPost existingReadPost = ReadPost.create(testUser, testPost1, LocalDateTime.now().minusHours(1), 200);
+        readPostRepository.save(existingReadPost);
+
+        Long currentViewCount = testPost1.getViewCount();
+        ReadPostRequest request = new ReadPostRequest(
+                testPost1.getId(),
+                LocalDateTime.now(),
+                400
+        );
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        // DB 검증 - 읽은 기록은 추가되지만 조회수는 증가하지 않음
+        List<ReadPost> readPosts = readPostRepository.findAll();
+        assertThat(readPosts).hasSize(2);
+
+        Post updatedPost = postRepository.findById(testPost1.getId()).orElseThrow();
+        assertThat(updatedPost.getViewCount()).isEqualTo(currentViewCount);
+    }
 
     @Test
     @DisplayName("읽은 게시글 저장 실패 - 존재하지 않는 게시글")

--- a/src/test/java/com/techfork/domain/activity/repository/ReadPostRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/activity/repository/ReadPostRepositoryTest.java
@@ -105,4 +105,23 @@ class ReadPostRepositoryTest {
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getReadDurationSeconds()).isNull();
     }
+
+    @Test
+    @DisplayName("같은 게시글 중복 저장 가능 - unique 제약조건 없음")
+    void saveDuplicateReadPost_Success() {
+        // Given
+        ReadPost readPost1 = ReadPost.create(testUser, testPost1, LocalDateTime.now().minusHours(1), 100);
+        ReadPost readPost2 = ReadPost.create(testUser, testPost1, LocalDateTime.now(), 200);
+
+        // When
+        readPostRepository.save(readPost1);
+        readPostRepository.save(readPost2);
+        readPostRepository.flush();
+
+        // Then
+        List<ReadPost> all = readPostRepository.findAll();
+        assertThat(all).hasSize(2);
+        assertThat(all).allMatch(rp -> rp.getPost().getId().equals(testPost1.getId()));
+        assertThat(all).allMatch(rp -> rp.getUser().getId().equals(testUser.getId()));
+    }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
ReadPost 엔티티에 있던 같은 게시글 저장 방지를 위한 unique 제약을 제거하여
유저 프로필에 유저의 관심사가 더 잘 담기도록 변경하였습니다.

그리고 관련 로직을 테스트 코드로 작성하였습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #201 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
