### PR TITLE
[fix/#206] 게시글 조회 API에서 섬네일 필드 누락 해결

### DIFF
--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -116,6 +116,7 @@ public class PostQueryService {
                         .company(post.company())
                         .url(post.url())
                         .logoUrl(post.logoUrl())
+                        .thumbnailUrl(post.thumbnailUrl())
                         .publishedAt(post.publishedAt())
                         .viewCount(post.viewCount())
                         .keywords(keywordMap.getOrDefault(post.id(), List.of()))


### PR DESCRIPTION
## ❤️ 기능 설명
게시글 조회 API에서 Post와 Keyword를 DTO로 변화하는 과정에서 thumbnail 필드 누락되었습니다.
이를 해결하였습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1675" height="471" alt="image" src="https://github.com/user-attachments/assets/f6755a28-2f5c-46e5-bff7-fc8f001cbccb" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #206 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
