### PR TITLE
[improve/#217] 게시글 조회 시 북마크 여부도 반환하도록 변경

### DIFF
--- a/src/main/java/com/techfork/domain/activity/repository/ScrabPostRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/ScrabPostRepository.java
@@ -37,4 +37,12 @@ public interface ScrabPostRepository extends JpaRepository<ScrabPost, Long> {
 
     @Query("SELECT sp FROM ScrabPost sp JOIN FETCH sp.post WHERE sp.user.id = :userId ORDER BY sp.scrappedAt DESC")
     List<ScrabPost> findRecentScrapPostsByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+            SELECT sp.post.id
+            FROM ScrabPost sp
+            WHERE sp.user.id = :userId
+            AND sp.post.id IN :postIds
+            """)
+    List<Long> findBookmarkedPostIds(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/com/techfork/domain/post/controller/PostController.java
+++ b/src/main/java/com/techfork/domain/post/controller/PostController.java
@@ -78,14 +78,17 @@ public class PostController {
 
     @Operation(
             summary = "게시글 상세 조회",
-            description = "특정 게시글의 상세 정보를 조회합니다."
+            description = "특정 게시글의 상세 정보를 조회합니다. 로그인 시 북마크 여부가 포함됩니다."
     )
     @GetMapping("/{postId}")
     public ResponseEntity<BaseResponse<PostDetailDto>> getPostDetail(
             @Parameter(description = "게시글 ID")
-            @PathVariable Long postId
+            @PathVariable Long postId,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        PostDetailDto response = postQueryService.getPostDetail(postId);
+        Long userId = userPrincipal != null ? userPrincipal.getId() : null;
+        PostDetailDto response = postQueryService.getPostDetail(postId, userId);
         return BaseResponse.of(SuccessCode.OK, response);
     }
 }

--- a/src/main/java/com/techfork/domain/post/controller/PostController.java
+++ b/src/main/java/com/techfork/domain/post/controller/PostController.java
@@ -7,12 +7,14 @@ import com.techfork.domain.post.enums.EPostSortType;
 import com.techfork.domain.post.service.PostQueryService;
 import com.techfork.global.common.code.SuccessCode;
 import com.techfork.global.response.BaseResponse;
+import com.techfork.global.security.oauth.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Post", description = "게시글 API")
@@ -36,7 +38,7 @@ public class PostController {
 
     @Operation(
             summary = "기업별 게시글 조회",
-            description = "특정 기업의 게시글을 무한 스크롤 방식으로 조회합니다. company 파라미터가 없으면 전체 게시글을 조회합니다."
+            description = "특정 기업의 게시글을 무한 스크롤 방식으로 조회합니다. company 파라미터가 없으면 전체 게시글을 조회합니다. 로그인 시 북마크 여부가 포함됩니다."
     )
     @GetMapping("/by-company")
     public ResponseEntity<BaseResponse<PostListResponse>> getPostsByCompany(
@@ -45,15 +47,18 @@ public class PostController {
             @Parameter(description = "마지막 게시글 ID (커서, 선택)")
             @RequestParam(required = false) Long lastPostId,
             @Parameter(description = "페이지 크기 (기본값: 20)")
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        PostListResponse response = postQueryService.getPostsByCompany(company, lastPostId, size);
+        Long userId = userPrincipal != null ? userPrincipal.getId() : null;
+        PostListResponse response = postQueryService.getPostsByCompany(company, lastPostId, size, userId);
         return BaseResponse.of(SuccessCode.OK, response);
     }
 
     @Operation(
             summary = "최근 게시글 조회",
-            description = "최근 생성된 게시글을 무한 스크롤 방식으로 조회합니다. sortBy로 정렬 기준을 선택할 수 있습니다."
+            description = "최근 생성된 게시글을 무한 스크롤 방식으로 조회합니다. sortBy로 정렬 기준을 선택할 수 있습니다. 로그인 시 북마크 여부가 포함됩니다."
     )
     @GetMapping("/recent")
     public ResponseEntity<BaseResponse<PostListResponse>> getRecentPosts(
@@ -62,9 +67,12 @@ public class PostController {
             @Parameter(description = "마지막 게시글 ID (커서, 선택)")
             @RequestParam(required = false) Long lastPostId,
             @Parameter(description = "페이지 크기 (기본값: 20)")
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        PostListResponse response = postQueryService.getRecentPosts(sortBy, lastPostId, size);
+        Long userId = userPrincipal != null ? userPrincipal.getId() : null;
+        PostListResponse response = postQueryService.getRecentPosts(sortBy, lastPostId, size, userId);
         return BaseResponse.of(SuccessCode.OK, response);
     }
 

--- a/src/main/java/com/techfork/domain/post/controller/PostControllerV2.java
+++ b/src/main/java/com/techfork/domain/post/controller/PostControllerV2.java
@@ -6,6 +6,7 @@ import com.techfork.domain.post.enums.EPostSortType;
 import com.techfork.domain.post.service.PostQueryService;
 import com.techfork.global.common.code.SuccessCode;
 import com.techfork.global.response.BaseResponse;
+import com.techfork.global.security.oauth.UserPrincipal;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -53,6 +55,7 @@ public class PostControllerV2 {
                         초기에는 lastPublishedAt과 lastPostId를 빈 채로 호출하고,
                         페이징을 할 땐 lastPublishedAt과 lastPostId를 둘 다 동시에 보내주셔야 합니다.
                         페이징 관련 값은 응답으로 반환됩니다.
+                        로그인 시 북마크 여부가 포함됩니다.
                         """
     )
     @GetMapping("/by-company")
@@ -68,9 +71,13 @@ public class PostControllerV2 {
             @RequestParam(required = false) Long lastPostId,
 
             @Parameter(description = "페이지 크기 (기본값: 20)")
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        PostListResponse response = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size);
+        Long userId = userPrincipal != null ? userPrincipal.getId() : null;
+        PostListResponse response = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size, userId);
         return BaseResponse.of(SuccessCode.OK, response);
     }
 
@@ -82,6 +89,7 @@ public class PostControllerV2 {
                     - LATEST: publishedAt 기준 정렬, lastPublishedAt과 lastPostId 필요
                     - POPULAR: viewCount 기준 정렬, lastViewCount와 lastPostId 필요
                     초기 요청 시에는 커서 파라미터를 비워두고, 페이징 시 응답에서 받은 값을 모두 전달해주셔야 합니다.
+                    로그인 시 북마크 여부가 포함됩니다.
                     """
     )
     @GetMapping("/recent")
@@ -100,9 +108,13 @@ public class PostControllerV2 {
             @RequestParam(required = false) Long lastPostId,
 
             @Parameter(description = "페이지 크기 (기본값: 20)")
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") int size,
+
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal UserPrincipal userPrincipal
     ) {
-        PostListResponse response = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size);
+        Long userId = userPrincipal != null ? userPrincipal.getId() : null;
+        PostListResponse response = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size, userId);
         return BaseResponse.of(SuccessCode.OK, response);
     }
 }

--- a/src/main/java/com/techfork/domain/post/converter/PostConverter.java
+++ b/src/main/java/com/techfork/domain/post/converter/PostConverter.java
@@ -46,7 +46,7 @@ public class PostConverter {
                 .build();
     }
 
-    public PostDetailDto toPostDetailDto(PostDetailDto baseDto, List<String> keywords) {
+    public PostDetailDto toPostDetailDto(PostDetailDto baseDto, List<String> keywords, Boolean isBookmarked) {
         return PostDetailDto.builder()
                 .id(baseDto.id())
                 .title(baseDto.title())
@@ -57,6 +57,7 @@ public class PostConverter {
                 .publishedAt(baseDto.publishedAt())
                 .viewCount(baseDto.viewCount())
                 .keywords(keywords)
+                .isBookmarked(isBookmarked)
                 .build();
     }
 }

--- a/src/main/java/com/techfork/domain/post/dto/PostDetailDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostDetailDto.java
@@ -17,6 +17,7 @@ public record PostDetailDto(
         String logoUrl,
         LocalDateTime publishedAt,
         Long viewCount,
-        List<String> keywords
+        List<String> keywords,
+        Boolean isBookmarked
 ) {
 }

--- a/src/main/java/com/techfork/domain/post/dto/PostInfoDto.java
+++ b/src/main/java/com/techfork/domain/post/dto/PostInfoDto.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import java.time.LocalDateTime;
 import java.util.List;
 
-@Builder
+@Builder(toBuilder = true)
 @Schema(name = "PostInfoDto")
 public record PostInfoDto(
         Long id,
@@ -17,6 +17,7 @@ public record PostInfoDto(
         String thumbnailUrl,
         LocalDateTime publishedAt,
         Long viewCount,
-        List<String> keywords
+        List<String> keywords,
+        Boolean isBookmarked
 ) {
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -137,7 +137,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostDetailDto(
-            p.id, p.title, p.summary, p.company, p.url, p.logoUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.summary, p.company, p.url, p.logoUrl, p.publishedAt, p.viewCount, null, null)
             FROM Post p
             WHERE p.id = :id
             """)

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -51,7 +51,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null, null)
             FROM Post p
             WHERE (:company IS NULL OR p.company = :company)
             AND (:lastPostId IS NULL OR p.id < :lastPostId)
@@ -65,7 +65,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null, null)
             FROM Post p
             WHERE (:companies IS NULL OR p.company IN :companies)
             AND (
@@ -79,7 +79,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null, null)
             FROM Post p
             WHERE :lastPostId IS NULL OR p.id < :lastPostId
             ORDER BY p.publishedAt DESC
@@ -91,7 +91,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null, null)
             FROM Post p
             WHERE (
                 :lastPublishedAt IS NULL OR
@@ -108,7 +108,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null, null)
             FROM Post p
             WHERE :lastPostId IS NULL OR p.id < :lastPostId
             ORDER BY p.viewCount DESC, p.publishedAt DESC
