### PR TITLE
[fix/#212] 소셜 로그인 중 baseUrl 값을 그대로 가져오는 문제 해결

### DIFF
--- a/src/main/java/com/techfork/global/security/config/AppleOAuth2Config.java
+++ b/src/main/java/com/techfork/global/security/config/AppleOAuth2Config.java
@@ -29,11 +29,17 @@ public class AppleOAuth2Config {
             // 기본 필수 파라미터 세팅
             parameters.add(OAuth2ParameterNames.GRANT_TYPE, grantRequest.getGrantType().getValue());
             parameters.add(OAuth2ParameterNames.CODE, grantRequest.getAuthorizationExchange().getAuthorizationResponse().getCode());
-            parameters.add(OAuth2ParameterNames.REDIRECT_URI, grantRequest.getClientRegistration().getRedirectUri());
+
+            // Authorization Request에서 실제 사용된 redirect_uri 가져오기 (템플릿이 아닌 실제 값)
+            String redirectUri = grantRequest.getAuthorizationExchange()
+                    .getAuthorizationRequest()
+                    .getRedirectUri();
+            parameters.add(OAuth2ParameterNames.REDIRECT_URI, redirectUri);
             parameters.add(OAuth2ParameterNames.CLIENT_ID, grantRequest.getClientRegistration().getClientId());
 
+            String registrationId = grantRequest.getClientRegistration().getRegistrationId();
             // Apple일 때만 client-secret 동적 생성
-            if ("apple".equals(grantRequest.getClientRegistration().getRegistrationId())) {
+            if ("apple".equals(registrationId)) {
                 String clientSecret = appleClientSecretGenerator.generateClientSecret();
                 parameters.add(OAuth2ParameterNames.CLIENT_SECRET, clientSecret);
                 log.debug("Apple client-secret generated dynamically");


### PR DESCRIPTION
## ❤️ 기능 설명
OAuth2 Token Exchange 단계에서 redirect_uri 불일치로 인한 카카오 로그인 실패 문제를 수정했습니다.

### 수정 내용
- `AppleOAuth2Config.java`에서 Token Exchange 요청 시 redirect_uri를 설정하는 로직 개선
- 기존: `getClientRegistration().getRedirectUri()` 사용 → 템플릿 문자열 반환
- 수정: `getAuthorizationExchange().getAuthorizationRequest().getRedirectUri()` 사용 → 실제 사용된 URI 반환

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #212 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
