### PR TITLE
[improve/#227] 북마크 목록 조회 API에서 페이징과 ORDER BY절 통일

### DIFF
--- a/src/main/java/com/techfork/domain/activity/repository/ScrabPostRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/ScrabPostRepository.java
@@ -24,7 +24,7 @@ public interface ScrabPostRepository extends JpaRepository<ScrabPost, Long> {
             JOIN p.techBlog t
             WHERE s.user = :user
             AND (:lastBookmarkId IS NULL OR s.id < :lastBookmarkId)
-            ORDER BY s.scrappedAt DESC, s.id DESC
+            ORDER BY s.id DESC
             """)
     List<BookmarkDto> findBookmarksWithCursor(
             @Param("user") User user,


### PR DESCRIPTION
## ❤️ 기능 설명
북마크 목록 조회 API에서 쿼리 부분에서 ORDER BY절과 커서가 다른 것을 ID로 통일하였습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #227 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