@@ -120,7 +120,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.post.dto.PostInfoDto(
-            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null)
+            p.id, p.title, p.company, p.url, p.logoUrl, p.thumbnailUrl, p.publishedAt, p.viewCount, null, null)
             FROM Post p
             WHERE (
                 :lastViewCount IS NULL OR

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -1,5 +1,6 @@
 package com.techfork.domain.post.service;
 
+import com.techfork.domain.activity.repository.ScrabPostRepository;
 import com.techfork.domain.post.converter.PostConverter;
 import com.techfork.domain.post.dto.*;
 import com.techfork.domain.post.entity.PostKeyword;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -27,6 +29,7 @@ public class PostQueryService {
 
     private final PostRepository postRepository;
     private final PostKeywordRepository postKeywordRepository;
+    private final ScrabPostRepository scrabPostRepository;
     private final PostConverter postConverter;
 
     public CompanyListResponse getCompanies() {
@@ -39,21 +42,31 @@ public class PostQueryService {
         return postConverter.toCompanyListResponseV2(companies);
     }
 
-    public PostListResponse getPostsByCompany(String company, Long lastPostId, int size) {
+    public PostListResponse getPostsByCompany(String company, Long lastPostId, int size, Long userId) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
         List<PostInfoDto> posts = postRepository.findByCompanyWithCursor(company, lastPostId, pageRequest);
         List<PostInfoDto> postsWithKeywords = attachKeywordsToPostInfoList(posts);
+
+        if (userId != null) {
+            postsWithKeywords = attachBookmarksToPostInfoList(postsWithKeywords, userId);
+        }
+
         return postConverter.toPostListResponse(postsWithKeywords, size);
     }
 
-    public PostListResponse getPostsByCompanyV2(List<String> companies, LocalDateTime lastPublishedAt, Long lastPostId, int size) {
+    public PostListResponse getPostsByCompanyV2(List<String> companies, LocalDateTime lastPublishedAt, Long lastPostId, int size, Long userId) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
         List<PostInfoDto> posts = postRepository.findByCompanyNamesWithCursor(companies, lastPublishedAt, lastPostId, pageRequest);
         List<PostInfoDto> postsWithKeywords = attachKeywordsToPostInfoList(posts);
+
+        if (userId != null) {
+            postsWithKeywords = attachBookmarksToPostInfoList(postsWithKeywords, userId);
+        }
+
         return postConverter.toPostListResponse(postsWithKeywords, size);
     }
 
-    public PostListResponse getRecentPosts(EPostSortType sortBy, Long lastPostId, int size) {
+    public PostListResponse getRecentPosts(EPostSortType sortBy, Long lastPostId, int size, Long userId) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
         List<PostInfoDto> posts;
 
@@ -64,10 +77,15 @@ public class PostQueryService {
         }
 
         List<PostInfoDto> postsWithKeywords = attachKeywordsToPostInfoList(posts);
+
+        if (userId != null) {
+            postsWithKeywords = attachBookmarksToPostInfoList(postsWithKeywords, userId);
+        }
+
         return postConverter.toPostListResponse(postsWithKeywords, size);
     }
 
-    public PostListResponse getRecentPostsV2(EPostSortType sortBy, Integer lastViewCount, LocalDateTime lastPublishedAt, Long lastPostId, int size) {
+    public PostListResponse getRecentPostsV2(EPostSortType sortBy, Integer lastViewCount, LocalDateTime lastPublishedAt, Long lastPostId, int size, Long userId) {
         PageRequest pageRequest = PageRequest.of(0, size + 1);
         List<PostInfoDto> posts;
 
@@ -78,6 +96,11 @@ public class PostQueryService {
         }
 
         List<PostInfoDto> postsWithKeywords = attachKeywordsToPostInfoList(posts);
+
+        if (userId != null) {
+            postsWithKeywords = attachBookmarksToPostInfoList(postsWithKeywords, userId);
+        }
+
         return postConverter.toPostListResponse(postsWithKeywords, size);
     }
 
@@ -120,6 +143,36 @@ public class PostQueryService {
                         .publishedAt(post.publishedAt())
                         .viewCount(post.viewCount())
                         .keywords(keywordMap.getOrDefault(post.id(), List.of()))
+                        .isBookmarked(null)
+                        .build())
+                .toList();
+    }
+
+    private List<PostInfoDto> attachBookmarksToPostInfoList(List<PostInfoDto> posts, Long userId) {
+        if (posts.isEmpty()) {
+            return posts;
+        }
+
+        List<Long> postIds = posts.stream()
+                .map(PostInfoDto::id)
+                .toList();
+
+        Set<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(userId, postIds)
+                .stream()
+                .collect(Collectors.toSet());
+
+        return posts.stream()
+                .map(post -> PostInfoDto.builder()
+                        .id(post.id())
+                        .title(post.title())
+                        .company(post.company())
+                        .url(post.url())
+                        .logoUrl(post.logoUrl())
+                        .thumbnailUrl(post.thumbnailUrl())
+                        .publishedAt(post.publishedAt())
+                        .viewCount(post.viewCount())
+                        .keywords(post.keywords())
+                        .isBookmarked(bookmarkedPostIds.contains(post.id()))
                         .build())
                 .toList();
     }

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -104,7 +104,7 @@ public class PostQueryService {
         return postConverter.toPostListResponse(postsWithKeywords, size);
     }
 
-    public PostDetailDto getPostDetail(Long postId) {
+    public PostDetailDto getPostDetail(Long postId, Long userId) {
         PostDetailDto postDetail = postRepository.findByIdWithTechBlog(postId)
                 .orElseThrow(() -> new GeneralException(CommonErrorCode.NOT_FOUND));
 
@@ -113,7 +113,12 @@ public class PostQueryService {
                 .map(PostKeyword::getKeyword)
                 .toList();
 
-        return postConverter.toPostDetailDto(postDetail, keywords);
+        Boolean isBookmarked = null;
+        if (userId != null) {
+            isBookmarked = !scrabPostRepository.findBookmarkedPostIds(userId, List.of(postId)).isEmpty();
+        }
+
+        return postConverter.toPostDetailDto(postDetail, keywords, isBookmarked);
     }
 
     private List<PostInfoDto> attachKeywordsToPostInfoList(List<PostInfoDto> posts) {

--- a/src/test/java/com/techfork/domain/activity/repository/ScrabPostRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/activity/repository/ScrabPostRepositoryTest.java
@@ -134,4 +134,59 @@ class ScrabPostRepositoryTest {
         assertThat(nextPage.get(0).postId()).isEqualTo(testPost2.getId());
         assertThat(nextPage.get(1).postId()).isEqualTo(testPost1.getId());
     }
+
+    @Test
+    @DisplayName("북마크된 게시글 ID 목록 조회")
+    void findBookmarkedPostIds() {
+        // Given
+        ScrabPost scrab1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
+        ScrabPost scrab3 = ScrabPost.create(testUser, testPost3, LocalDateTime.now());
+        scrabPostRepository.save(scrab1);
+        scrabPostRepository.save(scrab3);
+
+        List<Long> postIds = List.of(testPost1.getId(), testPost2.getId(), testPost3.getId());
+
+        // When
+        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(testUser.getId(), postIds);
+
+        // Then
+        assertThat(bookmarkedPostIds).hasSize(2);
+        assertThat(bookmarkedPostIds).containsExactlyInAnyOrder(testPost1.getId(), testPost3.getId());
+        assertThat(bookmarkedPostIds).doesNotContain(testPost2.getId());
+    }
+
+    @Test
+    @DisplayName("북마크된 게시글이 없을 때 빈 리스트 반환")
+    void findBookmarkedPostIds_whenNoBookmarks() {
+        // Given
+        List<Long> postIds = List.of(testPost1.getId(), testPost2.getId(), testPost3.getId());
+
+        // When
+        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(testUser.getId(), postIds);
+
+        // Then
+        assertThat(bookmarkedPostIds).isEmpty();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 북마크는 조회되지 않음")
+    void findBookmarkedPostIds_differentUser() {
+        // Given
+        User anotherUser = User.createSocialUser(SocialType.KAKAO, "anotherSocialId", "another@example.com", "another.jpg");
+        anotherUser = userRepository.save(anotherUser);
+
+        ScrabPost scrab1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
+        ScrabPost scrab2 = ScrabPost.create(anotherUser, testPost2, LocalDateTime.now());
+        scrabPostRepository.save(scrab1);
+        scrabPostRepository.save(scrab2);
+
+        List<Long> postIds = List.of(testPost1.getId(), testPost2.getId());
+
+        // When
+        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(testUser.getId(), postIds);
+
+        // Then
+        assertThat(bookmarkedPostIds).hasSize(1);
+        assertThat(bookmarkedPostIds).containsExactly(testPost1.getId());
+    }
 }

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
@@ -1,22 +1,29 @@
 package com.techfork.domain.post.controller;
 
+import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.repository.ScrabPostRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.post.repository.PostKeywordRepository;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.source.repository.TechBlogRepository;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.common.IntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -40,9 +47,16 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
     @Autowired
     private TechBlogRepository techBlogRepository;
 
+    @Autowired
+    private ScrabPostRepository scrabPostRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
     private TechBlog testTechBlog;
     private Post testPost1;
     private Post testPost2;
+    private User testUser;
 
     @BeforeEach
     void setUp() {
@@ -58,6 +72,7 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
                 .title("테스트 게시글 1")
                 .fullContent("<p>전체 내용 1</p>")
                 .plainContent("전체 내용 1")
+                .summary("요약 내용 1")
                 .company("테스트 회사")
                 .url("https://test.com/post/1")
                 .logoUrl("https://test.com/post/1/logo.png")
@@ -77,6 +92,7 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
                 .title("테스트 게시글 2")
                 .fullContent("<p>전체 내용 2</p>")
                 .plainContent("전체 내용 2")
+                .summary("요약 내용 2")
                 .company("테스트 회사")
                 .url("https://test.com/post/2")
                 .logoUrl("https://test.com/post/2/logo.png")
@@ -91,12 +107,21 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
         postKeywordRepository.save(keyword3);
     }
 
+    @BeforeEach
+    void setUpUser() {
+        // 테스트 사용자 생성
+        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
+        testUser = userRepository.save(testUser);
+    }
+
     @AfterEach
     void tearDown() {
         // 테스트 데이터 정리 (외래키 제약조건 순서 고려)
+        scrabPostRepository.deleteAll();
         postKeywordRepository.deleteAll();
         postRepository.deleteAll();
         techBlogRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test
@@ -106,9 +131,15 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
         mockMvc.perform(get("/api/v1/posts/{postId}", testPost1.getId()))
                 .andDo(print())
                 .andExpect(status().isOk())
+                // PostDetailDto의 모든 필드 검증
                 .andExpect(jsonPath("$.data.id").value(testPost1.getId()))
                 .andExpect(jsonPath("$.data.title").value("테스트 게시글 1"))
+                .andExpect(jsonPath("$.data.summary").exists())
                 .andExpect(jsonPath("$.data.company").value("테스트 회사"))
+                .andExpect(jsonPath("$.data.url").value("https://test.com/post/1"))
+                .andExpect(jsonPath("$.data.logoUrl").value("https://test.com/post/1/logo.png"))
+                .andExpect(jsonPath("$.data.publishedAt").exists())
+                .andExpect(jsonPath("$.data.viewCount").isNumber())
                 .andExpect(jsonPath("$.data.keywords").isArray())
                 .andExpect(jsonPath("$.data.keywords.length()").value(2));
     }
@@ -122,9 +153,23 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
                         .param("size", "20"))
                 .andDo(print())
                 .andExpect(status().isOk())
+                // PostListResponse의 모든 필드 검증
                 .andExpect(jsonPath("$.data.posts").isArray())
                 .andExpect(jsonPath("$.data.posts.length()").value(2))
-                .andExpect(jsonPath("$.data.hasNext").value(false));
+                .andExpect(jsonPath("$.data.lastPostId").exists())
+                .andExpect(jsonPath("$.data.lastViewCount").exists())
+                .andExpect(jsonPath("$.data.lastPublishedAt").exists())
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                // PostInfoDto의 모든 필드 검증 (첫 번째 항목만)
+                .andExpect(jsonPath("$.data.posts[0].id").isNumber())
+                .andExpect(jsonPath("$.data.posts[0].title").isString())
+                .andExpect(jsonPath("$.data.posts[0].company").isString())
+                .andExpect(jsonPath("$.data.posts[0].url").isString())
+                .andExpect(jsonPath("$.data.posts[0].logoUrl").exists())
+                .andExpect(jsonPath("$.data.posts[0].thumbnailUrl").exists())
+                .andExpect(jsonPath("$.data.posts[0].publishedAt").exists())
+                .andExpect(jsonPath("$.data.posts[0].viewCount").isNumber())
+                .andExpect(jsonPath("$.data.posts[0].keywords").isArray());
     }
 
     @Test
@@ -134,6 +179,7 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
         mockMvc.perform(get("/api/v1/posts/companies"))
                 .andDo(print())
                 .andExpect(status().isOk())
+                // CompanyListResponse의 모든 필드 검증 (V1)
                 .andExpect(jsonPath("$.data.companies").isArray())
                 .andExpect(jsonPath("$.data.companies[0]").value("테스트 회사"))
                 .andExpect(jsonPath("$.data.companies.length()").value(1));
@@ -146,5 +192,102 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
         mockMvc.perform(get("/api/v1/posts/{postId}", 99999L))
                 .andDo(print())
                 .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/recent - 비로그인 시 isBookmarked는 null")
+    void getRecentPosts_WithoutAuth_IsBookmarkedIsNull() throws Exception {
+        // When & Then: 비로그인 상태에서 게시글 조회
+        mockMvc.perform(get("/api/v1/posts/recent")
+                        .param("sortBy", "LATEST")
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/recent - 로그인 시 isBookmarked 포함 (북마크 없음)")
+    void getRecentPosts_WithAuth_IsBookmarkedFalse() throws Exception {
+        // Given: UserPrincipal 생성
+        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
+            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
+
+        // When & Then: 로그인 상태에서 게시글 조회 (북마크 없음)
+        mockMvc.perform(get("/api/v1/posts/recent")
+                        .param("sortBy", "LATEST")
+                        .param("size", "20")
+                        .with(user(userPrincipal)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(false))
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/recent - 로그인 시 isBookmarked 포함 (북마크 있음)")
+    void getRecentPosts_WithAuth_IsBookmarkedTrue() throws Exception {
+        // Given: 북마크 추가
+        ScrabPost scrabPost = ScrabPost.create(testUser, testPost1, java.time.LocalDateTime.now());
+        scrabPostRepository.save(scrabPost);
+
+        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
+            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
+
+        // When & Then: 로그인 상태에서 게시글 조회 (testPost1은 북마크, testPost2는 미북마크)
+        mockMvc.perform(get("/api/v1/posts/recent")
+                        .param("sortBy", "LATEST")
+                        .param("size", "20")
+                        .with(user(userPrincipal)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts.length()").value(2))
+                // testPost2가 최신이므로 먼저 오고 false여야 함
+                .andExpect(jsonPath("$.data.posts[0].id").value(testPost2.getId()))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(false))
+                // testPost1은 북마크되어 있으므로 true여야 함
+                .andExpect(jsonPath("$.data.posts[1].id").value(testPost1.getId()))
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/by-company - 로그인 시 북마크 정보 포함")
+    void getPostsByCompany_WithAuth_IncludesBookmarks() throws Exception {
+        // Given: testPost2만 북마크
+        ScrabPost scrabPost = ScrabPost.create(testUser, testPost2, java.time.LocalDateTime.now());
+        scrabPostRepository.save(scrabPost);
+
+        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
+            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
+
+        // When & Then: 특정 회사 게시글 조회
+        mockMvc.perform(get("/api/v1/posts/by-company")
+                        .param("company", "테스트 회사")
+                        .param("size", "20")
+                        .with(user(userPrincipal)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts.length()").value(2))
+                .andExpect(jsonPath("$.data.posts[0].id").value(testPost2.getId()))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true))
+                .andExpect(jsonPath("$.data.posts[1].id").value(testPost1.getId()))
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/by-company - 비로그인 시 isBookmarked는 null")
+    void getPostsByCompany_WithoutAuth_IsBookmarkedIsNull() throws Exception {
+        // When & Then: 비로그인 상태에서 회사별 게시글 조회
+        mockMvc.perform(get("/api/v1/posts/by-company")
+                        .param("company", "테스트 회사")
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist());
     }
 }

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
@@ -9,21 +9,21 @@ import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.source.repository.TechBlogRepository;
 import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.Role;
 import com.techfork.domain.user.enums.SocialType;
 import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.common.IntegrationTestBase;
+import com.techfork.global.security.jwt.JwtUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -53,10 +53,14 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private JwtUtil jwtUtil;
+
     private TechBlog testTechBlog;
     private Post testPost1;
     private Post testPost2;
     private User testUser;
+    private String accessToken;
 
     @BeforeEach
     void setUp() {
@@ -112,6 +116,13 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
         // 테스트 사용자 생성
         testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
         testUser = userRepository.save(testUser);
+
+        // JWT 토큰 생성
+        accessToken = jwtUtil.generateTokens(testUser.getId(), Role.USER).accessToken();
+
+        // testUser가 testPost1을 북마크
+        ScrabPost scrabPost = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
+        scrabPostRepository.save(scrabPost);
     }
 
     @AfterEach
@@ -125,8 +136,8 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("GET /api/v1/posts/{postId} - 게시글 상세 조회 성공")
-    void getPostDetail_Success() throws Exception {
+    @DisplayName("GET /api/v1/posts/{postId} - 비로그인 시 게시글 상세 조회 성공 (isBookmarked는 null)")
+    void getPostDetail_WithoutAuth_Success() throws Exception {
         // When & Then: 실제 DB에 저장된 데이터로 HTTP 요청 테스트
         mockMvc.perform(get("/api/v1/posts/{postId}", testPost1.getId()))
                 .andDo(print())
@@ -141,13 +152,62 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.publishedAt").exists())
                 .andExpect(jsonPath("$.data.viewCount").isNumber())
                 .andExpect(jsonPath("$.data.keywords").isArray())
-                .andExpect(jsonPath("$.data.keywords.length()").value(2));
+                .andExpect(jsonPath("$.data.keywords.length()").value(2))
+                .andExpect(jsonPath("$.data.isBookmarked").doesNotExist());
     }
 
     @Test
-    @DisplayName("GET /api/v1/posts/recent - 최근 게시글 조회 성공")
-    void getRecentPosts_Success() throws Exception {
-        // When & Then: 실제 DB에서 최근 게시글 조회
+    @DisplayName("GET /api/v1/posts/{postId} - 로그인 시 북마크한 게시글 상세 조회 (isBookmarked는 true)")
+    void getPostDetail_WithAuth_BookmarkedPost_Success() throws Exception {
+        // When & Then: 로그인한 사용자가 북마크한 게시글 조회
+        mockMvc.perform(get("/api/v1/posts/{postId}", testPost1.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(testPost1.getId()))
+                .andExpect(jsonPath("$.data.title").value("테스트 게시글 1"))
+                .andExpect(jsonPath("$.data.isBookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/{postId} - 로그인 시 북마크하지 않은 게시글 상세 조회 (isBookmarked는 false)")
+    void getPostDetail_WithAuth_NotBookmarkedPost_Success() throws Exception {
+        // When & Then: 로그인한 사용자가 북마크하지 않은 게시글 조회
+        mockMvc.perform(get("/api/v1/posts/{postId}", testPost2.getId())
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id").value(testPost2.getId()))
+                .andExpect(jsonPath("$.data.title").value("테스트 게시글 2"))
+                .andExpect(jsonPath("$.data.isBookmarked").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/{postId} - 존재하지 않는 게시글 조회 시 404")
+    void getPostDetail_NotFound() throws Exception {
+        // When & Then: 존재하지 않는 게시글 조회
+        mockMvc.perform(get("/api/v1/posts/{postId}", 99999L))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/companies - 회사 목록 조회 성공")
+    void getCompanies_Success() throws Exception {
+        // When & Then: 실제 DB에서 회사 목록 조회
+        mockMvc.perform(get("/api/v1/posts/companies"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                // CompanyListResponse의 모든 필드 검증 (V1)
+                .andExpect(jsonPath("$.data.companies").isArray())
+                .andExpect(jsonPath("$.data.companies[0]").value("테스트 회사"))
+                .andExpect(jsonPath("$.data.companies.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/recent - 비로그인 시 isBookmarked 미포함")
+    void getRecentPosts_WithoutAuth() throws Exception {
+        // When & Then: 비로그인 상태에서 게시글 조회
         mockMvc.perform(get("/api/v1/posts/recent")
                         .param("sortBy", "LATEST")
                         .param("size", "20"))
@@ -169,78 +229,20 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.posts[0].thumbnailUrl").exists())
                 .andExpect(jsonPath("$.data.posts[0].publishedAt").exists())
                 .andExpect(jsonPath("$.data.posts[0].viewCount").isNumber())
-                .andExpect(jsonPath("$.data.posts[0].keywords").isArray());
+                .andExpect(jsonPath("$.data.posts[0].keywords").isArray())
+                // isBookmarked는 비로그인이므로 없어야 함
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist())
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").doesNotExist());
     }
 
     @Test
-    @DisplayName("GET /api/v1/posts/companies - 회사 목록 조회 성공")
-    void getCompanies_Success() throws Exception {
-        // When & Then: 실제 DB에서 회사 목록 조회
-        mockMvc.perform(get("/api/v1/posts/companies"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                // CompanyListResponse의 모든 필드 검증 (V1)
-                .andExpect(jsonPath("$.data.companies").isArray())
-                .andExpect(jsonPath("$.data.companies[0]").value("테스트 회사"))
-                .andExpect(jsonPath("$.data.companies.length()").value(1));
-    }
-
-    @Test
-    @DisplayName("GET /api/v1/posts/{postId} - 존재하지 않는 게시글 조회 시 404")
-    void getPostDetail_NotFound() throws Exception {
-        // When & Then: 존재하지 않는 게시글 조회
-        mockMvc.perform(get("/api/v1/posts/{postId}", 99999L))
-                .andDo(print())
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    @DisplayName("GET /api/v1/posts/recent - 비로그인 시 isBookmarked는 null")
-    void getRecentPosts_WithoutAuth_IsBookmarkedIsNull() throws Exception {
-        // When & Then: 비로그인 상태에서 게시글 조회
-        mockMvc.perform(get("/api/v1/posts/recent")
-                        .param("sortBy", "LATEST")
-                        .param("size", "20"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.posts").isArray())
-                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist());
-    }
-
-    @Test
-    @DisplayName("GET /api/v1/posts/recent - 로그인 시 isBookmarked 포함 (북마크 없음)")
-    void getRecentPosts_WithAuth_IsBookmarkedFalse() throws Exception {
-        // Given: UserPrincipal 생성
-        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
-            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
-
-        // When & Then: 로그인 상태에서 게시글 조회 (북마크 없음)
+    @DisplayName("GET /api/v1/posts/recent - 로그인 시 북마크 여부 포함 (testPost1=true, testPost2=false)")
+    void getRecentPosts_WithAuth() throws Exception {
+        // When & Then: 로그인 상태에서 게시글 조회
         mockMvc.perform(get("/api/v1/posts/recent")
                         .param("sortBy", "LATEST")
                         .param("size", "20")
-                        .with(user(userPrincipal)))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.posts").isArray())
-                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(false))
-                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(false));
-    }
-
-    @Test
-    @DisplayName("GET /api/v1/posts/recent - 로그인 시 isBookmarked 포함 (북마크 있음)")
-    void getRecentPosts_WithAuth_IsBookmarkedTrue() throws Exception {
-        // Given: 북마크 추가
-        ScrabPost scrabPost = ScrabPost.create(testUser, testPost1, java.time.LocalDateTime.now());
-        scrabPostRepository.save(scrabPost);
-
-        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
-            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
-
-        // When & Then: 로그인 상태에서 게시글 조회 (testPost1은 북마크, testPost2는 미북마크)
-        mockMvc.perform(get("/api/v1/posts/recent")
-                        .param("sortBy", "LATEST")
-                        .param("size", "20")
-                        .with(user(userPrincipal)))
+                        .header("Authorization", "Bearer " + accessToken))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.posts").isArray())
@@ -254,33 +256,8 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("GET /api/v1/posts/by-company - 로그인 시 북마크 정보 포함")
-    void getPostsByCompany_WithAuth_IncludesBookmarks() throws Exception {
-        // Given: testPost2만 북마크
-        ScrabPost scrabPost = ScrabPost.create(testUser, testPost2, java.time.LocalDateTime.now());
-        scrabPostRepository.save(scrabPost);
-
-        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
-            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
-
-        // When & Then: 특정 회사 게시글 조회
-        mockMvc.perform(get("/api/v1/posts/by-company")
-                        .param("company", "테스트 회사")
-                        .param("size", "20")
-                        .with(user(userPrincipal)))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.posts").isArray())
-                .andExpect(jsonPath("$.data.posts.length()").value(2))
-                .andExpect(jsonPath("$.data.posts[0].id").value(testPost2.getId()))
-                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true))
-                .andExpect(jsonPath("$.data.posts[1].id").value(testPost1.getId()))
-                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(false));
-    }
-
-    @Test
-    @DisplayName("GET /api/v1/posts/by-company - 비로그인 시 isBookmarked는 null")
-    void getPostsByCompany_WithoutAuth_IsBookmarkedIsNull() throws Exception {
+    @DisplayName("GET /api/v1/posts/by-company - 비로그인 시 isBookmarked 미포함")
+    void getPostsByCompany_WithoutAuth() throws Exception {
         // When & Then: 비로그인 상태에서 회사별 게시글 조회
         mockMvc.perform(get("/api/v1/posts/by-company")
                         .param("company", "테스트 회사")
@@ -288,6 +265,26 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.posts").isArray())
-                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist());
+                .andExpect(jsonPath("$.data.posts.length()").value(2))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist())
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/posts/by-company - 로그인 시 북마크 여부 포함 (testPost1=true, testPost2=false)")
+    void getPostsByCompany_WithAuth() throws Exception {
+        // When & Then: 특정 회사 게시글 조회
+        mockMvc.perform(get("/api/v1/posts/by-company")
+                        .param("company", "테스트 회사")
+                        .param("size", "20")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts.length()").value(2))
+                .andExpect(jsonPath("$.data.posts[0].id").value(testPost2.getId()))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(false))
+                .andExpect(jsonPath("$.data.posts[1].id").value(testPost1.getId()))
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(true));
     }
 }

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerV2IntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerV2IntegrationTest.java
@@ -1,9 +1,14 @@
 package com.techfork.domain.post.controller;
 
+import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.repository.ScrabPostRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.source.repository.TechBlogRepository;
+import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.SocialType;
+import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.common.IntegrationTestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +21,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -37,14 +43,24 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     @Autowired
     private TechBlogRepository techBlogRepository;
 
+    @Autowired
+    private ScrabPostRepository scrabPostRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
     private TechBlog testTechBlog1;
     private TechBlog testTechBlog2;
     private Post todayPost;
     private Post oldPost;
+    private User testUser;
 
     @BeforeEach
     void setUp() {
         // Given: 실제 DB에 테스트 데이터 저장
+        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
+        testUser = userRepository.save(testUser);
+
         testTechBlog1 = TechBlog.builder()
                 .companyName("카카오")
                 .blogUrl("https://kakao.com")
@@ -66,6 +82,7 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                 .title("오늘의 게시글")
                 .fullContent("<p>오늘 내용</p>")
                 .plainContent("오늘 내용")
+                .summary("오늘 요약")
                 .company("카카오")
                 .url("https://kakao.com/post/today")
                 .logoUrl("https://kakao.com/logo.png")
@@ -81,6 +98,7 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                 .title("어제의 게시글")
                 .fullContent("<p>어제 내용</p>")
                 .plainContent("어제 내용")
+                .summary("어제 요약")
                 .company("네이버")
                 .url("https://naver.com/post/old")
                 .logoUrl("https://naver.com/logo.png")
@@ -95,8 +113,10 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     @AfterEach
     void tearDown() {
         // 테스트 데이터 정리 (외래키 제약조건 순서 고려)
+        scrabPostRepository.deleteAll();
         postRepository.deleteAll();
         techBlogRepository.deleteAll();
+        userRepository.deleteAll();
     }
 
     @Test
@@ -106,17 +126,14 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
         mockMvc.perform(get("/api/v2/posts/companies"))
                 .andDo(print())
                 .andExpect(status().isOk())
+                // CompanyListResponse의 모든 필드 검증
                 .andExpect(jsonPath("$.data.totalNumber").value(2))
                 .andExpect(jsonPath("$.data.companies").isArray())
                 .andExpect(jsonPath("$.data.companies.length()").value(2))
-                // 첫 번째 회사 (카카오 - 오늘 발행)
+                // CompanyDto의 모든 필드 검증 (첫 번째 항목만)
                 .andExpect(jsonPath("$.data.companies[0].company").value("카카오"))
                 .andExpect(jsonPath("$.data.companies[0].hasNewPost").value(true))
-                .andExpect(jsonPath("$.data.companies[0].logoUrl").value("https://kakao.com/logo.png"))
-                // 두 번째 회사 (네이버 - 어제 발행)
-                .andExpect(jsonPath("$.data.companies[1].company").value("네이버"))
-                .andExpect(jsonPath("$.data.companies[1].hasNewPost").value(false))
-                .andExpect(jsonPath("$.data.companies[1].logoUrl").value("https://naver.com/logo.png"));
+                .andExpect(jsonPath("$.data.companies[0].logoUrl").value("https://kakao.com/logo.png"));
     }
 
     @Test
@@ -167,13 +184,23 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                         .param("size", "20"))
                 .andDo(print())
                 .andExpect(status().isOk())
+                // PostListResponse의 모든 필드 검증
                 .andExpect(jsonPath("$.data.posts").isArray())
                 .andExpect(jsonPath("$.data.posts.length()").value(2))
-                .andExpect(jsonPath("$.data.posts[0].company").value("카카오"))
-                .andExpect(jsonPath("$.data.posts[1].company").value("네이버"))
-                .andExpect(jsonPath("$.data.hasNext").value(false))
                 .andExpect(jsonPath("$.data.lastPostId").exists())
-                .andExpect(jsonPath("$.data.lastPublishedAt").exists());
+                .andExpect(jsonPath("$.data.lastViewCount").exists())
+                .andExpect(jsonPath("$.data.lastPublishedAt").exists())
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                // PostInfoDto의 모든 필드 검증 (첫 번째 항목만)
+                .andExpect(jsonPath("$.data.posts[0].id").isNumber())
+                .andExpect(jsonPath("$.data.posts[0].title").isString())
+                .andExpect(jsonPath("$.data.posts[0].company").value("카카오"))
+                .andExpect(jsonPath("$.data.posts[0].url").isString())
+                .andExpect(jsonPath("$.data.posts[0].logoUrl").exists())
+                .andExpect(jsonPath("$.data.posts[0].thumbnailUrl").exists())
+                .andExpect(jsonPath("$.data.posts[0].publishedAt").exists())
+                .andExpect(jsonPath("$.data.posts[0].viewCount").isNumber())
+                .andExpect(jsonPath("$.data.posts[0].keywords").isArray());
     }
 
     @Test
@@ -280,13 +307,24 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                         .param("size", "20"))
                 .andDo(print())
                 .andExpect(status().isOk())
+                // PostListResponse의 모든 필드 검증 (LATEST 정렬)
                 .andExpect(jsonPath("$.data.posts").isArray())
                 .andExpect(jsonPath("$.data.posts.length()").value(2))
-                .andExpect(jsonPath("$.data.posts[0].title").value("오늘의 게시글"))
-                .andExpect(jsonPath("$.data.posts[1].title").value("어제의 게시글"))
-                .andExpect(jsonPath("$.data.hasNext").value(false))
                 .andExpect(jsonPath("$.data.lastPostId").exists())
-                .andExpect(jsonPath("$.data.lastPublishedAt").exists());
+                .andExpect(jsonPath("$.data.lastPublishedAt").exists())
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                // PostInfoDto의 모든 필드 검증 (첫 번째 항목만)
+                .andExpect(jsonPath("$.data.posts[0].id").isNumber())
+                .andExpect(jsonPath("$.data.posts[0].title").value("오늘의 게시글"))
+                .andExpect(jsonPath("$.data.posts[0].company").isString())
+                .andExpect(jsonPath("$.data.posts[0].url").isString())
+                .andExpect(jsonPath("$.data.posts[0].logoUrl").exists())
+                .andExpect(jsonPath("$.data.posts[0].thumbnailUrl").exists())
+                .andExpect(jsonPath("$.data.posts[0].publishedAt").exists())
+                .andExpect(jsonPath("$.data.posts[0].viewCount").isNumber())
+                .andExpect(jsonPath("$.data.posts[0].keywords").isArray())
+                // 정렬 순서 검증 (두 번째 항목)
+                .andExpect(jsonPath("$.data.posts[1].title").value("어제의 게시글"));
     }
 
     @Test
@@ -307,13 +345,25 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                         .param("size", "20"))
                 .andDo(print())
                 .andExpect(status().isOk())
+                // PostListResponse의 모든 필드 검증 (POPULAR 정렬)
                 .andExpect(jsonPath("$.data.posts").isArray())
                 .andExpect(jsonPath("$.data.posts.length()").value(2))
-                .andExpect(jsonPath("$.data.posts[0].title").value("오늘의 게시글"))
-                .andExpect(jsonPath("$.data.posts[1].title").value("어제의 게시글"))
-                .andExpect(jsonPath("$.data.hasNext").value(false))
                 .andExpect(jsonPath("$.data.lastPostId").exists())
-                .andExpect(jsonPath("$.data.lastViewCount").exists());
+                .andExpect(jsonPath("$.data.lastViewCount").exists())
+                .andExpect(jsonPath("$.data.lastPublishedAt").exists())
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                // PostInfoDto의 모든 필드 검증 (첫 번째 항목만)
+                .andExpect(jsonPath("$.data.posts[0].id").isNumber())
+                .andExpect(jsonPath("$.data.posts[0].title").value("오늘의 게시글"))
+                .andExpect(jsonPath("$.data.posts[0].company").isString())
+                .andExpect(jsonPath("$.data.posts[0].url").isString())
+                .andExpect(jsonPath("$.data.posts[0].logoUrl").exists())
+                .andExpect(jsonPath("$.data.posts[0].thumbnailUrl").exists())
+                .andExpect(jsonPath("$.data.posts[0].publishedAt").exists())
+                .andExpect(jsonPath("$.data.posts[0].viewCount").isNumber())
+                .andExpect(jsonPath("$.data.posts[0].keywords").isArray())
+                // 정렬 순서 검증 (두 번째 항목)
+                .andExpect(jsonPath("$.data.posts[1].title").value("어제의 게시글"));
     }
 
     @Test
@@ -408,5 +458,103 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.posts").isArray())
                 .andExpect(jsonPath("$.data.posts.length()").value(0))
                 .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /api/v2/posts/recent - 비로그인 시 isBookmarked는 null")
+    void getRecentPosts_WithoutAuth_IsBookmarkedIsNull() throws Exception {
+        // When & Then: 비로그인 상태에서 게시글 조회
+        mockMvc.perform(get("/api/v2/posts/recent")
+                        .param("sortBy", "LATEST")
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /api/v2/posts/recent - 로그인 시 isBookmarked 포함")
+    void getRecentPosts_WithAuth_IncludesBookmarks() throws Exception {
+        // Given: todayPost를 북마크
+        ScrabPost scrabPost = ScrabPost.create(testUser, todayPost, LocalDateTime.now());
+        scrabPostRepository.save(scrabPost);
+
+        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
+            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
+
+        // When & Then: 로그인 상태에서 게시글 조회
+        mockMvc.perform(get("/api/v2/posts/recent")
+                        .param("sortBy", "LATEST")
+                        .param("size", "20")
+                        .with(user(userPrincipal)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts.length()").value(2))
+                .andExpect(jsonPath("$.data.posts[0].id").value(todayPost.getId()))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true))
+                .andExpect(jsonPath("$.data.posts[1].id").value(oldPost.getId()))
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /api/v2/posts/by-company - 로그인 시 북마크 정보 포함")
+    void getPostsByCompany_WithAuth_IncludesBookmarks() throws Exception {
+        // Given: oldPost를 북마크
+        ScrabPost scrabPost = ScrabPost.create(testUser, oldPost, LocalDateTime.now());
+        scrabPostRepository.save(scrabPost);
+
+        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
+            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
+
+        // When & Then: 특정 회사 게시글 조회
+        mockMvc.perform(get("/api/v2/posts/by-company")
+                        .param("companies", "네이버")
+                        .param("size", "20")
+                        .with(user(userPrincipal)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts.length()").value(1))
+                .andExpect(jsonPath("$.data.posts[0].id").value(oldPost.getId()))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true));
+    }
+
+    @Test
+    @DisplayName("GET /api/v2/posts/by-company - 비로그인 시 isBookmarked는 null")
+    void getPostsByCompany_WithoutAuth_IsBookmarkedIsNull() throws Exception {
+        // When & Then: 비로그인 상태에서 회사별 게시글 조회
+        mockMvc.perform(get("/api/v2/posts/by-company")
+                        .param("companies", "카카오")
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /api/v2/posts/by-company - 여러 회사 조회 시 북마크 정보 포함")
+    void getPostsByMultipleCompanies_WithAuth_IncludesBookmarks() throws Exception {
+        // Given: 두 게시글 모두 북마크
+        ScrabPost scrabPost1 = ScrabPost.create(testUser, todayPost, LocalDateTime.now());
+        ScrabPost scrabPost2 = ScrabPost.create(testUser, oldPost, LocalDateTime.now());
+        scrabPostRepository.saveAll(List.of(scrabPost1, scrabPost2));
+
+        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
+            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
+
+        // When & Then: 여러 회사 게시글 조회
+        mockMvc.perform(get("/api/v2/posts/by-company")
+                        .param("companies", "카카오", "네이버")
+                        .param("size", "20")
+                        .with(user(userPrincipal)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts.length()").value(2))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true))
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(true));
     }
 }

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerV2IntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerV2IntegrationTest.java
@@ -7,9 +7,11 @@ import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.source.repository.TechBlogRepository;
 import com.techfork.domain.user.entity.User;
+import com.techfork.domain.user.enums.Role;
 import com.techfork.domain.user.enums.SocialType;
 import com.techfork.domain.user.repository.UserRepository;
 import com.techfork.global.common.IntegrationTestBase;
+import com.techfork.global.security.jwt.JwtUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +23,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -49,17 +50,24 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private JwtUtil jwtUtil;
+
     private TechBlog testTechBlog1;
     private TechBlog testTechBlog2;
     private Post todayPost;
     private Post oldPost;
     private User testUser;
+    private String accessToken;
 
     @BeforeEach
     void setUp() {
         // Given: 실제 DB에 테스트 데이터 저장
         testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", "profile.jpg");
         testUser = userRepository.save(testUser);
+
+        // JWT 토큰 생성
+        accessToken = jwtUtil.generateTokens(testUser.getId(), Role.USER).accessToken();
 
         testTechBlog1 = TechBlog.builder()
                 .companyName("카카오")
@@ -108,6 +116,10 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                 .techBlog(testTechBlog2)
                 .build();
         postRepository.save(oldPost);
+
+        // testUser가 todayPost를 북마크
+        ScrabPost scrabPost = ScrabPost.create(testUser, todayPost, LocalDateTime.now());
+        scrabPostRepository.save(scrabPost);
     }
 
     @AfterEach
@@ -140,6 +152,7 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     @DisplayName("GET /api/v2/posts/companies - 게시글이 없는 경우 빈 배열 반환")
     void getCompanies_EmptyWhenNoPosts() throws Exception {
         // Given: 모든 게시글 삭제
+        scrabPostRepository.deleteAll();
         postRepository.deleteAll();
 
         // When & Then: 빈 배열 반환 확인
@@ -299,6 +312,40 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.posts[1].title").value("오늘의 게시글"));
     }
 
+
+    @Test
+    @DisplayName("GET /api/v2/posts/by-company - 비로그인 시 isBookmarked 미포함")
+    void getPostsByCompany_WithoutAuth() throws Exception {
+        // When & Then: 비로그인 상태에서 회사별 게시글 조회
+        mockMvc.perform(get("/api/v2/posts/by-company")
+                        .param("companies", "카카오", "네이버")
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts.length()").value(2))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist())
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /api/v2/posts/by-company - 로그인 시 북마크 여부 포함 (todayPost=true, oldPost=false)")
+    void getPostsByCompany_WithAuth() throws Exception {
+        // When & Then: 여러 회사 게시글 조회
+        mockMvc.perform(get("/api/v2/posts/by-company")
+                        .param("companies", "카카오", "네이버")
+                        .param("size", "20")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts.length()").value(2))
+                .andExpect(jsonPath("$.data.posts[0].id").value(todayPost.getId()))
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true))
+                .andExpect(jsonPath("$.data.posts[1].id").value(oldPost.getId()))
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(false));
+    }
+
     @Test
     @DisplayName("GET /api/v2/posts/recent - LATEST 정렬로 최근 게시글 조회")
     void getRecentPosts_Latest_Success() throws Exception {
@@ -447,6 +494,7 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     @DisplayName("GET /api/v2/posts/recent - 게시글이 없으면 빈 배열 반환")
     void getRecentPosts_EmptyWhenNoPosts() throws Exception {
         // Given: 모든 게시글 삭제
+        scrabPostRepository.deleteAll();
         postRepository.deleteAll();
 
         // When & Then: 빈 배열 반환
@@ -461,8 +509,8 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     }
 
     @Test
-    @DisplayName("GET /api/v2/posts/recent - 비로그인 시 isBookmarked는 null")
-    void getRecentPosts_WithoutAuth_IsBookmarkedIsNull() throws Exception {
+    @DisplayName("GET /api/v2/posts/recent - 비로그인 시 isBookmarked 미포함")
+    void getRecentPosts_WithoutAuth() throws Exception {
         // When & Then: 비로그인 상태에서 게시글 조회
         mockMvc.perform(get("/api/v2/posts/recent")
                         .param("sortBy", "LATEST")
@@ -470,24 +518,20 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.posts").isArray())
-                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist());
+                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist())
+                .andExpect(jsonPath("$.data.posts[1].isBookmarked").doesNotExist());
     }
 
     @Test
-    @DisplayName("GET /api/v2/posts/recent - 로그인 시 isBookmarked 포함")
-    void getRecentPosts_WithAuth_IncludesBookmarks() throws Exception {
-        // Given: todayPost를 북마크
-        ScrabPost scrabPost = ScrabPost.create(testUser, todayPost, LocalDateTime.now());
-        scrabPostRepository.save(scrabPost);
-
-        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
-            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
+    @DisplayName("GET /api/v2/posts/recent - 로그인 시 북마크 여부 포함 (todayPost=true, oldPost=false)")
+    void getRecentPosts_WithAuth() throws Exception {
+        // Given: setUp()에서 todayPost가 이미 북마크됨
 
         // When & Then: 로그인 상태에서 게시글 조회
         mockMvc.perform(get("/api/v2/posts/recent")
                         .param("sortBy", "LATEST")
                         .param("size", "20")
-                        .with(user(userPrincipal)))
+                        .header("Authorization", "Bearer " + accessToken))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.posts").isArray())
@@ -496,65 +540,5 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true))
                 .andExpect(jsonPath("$.data.posts[1].id").value(oldPost.getId()))
                 .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(false));
-    }
-
-    @Test
-    @DisplayName("GET /api/v2/posts/by-company - 로그인 시 북마크 정보 포함")
-    void getPostsByCompany_WithAuth_IncludesBookmarks() throws Exception {
-        // Given: oldPost를 북마크
-        ScrabPost scrabPost = ScrabPost.create(testUser, oldPost, LocalDateTime.now());
-        scrabPostRepository.save(scrabPost);
-
-        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
-            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
-
-        // When & Then: 특정 회사 게시글 조회
-        mockMvc.perform(get("/api/v2/posts/by-company")
-                        .param("companies", "네이버")
-                        .param("size", "20")
-                        .with(user(userPrincipal)))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.posts").isArray())
-                .andExpect(jsonPath("$.data.posts.length()").value(1))
-                .andExpect(jsonPath("$.data.posts[0].id").value(oldPost.getId()))
-                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true));
-    }
-
-    @Test
-    @DisplayName("GET /api/v2/posts/by-company - 비로그인 시 isBookmarked는 null")
-    void getPostsByCompany_WithoutAuth_IsBookmarkedIsNull() throws Exception {
-        // When & Then: 비로그인 상태에서 회사별 게시글 조회
-        mockMvc.perform(get("/api/v2/posts/by-company")
-                        .param("companies", "카카오")
-                        .param("size", "20"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.posts").isArray())
-                .andExpect(jsonPath("$.data.posts[0].isBookmarked").doesNotExist());
-    }
-
-    @Test
-    @DisplayName("GET /api/v2/posts/by-company - 여러 회사 조회 시 북마크 정보 포함")
-    void getPostsByMultipleCompanies_WithAuth_IncludesBookmarks() throws Exception {
-        // Given: 두 게시글 모두 북마크
-        ScrabPost scrabPost1 = ScrabPost.create(testUser, todayPost, LocalDateTime.now());
-        ScrabPost scrabPost2 = ScrabPost.create(testUser, oldPost, LocalDateTime.now());
-        scrabPostRepository.saveAll(List.of(scrabPost1, scrabPost2));
-
-        com.techfork.global.security.oauth.UserPrincipal userPrincipal =
-            com.techfork.global.security.oauth.UserPrincipal.buildUserPrincipal(testUser);
-
-        // When & Then: 여러 회사 게시글 조회
-        mockMvc.perform(get("/api/v2/posts/by-company")
-                        .param("companies", "카카오", "네이버")
-                        .param("size", "20")
-                        .with(user(userPrincipal)))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.posts").isArray())
-                .andExpect(jsonPath("$.data.posts.length()").value(2))
-                .andExpect(jsonPath("$.data.posts[0].isBookmarked").value(true))
-                .andExpect(jsonPath("$.data.posts[1].isBookmarked").value(true));
     }
 }

--- a/src/test/java/com/techfork/domain/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/techfork/domain/post/service/PostQueryServiceTest.java
@@ -119,10 +119,11 @@ class PostQueryServiceTest {
     }
 
     @Test
-    @DisplayName("getPostDetail() - 게시글 상세 조회 성공")
-    void getPostDetail_Success() {
+    @DisplayName("getPostDetail() - 비로그인 상태에서 게시글 상세 조회 성공")
+    void getPostDetail_WithoutAuth_Success() {
         // Given
         Long postId = 1L;
+        Long userId = null;
 
         PostDetailDto mockPostDetail = PostDetailDto.builder()
                 .id(postId)
@@ -134,6 +135,7 @@ class PostQueryServiceTest {
                 .publishedAt(LocalDateTime.now())
                 .viewCount(100L)
                 .keywords(null) // 키워드는 나중에 추가됨
+                .isBookmarked(null)
                 .build();
 
         PostKeyword keyword1 = mock(PostKeyword.class);
@@ -154,14 +156,15 @@ class PostQueryServiceTest {
                 .publishedAt(mockPostDetail.publishedAt())
                 .viewCount(100L)
                 .keywords(keywordStrings)
+                .isBookmarked(null)
                 .build();
 
         given(postRepository.findByIdWithTechBlog(postId)).willReturn(Optional.of(mockPostDetail));
         given(postKeywordRepository.findByPostIdIn(List.of(postId))).willReturn(mockKeywords);
-        given(postConverter.toPostDetailDto(mockPostDetail, keywordStrings)).willReturn(expectedResponse);
+        given(postConverter.toPostDetailDto(mockPostDetail, keywordStrings, null)).willReturn(expectedResponse);
 
         // When
-        PostDetailDto result = postQueryService.getPostDetail(postId);
+        PostDetailDto result = postQueryService.getPostDetail(postId, userId);
 
         // Then
         assertThat(result).isNotNull();
@@ -170,10 +173,126 @@ class PostQueryServiceTest {
         assertThat(result.viewCount()).isEqualTo(100L);
         assertThat(result.keywords()).hasSize(2);
         assertThat(result.keywords()).contains("Java", "Spring");
+        assertThat(result.isBookmarked()).isNull();
 
         verify(postRepository, times(1)).findByIdWithTechBlog(postId);
         verify(postKeywordRepository, times(1)).findByPostIdIn(List.of(postId));
-        verify(postConverter, times(1)).toPostDetailDto(mockPostDetail, keywordStrings);
+        verify(postConverter, times(1)).toPostDetailDto(mockPostDetail, keywordStrings, null);
+        verify(scrabPostRepository, never()).findBookmarkedPostIds(any(), any());
+    }
+
+    @Test
+    @DisplayName("getPostDetail() - 로그인 상태에서 북마크한 게시글 상세 조회 성공")
+    void getPostDetail_WithAuth_BookmarkedPost_Success() {
+        // Given
+        Long postId = 1L;
+        Long userId = 100L;
+
+        PostDetailDto mockPostDetail = PostDetailDto.builder()
+                .id(postId)
+                .title("테스트 제목")
+                .summary("테스트 요약")
+                .company("카카오")
+                .url("https://test.com/1")
+                .logoUrl("https://test.com/logo.png")
+                .publishedAt(LocalDateTime.now())
+                .viewCount(100L)
+                .keywords(null)
+                .isBookmarked(null)
+                .build();
+
+        PostKeyword keyword1 = mock(PostKeyword.class);
+        when(keyword1.getKeyword()).thenReturn("Java");
+        List<PostKeyword> mockKeywords = List.of(keyword1);
+        List<String> keywordStrings = List.of("Java");
+
+        PostDetailDto expectedResponse = PostDetailDto.builder()
+                .id(postId)
+                .title("테스트 제목")
+                .summary("테스트 요약")
+                .company("카카오")
+                .url("https://test.com/1")
+                .logoUrl("https://test.com/logo.png")
+                .publishedAt(mockPostDetail.publishedAt())
+                .viewCount(100L)
+                .keywords(keywordStrings)
+                .isBookmarked(true)
+                .build();
+
+        given(postRepository.findByIdWithTechBlog(postId)).willReturn(Optional.of(mockPostDetail));
+        given(postKeywordRepository.findByPostIdIn(List.of(postId))).willReturn(mockKeywords);
+        given(scrabPostRepository.findBookmarkedPostIds(userId, List.of(postId))).willReturn(List.of(postId));
+        given(postConverter.toPostDetailDto(mockPostDetail, keywordStrings, true)).willReturn(expectedResponse);
+
+        // When
+        PostDetailDto result = postQueryService.getPostDetail(postId, userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(postId);
+        assertThat(result.isBookmarked()).isTrue();
+
+        verify(postRepository, times(1)).findByIdWithTechBlog(postId);
+        verify(postKeywordRepository, times(1)).findByPostIdIn(List.of(postId));
+        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(userId, List.of(postId));
+        verify(postConverter, times(1)).toPostDetailDto(mockPostDetail, keywordStrings, true);
+    }
+
+    @Test
+    @DisplayName("getPostDetail() - 로그인 상태에서 북마크하지 않은 게시글 상세 조회 성공")
+    void getPostDetail_WithAuth_NotBookmarkedPost_Success() {
+        // Given
+        Long postId = 1L;
+        Long userId = 100L;
+
+        PostDetailDto mockPostDetail = PostDetailDto.builder()
+                .id(postId)
+                .title("테스트 제목")
+                .summary("테스트 요약")
+                .company("카카오")
+                .url("https://test.com/1")
+                .logoUrl("https://test.com/logo.png")
+                .publishedAt(LocalDateTime.now())
+                .viewCount(100L)
+                .keywords(null)
+                .isBookmarked(null)
+                .build();
+
+        PostKeyword keyword1 = mock(PostKeyword.class);
+        when(keyword1.getKeyword()).thenReturn("Java");
+        List<PostKeyword> mockKeywords = List.of(keyword1);
+        List<String> keywordStrings = List.of("Java");
+
+        PostDetailDto expectedResponse = PostDetailDto.builder()
+                .id(postId)
+                .title("테스트 제목")
+                .summary("테스트 요약")
+                .company("카카오")
+                .url("https://test.com/1")
+                .logoUrl("https://test.com/logo.png")
+                .publishedAt(mockPostDetail.publishedAt())
+                .viewCount(100L)
+                .keywords(keywordStrings)
+                .isBookmarked(false)
+                .build();
+
+        given(postRepository.findByIdWithTechBlog(postId)).willReturn(Optional.of(mockPostDetail));
+        given(postKeywordRepository.findByPostIdIn(List.of(postId))).willReturn(mockKeywords);
+        given(scrabPostRepository.findBookmarkedPostIds(userId, List.of(postId))).willReturn(List.of());
+        given(postConverter.toPostDetailDto(mockPostDetail, keywordStrings, false)).willReturn(expectedResponse);
+
+        // When
+        PostDetailDto result = postQueryService.getPostDetail(postId, userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.id()).isEqualTo(postId);
+        assertThat(result.isBookmarked()).isFalse();
+
+        verify(postRepository, times(1)).findByIdWithTechBlog(postId);
+        verify(postKeywordRepository, times(1)).findByPostIdIn(List.of(postId));
+        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(userId, List.of(postId));
+        verify(postConverter, times(1)).toPostDetailDto(mockPostDetail, keywordStrings, false);
     }
 
     @Test
@@ -181,10 +300,11 @@ class PostQueryServiceTest {
     void getPostDetail_NotFound_ThrowsException() {
         // Given
         Long postId = 999L;
+        Long userId = null;
         given(postRepository.findByIdWithTechBlog(postId)).willReturn(Optional.empty());
 
         // When & Then
-        assertThatThrownBy(() -> postQueryService.getPostDetail(postId))
+        assertThatThrownBy(() -> postQueryService.getPostDetail(postId, userId))
                 .isInstanceOf(GeneralException.class);
 
         verify(postRepository, times(1)).findByIdWithTechBlog(postId);

--- a/src/test/java/com/techfork/domain/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/techfork/domain/post/service/PostQueryServiceTest.java
@@ -1,5 +1,6 @@
 package com.techfork.domain.post.service;
 
+import com.techfork.domain.activity.repository.ScrabPostRepository;
 import com.techfork.domain.post.converter.PostConverter;
 import com.techfork.domain.post.dto.*;
 import com.techfork.domain.post.entity.PostKeyword;
@@ -39,6 +40,9 @@ class PostQueryServiceTest {
 
     @Mock
     private PostKeywordRepository postKeywordRepository;
+
+    @Mock
+    private ScrabPostRepository scrabPostRepository;
 
     @Mock
     private PostConverter postConverter;
@@ -230,7 +234,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getRecentPosts(sortBy, lastPostId, size);
+        PostListResponse result = postQueryService.getRecentPosts(sortBy, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -284,7 +288,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getRecentPosts(sortBy, lastPostId, size);
+        PostListResponse result = postQueryService.getRecentPosts(sortBy, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -328,7 +332,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getPostsByCompany(company, lastPostId, size);
+        PostListResponse result = postQueryService.getPostsByCompany(company, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -384,7 +388,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size);
+        PostListResponse result = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -444,7 +448,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size);
+        PostListResponse result = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -488,7 +492,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size);
+        PostListResponse result = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -545,7 +549,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size);
+        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -604,7 +608,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size);
+        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -651,7 +655,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size);
+        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -697,7 +701,7 @@ class PostQueryServiceTest {
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
-        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size);
+        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size, null);
 
         // Then
         assertThat(result).isNotNull();
@@ -705,5 +709,319 @@ class PostQueryServiceTest {
         assertThat(result.posts().get(0).publishedAt()).isBefore(lastPublishedAt);
 
         verify(postRepository, times(1)).findRecentPostsWithCursorV2(eq(lastPublishedAt), eq(lastPostId), any(PageRequest.class));
+    }
+
+    @Test
+    @DisplayName("getPostsByCompany() - 로그인 사용자의 북마크 정보 포함 조회")
+    void getPostsByCompany_WithUserId_IncludesBookmarks() {
+        // Given
+        String company = "카카오";
+        Long lastPostId = null;
+        int size = 20;
+        Long userId = 1L;
+
+        List<PostInfoDto> mockPosts = List.of(
+                PostInfoDto.builder()
+                        .id(1L)
+                        .title("카카오 게시글 1")
+                        .company(company)
+                        .url("https://test.com/1")
+                        .logoUrl("https://test.com/logo.png")
+                        .publishedAt(LocalDateTime.now())
+                        .viewCount(50L)
+                        .keywords(List.of("Java"))
+                        .isBookmarked(null)
+                        .build(),
+                PostInfoDto.builder()
+                        .id(2L)
+                        .title("카카오 게시글 2")
+                        .company(company)
+                        .url("https://test.com/2")
+                        .logoUrl("https://test.com/logo.png")
+                        .publishedAt(LocalDateTime.now())
+                        .viewCount(100L)
+                        .keywords(List.of("Spring"))
+                        .isBookmarked(null)
+                        .build()
+        );
+
+        List<Long> bookmarkedPostIds = List.of(1L);
+
+        PostListResponse expectedResponse = PostListResponse.builder()
+                .posts(List.of(
+                        PostInfoDto.builder()
+                                .id(1L)
+                                .title("카카오 게시글 1")
+                                .company(company)
+                                .url("https://test.com/1")
+                                .logoUrl("https://test.com/logo.png")
+                                .publishedAt(mockPosts.get(0).publishedAt())
+                                .viewCount(50L)
+                                .keywords(List.of("Java"))
+                                .isBookmarked(true)
+                                .build(),
+                        PostInfoDto.builder()
+                                .id(2L)
+                                .title("카카오 게시글 2")
+                                .company(company)
+                                .url("https://test.com/2")
+                                .logoUrl("https://test.com/logo.png")
+                                .publishedAt(mockPosts.get(1).publishedAt())
+                                .viewCount(100L)
+                                .keywords(List.of("Spring"))
+                                .isBookmarked(false)
+                                .build()
+                ))
+                .lastPostId(2L)
+                .hasNext(false)
+                .build();
+
+        given(postRepository.findByCompanyWithCursor(eq(company), eq(lastPostId), any(PageRequest.class)))
+                .willReturn(mockPosts);
+        given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
+        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
+
+        // When
+        PostListResponse result = postQueryService.getPostsByCompany(company, lastPostId, size, userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.posts()).hasSize(2);
+        assertThat(result.posts().get(0).isBookmarked()).isTrue();
+        assertThat(result.posts().get(1).isBookmarked()).isFalse();
+
+        verify(postRepository, times(1)).findByCompanyWithCursor(eq(company), eq(lastPostId), any(PageRequest.class));
+        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+    }
+
+    @Test
+    @DisplayName("getPostsByCompany() - 비로그인 사용자는 북마크 정보 없음")
+    void getPostsByCompany_WithoutUserId_NoBookmarks() {
+        // Given
+        String company = "카카오";
+        Long lastPostId = null;
+        int size = 20;
+        Long userId = null;
+
+        List<PostInfoDto> mockPosts = List.of(
+                PostInfoDto.builder()
+                        .id(1L)
+                        .title("카카오 게시글 1")
+                        .company(company)
+                        .url("https://test.com/1")
+                        .logoUrl("https://test.com/logo.png")
+                        .publishedAt(LocalDateTime.now())
+                        .viewCount(50L)
+                        .keywords(List.of("Java"))
+                        .isBookmarked(null)
+                        .build()
+        );
+
+        PostListResponse expectedResponse = PostListResponse.builder()
+                .posts(mockPosts)
+                .lastPostId(1L)
+                .hasNext(false)
+                .build();
+
+        given(postRepository.findByCompanyWithCursor(eq(company), eq(lastPostId), any(PageRequest.class)))
+                .willReturn(mockPosts);
+        given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
+        given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
+
+        // When
+        PostListResponse result = postQueryService.getPostsByCompany(company, lastPostId, size, userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.posts()).hasSize(1);
+        assertThat(result.posts().get(0).isBookmarked()).isNull();
+
+        verify(postRepository, times(1)).findByCompanyWithCursor(eq(company), eq(lastPostId), any(PageRequest.class));
+        verify(scrabPostRepository, never()).findBookmarkedPostIds(any(), any());
+    }
+
+    @Test
+    @DisplayName("getRecentPosts() - 로그인 사용자의 북마크 정보 포함 최근 게시글 조회")
+    void getRecentPosts_WithUserId_IncludesBookmarks() {
+        // Given
+        EPostSortType sortBy = EPostSortType.LATEST;
+        Long lastPostId = null;
+        int size = 20;
+        Long userId = 1L;
+
+        List<PostInfoDto> mockPosts = List.of(
+                PostInfoDto.builder()
+                        .id(1L)
+                        .title("게시글 1")
+                        .company("카카오")
+                        .url("https://test.com/1")
+                        .logoUrl("https://test.com/logo.png")
+                        .publishedAt(LocalDateTime.now())
+                        .viewCount(50L)
+                        .keywords(List.of())
+                        .isBookmarked(null)
+                        .build(),
+                PostInfoDto.builder()
+                        .id(2L)
+                        .title("게시글 2")
+                        .company("네이버")
+                        .url("https://test.com/2")
+                        .logoUrl("https://test.com/logo.png")
+                        .publishedAt(LocalDateTime.now())
+                        .viewCount(100L)
+                        .keywords(List.of())
+                        .isBookmarked(null)
+                        .build()
+        );
+
+        List<Long> bookmarkedPostIds = List.of(2L);
+
+        PostListResponse expectedResponse = PostListResponse.builder()
+                .posts(List.of(
+                        mockPosts.get(0).toBuilder().isBookmarked(false).build(),
+                        mockPosts.get(1).toBuilder().isBookmarked(true).build()
+                ))
+                .lastPostId(2L)
+                .hasNext(false)
+                .build();
+
+        given(postRepository.findRecentPostsWithCursor(eq(lastPostId), any(PageRequest.class)))
+                .willReturn(mockPosts);
+        given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
+        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
+
+        // When
+        PostListResponse result = postQueryService.getRecentPosts(sortBy, lastPostId, size, userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.posts()).hasSize(2);
+        assertThat(result.posts().get(0).isBookmarked()).isFalse();
+        assertThat(result.posts().get(1).isBookmarked()).isTrue();
+
+        verify(postRepository, times(1)).findRecentPostsWithCursor(eq(lastPostId), any(PageRequest.class));
+        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+    }
+
+    @Test
+    @DisplayName("getPostsByCompanyV2() - V2 API 북마크 정보 포함 조회")
+    void getPostsByCompanyV2_WithUserId_IncludesBookmarks() {
+        // Given
+        List<String> companies = List.of("카카오", "네이버");
+        LocalDateTime lastPublishedAt = null;
+        Long lastPostId = null;
+        int size = 20;
+        Long userId = 1L;
+
+        LocalDateTime now = LocalDateTime.now();
+        List<PostInfoDto> mockPosts = List.of(
+                PostInfoDto.builder()
+                        .id(1L)
+                        .title("카카오 게시글")
+                        .company("카카오")
+                        .url("https://test.com/1")
+                        .logoUrl("https://test.com/logo.png")
+                        .publishedAt(now)
+                        .viewCount(50L)
+                        .keywords(List.of())
+                        .isBookmarked(null)
+                        .build(),
+                PostInfoDto.builder()
+                        .id(2L)
+                        .title("네이버 게시글")
+                        .company("네이버")
+                        .url("https://test.com/2")
+                        .logoUrl("https://test.com/logo.png")
+                        .publishedAt(now.minusHours(1))
+                        .viewCount(100L)
+                        .keywords(List.of())
+                        .isBookmarked(null)
+                        .build()
+        );
+
+        List<Long> bookmarkedPostIds = List.of(1L, 2L);
+
+        PostListResponse expectedResponse = PostListResponse.builder()
+                .posts(List.of(
+                        mockPosts.get(0).toBuilder().isBookmarked(true).build(),
+                        mockPosts.get(1).toBuilder().isBookmarked(true).build()
+                ))
+                .lastPostId(2L)
+                .hasNext(false)
+                .build();
+
+        given(postRepository.findByCompanyNamesWithCursor(eq(companies), eq(lastPublishedAt), eq(lastPostId), any(PageRequest.class)))
+                .willReturn(mockPosts);
+        given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
+        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
+
+        // When
+        PostListResponse result = postQueryService.getPostsByCompanyV2(companies, lastPublishedAt, lastPostId, size, userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.posts()).hasSize(2);
+        assertThat(result.posts().get(0).isBookmarked()).isTrue();
+        assertThat(result.posts().get(1).isBookmarked()).isTrue();
+
+        verify(postRepository, times(1)).findByCompanyNamesWithCursor(eq(companies), eq(lastPublishedAt), eq(lastPostId), any(PageRequest.class));
+        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+    }
+
+    @Test
+    @DisplayName("getRecentPostsV2() - V2 API POPULAR 정렬 북마크 정보 포함")
+    void getRecentPostsV2_WithUserId_Popular_IncludesBookmarks() {
+        // Given
+        EPostSortType sortBy = EPostSortType.POPULAR;
+        Integer lastViewCount = null;
+        LocalDateTime lastPublishedAt = null;
+        Long lastPostId = null;
+        int size = 20;
+        Long userId = 1L;
+
+        LocalDateTime now = LocalDateTime.now();
+        List<PostInfoDto> mockPosts = List.of(
+                PostInfoDto.builder()
+                        .id(1L)
+                        .title("인기 게시글 1")
+                        .company("카카오")
+                        .url("https://test.com/1")
+                        .logoUrl("https://test.com/logo.png")
+                        .publishedAt(now)
+                        .viewCount(1000L)
+                        .keywords(List.of())
+                        .isBookmarked(null)
+                        .build()
+        );
+
+        List<Long> bookmarkedPostIds = List.of();
+
+        PostListResponse expectedResponse = PostListResponse.builder()
+                .posts(List.of(
+                        mockPosts.get(0).toBuilder().isBookmarked(false).build()
+                ))
+                .lastPostId(1L)
+                .hasNext(false)
+                .build();
+
+        given(postRepository.findPopularPostsWithCursorV2(eq(lastViewCount), eq(lastPostId), any(PageRequest.class)))
+                .willReturn(mockPosts);
+        given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
+        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
+
+        // When
+        PostListResponse result = postQueryService.getRecentPostsV2(sortBy, lastViewCount, lastPublishedAt, lastPostId, size, userId);
+
+        // Then
+        assertThat(result).isNotNull();
+        assertThat(result.posts()).hasSize(1);
+        assertThat(result.posts().get(0).isBookmarked()).isFalse();
+
+        verify(postRepository, times(1)).findPopularPostsWithCursorV2(eq(lastViewCount), eq(lastPostId), any(PageRequest.class));
+        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
게시글 목록 및 상세 조회 API 응답에 사용자의 북마크 여부를 추가했습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #217 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
