### PR TITLE
[fix/#222] RSS 크롤링 배치 shortSummary 누락 및 API 동시 실행 방지 기능 추가

### DIFF
--- a/src/main/java/com/techfork/domain/post/batch/PostSummaryWriter.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostSummaryWriter.java
@@ -47,14 +47,15 @@ public class PostSummaryWriter implements ItemWriter<Post> {
     }
 
     private void updatePostSummaries(List<? extends Post> posts) {
-        String sql = "UPDATE posts SET summary = ? WHERE id = ?";
+        String sql = "UPDATE posts SET summary = ?, short_summary = ? WHERE id = ?";
 
         @SuppressWarnings("unchecked")
         List<Post> postList = (List<Post>) posts;
 
         int totalUpdated = jdbcBatchExecutor.batchExecute(sql, postList, (ps, post, i) -> {
             ps.setString(1, post.getSummary());
-            ps.setLong(2, post.getId());
+            ps.setString(2, post.getShortSummary());
+            ps.setLong(3, post.getId());
         });
 
         log.debug("UPDATE posts: {}개 업데이트", totalUpdated);

--- a/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
+++ b/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
@@ -1,18 +1,14 @@
 package com.techfork.domain.source.scheduler;
 
 import com.techfork.domain.source.service.CrawlingService;
-import com.techfork.global.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
-
 /**
  * RSS 크롤링 스케줄러
  * - 매일 오전 5시마다 RSS 피드 크롤링 실행
- * - Redis 분산 락으로 중복 실행 방지
  *
  * Note: Job 실행 이력은 Spring Batch의 BATCH_JOB_EXECUTION 테이블에서 관리
  */
@@ -22,10 +18,6 @@ import java.time.Duration;
 public class RssCrawlingScheduler {
 
     private final CrawlingService crawlingService;
-    private final DistributedLock distributedLock;
-
-    private static final String CRAWLING_LOCK_KEY = "rss-crawling";
-    private static final Duration LOCK_TTL = Duration.ofMinutes(30); // 크롤링 최대 실행 시간
 
     /**
      * 매일 오전 5시마다 RSS 크롤링 실행
@@ -34,20 +26,6 @@ public class RssCrawlingScheduler {
     @Scheduled(cron = "0 0 5 * * *")
     public void scheduleCrawling() {
         log.info("RSS crawling scheduler triggered");
-
-        String lockValue = distributedLock.tryLock(CRAWLING_LOCK_KEY, LOCK_TTL);
-
-        if (lockValue == null) {
-            log.warn("Another crawling job is already running. Skipping this execution.");
-            return;
-        }
-
-        try {
-            crawlingService.executeCrawling();
-        } catch (Exception e) {
-            log.error("Unexpected error during scheduled crawling", e);
-        } finally {
-            distributedLock.unlock(CRAWLING_LOCK_KEY, lockValue);
-        }
+        crawlingService.executeCrawling();
     }
 }

--- a/src/main/java/com/techfork/domain/source/service/CrawlingService.java
+++ b/src/main/java/com/techfork/domain/source/service/CrawlingService.java
@@ -1,5 +1,7 @@
 package com.techfork.domain.source.service;
 
+import com.techfork.global.constant.RedisKey;
+import com.techfork.global.lock.DistributedLock;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.*;
@@ -9,10 +11,13 @@ import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteExcep
 import org.springframework.batch.core.repository.JobRestartException;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+
 /**
  * RSS 크롤링 실행 서비스
- * - Job 실행만 담당
+ * - Job 실행 담당
  * - Job 라이프사이클 이벤트(시작/종료)는 RssCrawlingJobListener에서 처리
+ * - Redis 분산 락으로 중복 실행 방지 (스케줄러/API 공통)
  */
 @Slf4j
 @Service
@@ -21,8 +26,20 @@ public class CrawlingService {
 
     private final JobLauncher jobLauncher;
     private final Job rssCrawlingJob;
+    private final DistributedLock distributedLock;
+
+    private static final Duration LOCK_TTL = Duration.ofMinutes(30); // 크롤링 최대 실행 시간
 
     public void executeCrawling() {
+        log.info("RSS crawling execution requested");
+
+        String lockValue = distributedLock.tryLock(RedisKey.CRAWLING_LOCK_KEY, LOCK_TTL);
+
+        if (lockValue == null) {
+            log.warn("Another crawling job is already running. Skipping this execution.");
+            return;
+        }
+
         try {
             // Job 파라미터 생성 (매번 다른 파라미터로 실행)
             JobParameters jobParameters = new JobParametersBuilder()
@@ -41,6 +58,8 @@ public class CrawlingService {
             log.error("Invalid job parameters", e);
         } catch (Exception e) {
             log.error("Unexpected error during crawling", e);
+        } finally {
+            distributedLock.unlock(RedisKey.CRAWLING_LOCK_KEY, lockValue);
         }
     }
 }

--- a/src/main/java/com/techfork/global/constant/RedisKey.java
+++ b/src/main/java/com/techfork/global/constant/RedisKey.java
@@ -4,4 +4,5 @@ public final class RedisKey {
     private RedisKey() {}
 
     public static final String REFRESH_TOKEN_PREFIX = "refreshToken:";
+    public static final String CRAWLING_LOCK_KEY = "rss-crawling";
 }


### PR DESCRIPTION
## ❤️ 기능 설명
현재 수동 크롤링 API에서는 분산락을 적용하지 않아 API와 스케쥴러가 동시에 돌 수 있는 문제점이 있었습니다.
이를 서비스 단에서 분산락을 적용하여 해결하였습니다.

또한 LLM을 통해 추출한 shortSummary 필드를 DB에 저장하지 않던 문제를 해결하였습니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #222 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
