### PR TITLE
[fix/#236] Elasticsearch 인덱싱 실패 시 embeddedAt 필드가 잘못 업데이트되는 문제 해결

### DIFF
--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingReader.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingReader.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * 요약이 완료되고 임베딩이 필요한 Post를 읽어오는 Reader
@@ -27,9 +28,8 @@ public class PostEmbeddingReader implements ItemReader<Post> {
     @Override
     public Post read() {
         if(postIterator == null) {
-            Pageable pageable = PageRequest.of(0, 1000, Sort.by(Sort.Direction.DESC, "id"));
-            Page<Post> posts = postRepository.findBySummaryIsNotNullAndEmbeddedAtIsNull(pageable);
-            log.info("임베딩 대상 Post 개수: {}", posts.getContent().size());
+            List<Post> posts = postRepository.findBySummaryIsNotNullAndEmbeddedAtIsNull();
+            log.info("임베딩 대상 Post 개수: {}", posts.size());
             postIterator = posts.iterator();
         }
 

--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingWriter.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingWriter.java
@@ -1,16 +1,14 @@
 package com.techfork.domain.post.batch;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import com.techfork.domain.post.document.PostDocument;
 import com.techfork.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
-import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
-import org.springframework.data.elasticsearch.core.IndexedObjectInformation;
-import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
-import org.springframework.data.elasticsearch.core.query.IndexQuery;
-import org.springframework.data.elasticsearch.core.query.IndexQueryBuilder;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -20,7 +18,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class PostEmbeddingWriter implements ItemWriter<PostDocument> {
 
-    private final ElasticsearchOperations elasticsearchOperations;
+    private final ElasticsearchClient elasticsearchClient;
     private final PostRepository postRepository;
 
     @Override
@@ -31,26 +29,43 @@ public class PostEmbeddingWriter implements ItemWriter<PostDocument> {
             return;
         }
 
-        List<IndexQuery> queries = documents.stream()
-                .map(doc -> new IndexQueryBuilder()
-                        .withId(doc.getId())
-                        .withObject(doc)
-                        .build())
-                .toList();
+        BulkResponse bulkResponse = elasticsearchClient.bulk(b -> b
+                .index("posts")
+                .operations(documents.stream()
+                        .map(doc -> BulkOperation.of(op -> op
+                                .index(i -> i
+                                        .id(doc.getId())
+                                        .document(doc)
+                                )
+                        ))
+                        .toList()
+                )
+        );
 
-        IndexCoordinates index = IndexCoordinates.of("posts");
-        List<IndexedObjectInformation> result = elasticsearchOperations.bulkIndex(queries, index);
-
-        log.info("Elasticsearch Bulk Insert 완료: {} 개 성공", result.size());
-
-        if (result.size() != documents.size()) {
-            log.warn("일부 문서 저장 실패: 요청={}, 성공={}", documents.size(), result.size());
+        if (bulkResponse == null) {
+            log.error("Bulk 응답이 null입니다.");
+            return;
         }
 
-        List<Long> successPostIds = result.stream()
-                .map(IndexedObjectInformation::id)
-                .map(Long::parseLong)
+        if (bulkResponse.errors()) {
+            log.warn("Bulk 인덱싱 중 일부 실패 발생");
+        }
+
+        List<Long> successPostIds = bulkResponse.items().stream()
+                .filter(item -> item.error() == null)  // 에러 없는 것만
+                .map(item -> Long.parseLong(item.id()))
                 .toList();
+
+        int failureCount = documents.size() - successPostIds.size();
+
+        log.info("Elasticsearch Bulk Insert 완료: 성공={}, 실패={}", successPostIds.size(), failureCount);
+
+        if (failureCount > 0) {
+            log.warn("실패한 문서 ID 목록:");
+            bulkResponse.items().stream()
+                    .filter(item -> item.error() != null)
+                    .forEach(item -> log.warn("ID={}, Error={}", item.id(), item.error().reason()));
+        }
 
         if (!successPostIds.isEmpty()) {
             postRepository.bulkUpdateEmbeddedAt(successPostIds, java.time.LocalDateTime.now());

--- a/src/main/java/com/techfork/domain/post/batch/PostEmbeddingWriter.java
+++ b/src/main/java/com/techfork/domain/post/batch/PostEmbeddingWriter.java
@@ -1,7 +1,6 @@
 package com.techfork.domain.post.batch;
 
 import com.techfork.domain.post.document.PostDocument;
-import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,9 +15,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-/**
- * PostDocument를 Elasticsearch에 Bulk Insert하는 Writer
- */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -51,13 +47,16 @@ public class PostEmbeddingWriter implements ItemWriter<PostDocument> {
             log.warn("일부 문서 저장 실패: 요청={}, 성공={}", documents.size(), result.size());
         }
 
-        // ES 저장 성공 후 embeddedAt Bulk 업데이트
-        List<Long> successPostIds = documents.stream()
-                .map(PostDocument::getPostId)
+        List<Long> successPostIds = result.stream()
+                .map(IndexedObjectInformation::id)
+                .map(Long::parseLong)
                 .toList();
 
-        postRepository.bulkUpdateEmbeddedAt(successPostIds, java.time.LocalDateTime.now());
-
-        log.info("Post embeddedAt Bulk 업데이트 완료: {} 개", successPostIds.size());
+        if (!successPostIds.isEmpty()) {
+            postRepository.bulkUpdateEmbeddedAt(successPostIds, java.time.LocalDateTime.now());
+            log.info("Post embeddedAt Bulk 업데이트 완료: {} 개", successPostIds.size());
+        } else {
+            log.warn("ES 저장에 성공한 문서가 없어 embeddedAt 업데이트를 건너뜁니다.");
+        }
     }
 }

--- a/src/main/java/com/techfork/domain/post/document/PostDocument.java
+++ b/src/main/java/com/techfork/domain/post/document/PostDocument.java
@@ -1,5 +1,6 @@
 package com.techfork.domain.post.document;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.techfork.domain.post.entity.Post;
@@ -62,6 +63,7 @@ public class PostDocument {
     @Field(type = FieldType.Nested)
     private List<ContentChunk> contentChunks;
 
+    @JsonIgnore
     public LocalDateTime getPublishedAt() {
         if (publishedAtString == null) {
             return null;

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -28,7 +28,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
             """)
     List<Post> findWithKeywordsBySummaryIsNull();
 
-    Page<Post> findBySummaryIsNotNullAndEmbeddedAtIsNull(Pageable pageable);
+    List<Post> findBySummaryIsNotNullAndEmbeddedAtIsNull();
 
     @Modifying
     @Query("UPDATE Post p SET p.embeddedAt = :embeddedAt WHERE p.id IN :ids")

--- a/src/main/java/com/techfork/domain/post/service/ContentChunkerService.java
+++ b/src/main/java/com/techfork/domain/post/service/ContentChunkerService.java
@@ -1,7 +1,6 @@
 package com.techfork.domain.post.service;
 
 import com.techfork.global.util.ContentCleaner;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -22,14 +21,10 @@ import java.util.regex.Pattern;
 @Service
 public class ContentChunkerService {
 
-    // 최대 청크 크기 (약 500 토큰)
-    private static final int MAX_CHUNK_SIZE = 2000;
+    private static final int MAX_CHUNK_SIZE = 4000;
+    private static final int MIN_CHUNK_SIZE = 500;
+    private static final int OVERLAP_SIZE = 400;
 
-    // 최소 청크 크기 (너무 작은 청크 방지)
-    private static final int MIN_CHUNK_SIZE = 100;
-
-    // 청크 간 오버랩 크기
-    private static final int OVERLAP_SIZE = 200;
 
     // HTML 헤더 패턴 (h1~h6 태그로 섹션 시작 위치 찾기)
     private static final Pattern HTML_HEADER = Pattern.compile("<h[1-6][^>]*>", Pattern.CASE_INSENSITIVE);
@@ -59,7 +54,7 @@ public class ContentChunkerService {
      */
     private List<String> chunkByStructure(String content) {
         List<String> chunks = new ArrayList<>();
-        
+
         Set<Integer> startSet = new TreeSet<>();
         startSet.add(0);
 


### PR DESCRIPTION
## ❤️ 기능 설명
Elasticsearch 인덱싱 실패 시에도 DB의 `embedded_at` 필드가 업데이트되는 문제를 해결했습니다.

### 주요 변경사항

1. **PostEmbeddingWriter 개선**
   - `ElasticsearchOperations.bulkIndex()` → `ElasticsearchClient.bulk()` 직접 사용
   - `BulkResponse.errors()` 및 `item.error()` 체크로 실패한 문서 명확히 식별
   - 성공한 Post ID만 `embeddedAt` 업데이트
   - 실패한 문서의 ID와 에러 원인을 로그에 출력

2. **PostDocument 직렬화 문제 해결**
   - `getPublishedAt()` 메서드에 `@JsonIgnore` 추가
   - ElasticsearchClient가 getter를 자동 호출하여 `LocalDateTime` 직렬화 시도하던 문제 해결
   - `publishedAtString` 필드는 정상적으로 ES에 저장됨

3. **PostEmbeddingReader 페이징 제거**
   - `PageRequest.of(0, 1000)`에서 `List<Post>` 전체 조회로 변경
   - PostRepository에 `findBySummaryIsNotNullAndEmbeddedAtIsNull()` 메서드 추가
   - 수천 개 이하의 데이터에 대해 메모리 문제 없이 전체 처리 가능

4. **ContentChunkerService 최적화**
   - 청크 단위를 늘려 한 게시글당 청크 개수를 최대 20개 전후로 조정
   - 임베딩 API 호출 횟수 감소 및 효율성 개선

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #236 
<br>
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
