### PR TITLE
[improve/#223] 스케쥴러 Cron값을 한국 시간에 맞추도록 변경

### DIFF
--- a/src/main/java/com/techfork/domain/recommendation/scheduler/RecommendationScheduler.java
+++ b/src/main/java/com/techfork/domain/recommendation/scheduler/RecommendationScheduler.java
@@ -22,11 +22,12 @@ public class RecommendationScheduler {
     private final RecommendationProperties properties;
 
     /**
-     * 매일 새벽 4시에 활성 사용자 대상 추천 생성
-     * - 프로필 생성(3시) 후 1시간 뒤 실행
+     * 매일 오전 7시(KST)에 활성 사용자 대상 추천 생성
+     * - 크롤링(5시) → 프로필 생성(6시) → 추천 생성(7시) 순서
      * - 최근 N시간 이내 활성 사용자만 대상
+     * - 향후 추천 알림 기능 추가 예정
      */
-    @Scheduled(cron = "0 0 4 * * *")
+    @Scheduled(cron = "0 0 7 * * *", zone = "Asia/Seoul")
     public void generateDailyRecommendations() {
         log.info("활성 사용자 대상으로 게시글 추천 시작");
 

--- a/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
+++ b/src/main/java/com/techfork/domain/source/scheduler/RssCrawlingScheduler.java
@@ -6,12 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/**
- * RSS 크롤링 스케줄러
- * - 매일 오전 5시마다 RSS 피드 크롤링 실행
- *
- * Note: Job 실행 이력은 Spring Batch의 BATCH_JOB_EXECUTION 테이블에서 관리
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -20,10 +14,11 @@ public class RssCrawlingScheduler {
     private final CrawlingService crawlingService;
 
     /**
-     * 매일 오전 5시마다 RSS 크롤링 실행
+     * 매일 오전 5시(KST)마다 RSS 크롤링 실행
+     * - 새 글 수집 후 프로필/추천 생성 파이프라인 시작
      * cron: 0 0 5 * * * -> 매일 오전 5시
      */
-    @Scheduled(cron = "0 0 5 * * *")
+    @Scheduled(cron = "0 0 5 * * *", zone = "Asia/Seoul")
     public void scheduleCrawling() {
         log.info("RSS crawling scheduler triggered");
         crawlingService.executeCrawling();

--- a/src/main/java/com/techfork/domain/user/scheduler/UserProfileScheduler.java
+++ b/src/main/java/com/techfork/domain/user/scheduler/UserProfileScheduler.java
@@ -20,9 +20,10 @@ public class UserProfileScheduler {
     private final UserProfileService userProfileService;
 
     /**
-     * 매일 새벽 3시에 최근 24시간 내 활성 사용자의 프로필을 재생성
+     * 매일 오전 6시(KST)에 최근 24시간 내 활성 사용자의 프로필을 재생성
+     * - 크롤링(5시) 후 1시간 뒤 실행
      */
-    @Scheduled(cron = "0 0 3 * * *")
+    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul")
     public void regenerateActiveUserProfiles() {
         log.info("Starting daily user profile regeneration for active users");
 


### PR DESCRIPTION
## ❤️ 기능 설명
현재 스케쥴러들의 Cron의 기본값은 컴퓨터의 시간을 따라가므로 예상과는 다른 시간대에 동작하고 있습니다.
이를 아시아 시간대로 설정하여 원하는대로 동작하도록 변경하였습니다.

또한 크롤링(05:00) -> 사용자 프로필 생성(06:00) -> 추천(07:00) 순으로 동작하도록 스케쥴러의 동작 시간을 변경하였습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #223 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
