### PR TITLE
[chore/#221] Redis 백업 설정 OFF 및 O(N) 명령어 방지

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,9 @@ services:
       --maxmemory-policy allkeys-lru
       --save ""
       --appendonly no
+      --rename-command KEYS ""
+      --rename-command FLUSHALL ""
+      --rename-command FLUSHDB ""
     networks:
       - app-network
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       --requirepass ${REDIS_PASSWORD}
       --maxmemory 1gb
       --maxmemory-policy allkeys-lru
+      --save ""
     networks:
       - app-network
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,6 +72,7 @@ services:
       --maxmemory 1gb
       --maxmemory-policy allkeys-lru
       --save ""
+      --appendonly no
     networks:
       - app-network
     volumes:


### PR DESCRIPTION
## ❤️ 기능 설명
기존에 redis에서 백업이 필요하지 않음에도 기본값으로 백업이 진행되고 있었습니다.
이를 OFF시킴으로써 메모리 활용을 최적화하였고,
` --save ""` : RDB 스냅샷 저장 OFF
`--appendonly no`: AOF 로그 저장 OFF

REDIS는 싱글스레드이므로 O(N) 명령어가 동작할경우 나머지 명령어들이 동작하지 못합니다.
이를 방지하기 위해 명령어를 사용할 수 없도록 하였습니다.
```
--rename-command KEYS ""
--rename-command FLUSHALL ""
--rename-command FLUSHDB ""
```

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #221 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
