### PR TITLE
[improve/#209] 엔티티 빌더에서 전체 필드를 파라미터로 갖도록 변경

### DIFF
--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -71,11 +71,12 @@ public class Post extends BaseEntity {
 
     @PersistenceCreator
     @Builder
-    Post(String title, String fullContent, String plainContent, String company, String logoUrl, String thumbnailUrl,
+    Post(String title, String fullContent, String plainContent, String summary, String company, String logoUrl, String thumbnailUrl,
                  String url, LocalDateTime publishedAt, LocalDateTime crawledAt, LocalDateTime embeddedAt, TechBlog techBlog) {
         this.title = title;
         this.fullContent = fullContent;
         this.plainContent = plainContent;
+        this.summary = summary;
         this.company = company;
         this.logoUrl = logoUrl;
         this.thumbnailUrl = thumbnailUrl;

--- a/src/main/java/com/techfork/domain/recommendation/entity/RecommendationHistory.java
+++ b/src/main/java/com/techfork/domain/recommendation/entity/RecommendationHistory.java
@@ -56,14 +56,16 @@ public class RecommendationHistory extends BaseEntity {
     @PersistenceCreator
     @Builder
     RecommendationHistory(User user, Post post, Double similarityScore,
-                                   Double mmrScore, Integer rankOrder, LocalDateTime recommendedAt) {
+                                   Double mmrScore, Integer rankOrder, LocalDateTime recommendedAt,
+                                   Boolean isClicked, LocalDateTime clickedAt) {
         this.user = user;
         this.post = post;
         this.similarityScore = similarityScore;
         this.mmrScore = mmrScore;
         this.rankOrder = rankOrder;
         this.recommendedAt = recommendedAt;
-        this.isClicked = false;
+        this.isClicked = isClicked != null ? isClicked : false;
+        this.clickedAt = clickedAt;
     }
 
     /**


### PR DESCRIPTION
## ❤️ 기능 설명
Post 엔티티와 RecommendationHistory 엔티티에서 빌더에 누락되었던 필드들을 추가하였습니다.
이를 통해 빌더를 통해 모든 필드를 설정하여 생성할 수 있고, JPA의 객체 생성 최적화 로직이 정상적으로 작동합니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #209 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
