### PR TITLE
[feat/#229] 내가 읽은 게시글 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/techfork/domain/activity/controller/ActivityController.java
+++ b/src/main/java/com/techfork/domain/activity/controller/ActivityController.java
@@ -2,6 +2,7 @@ package com.techfork.domain.activity.controller;
 
 import com.techfork.domain.activity.dto.BookmarkListResponse;
 import com.techfork.domain.activity.dto.BookmarkRequest;
+import com.techfork.domain.activity.dto.ReadPostListResponse;
 import com.techfork.domain.activity.dto.ReadPostRequest;
 import com.techfork.domain.activity.dto.SearchHistoryRequest;
 import com.techfork.domain.activity.service.ActivityCommandService;
@@ -28,7 +29,23 @@ public class ActivityController {
 
     private final ActivityCommandService activityCommandService;
     private final ActivityQueryService activityQueryService;
-
+    
+    @Operation(
+            summary = "읽은 게시글 목록 조회",
+            description = "사용자가 읽은 게시글 목록을 조회합니다. 최근 읽은 순서로 정렬됩니다."
+    )
+    @GetMapping("/read-posts")
+    public ResponseEntity<BaseResponse<ReadPostListResponse>> getReadPosts(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Parameter(description = "마지막 읽은 게시글 ID (커서, 선택)")
+            @RequestParam(required = false) Long lastReadPostId,
+            @Parameter(description = "페이지 크기 (기본값: 20)")
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        ReadPostListResponse response = activityQueryService.getReadPosts(userPrincipal.getId(), lastReadPostId, size);
+        return BaseResponse.of(SuccessCode.OK, response);
+    }
+    
     @Operation(
             summary = "읽은 게시글 저장",
             description = "사용자가 특정 게시글을 읽은 기록을 저장합니다. 읽은 시간과 체류 시간을 기록합니다."
@@ -96,5 +113,4 @@ public class ActivityController {
         activityCommandService.deleteBookmark(userPrincipal.getId(), request);
         return BaseResponse.of(SuccessCode.OK);
     }
-
 }

--- a/src/main/java/com/techfork/domain/activity/converter/ActivityConverter.java
+++ b/src/main/java/com/techfork/domain/activity/converter/ActivityConverter.java
@@ -2,6 +2,8 @@ package com.techfork.domain.activity.converter;
 
 import com.techfork.domain.activity.dto.BookmarkDto;
 import com.techfork.domain.activity.dto.BookmarkListResponse;
+import com.techfork.domain.activity.dto.ReadPostDto;
+import com.techfork.domain.activity.dto.ReadPostListResponse;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -18,6 +20,19 @@ public class ActivityConverter {
         return BookmarkListResponse.builder()
                 .bookmarks(content)
                 .lastBookmarkId(lastBookmarkId)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    public ReadPostListResponse toReadPostListResponse(List<ReadPostDto> readPosts, int requestedSize) {
+        boolean hasNext = readPosts.size() > requestedSize;
+        List<ReadPostDto> content = hasNext ? readPosts.subList(0, requestedSize) : readPosts;
+
+        Long lastReadPostId = content.isEmpty() ? null : content.get(content.size() - 1).readPostId();
+
+        return ReadPostListResponse.builder()
+                .readPosts(content)
+                .lastReadPostId(lastReadPostId)
                 .hasNext(hasNext)
                 .build();
     }

--- a/src/main/java/com/techfork/domain/activity/dto/ReadPostDto.java
+++ b/src/main/java/com/techfork/domain/activity/dto/ReadPostDto.java
@@ -1,0 +1,24 @@
+package com.techfork.domain.activity.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record ReadPostDto(
+        Long readPostId,
+        Long postId,
+        String title,
+        String shortSummary,
+        String url,
+        String companyName,
+        String logoUrl,
+        LocalDateTime publishedAt,
+        String thumbnailUrl,
+        Long viewCount,
+        List<String> keywords,
+        Boolean isBookmarked,
+        LocalDateTime readAt
+) {
+}

--- a/src/main/java/com/techfork/domain/activity/dto/ReadPostListResponse.java
+++ b/src/main/java/com/techfork/domain/activity/dto/ReadPostListResponse.java
@@ -1,0 +1,13 @@
+package com.techfork.domain.activity.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReadPostListResponse(
+        List<ReadPostDto> readPosts,
+        Long lastReadPostId,
+        boolean hasNext
+) {
+}

--- a/src/main/java/com/techfork/domain/activity/repository/ReadPostRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/ReadPostRepository.java
@@ -1,5 +1,6 @@
 package com.techfork.domain.activity.repository;
 
+import com.techfork.domain.activity.dto.ReadPostDto;
 import com.techfork.domain.activity.entity.ReadPost;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.user.entity.User;
@@ -22,4 +23,22 @@ public interface ReadPostRepository extends JpaRepository<ReadPost, Long> {
             ORDER BY rp.readAt DESC
             """)
     List<ReadPost> findRecentReadPostsByUserIdWithMinDuration(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("""
+            SELECT new com.techfork.domain.activity.dto.ReadPostDto(
+                rp.id, p.id, p.title, p.shortSummary, p.url, t.companyName, t.logoUrl,
+                p.publishedAt, p.thumbnailUrl, p.viewCount, null, null, rp.readAt
+            )
+            FROM ReadPost rp
+            JOIN rp.post p
+            JOIN p.techBlog t
+            WHERE rp.user.id = :userId
+            AND (:lastReadPostId IS NULL OR rp.id < :lastReadPostId)
+            ORDER BY rp.id DESC
+            """)
+    List<ReadPostDto> findReadPostsWithCursor(
+            @Param("userId") Long userId,
+            @Param("lastReadPostId") Long lastReadPostId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/techfork/domain/activity/service/ActivityQueryService.java
+++ b/src/main/java/com/techfork/domain/activity/service/ActivityQueryService.java
@@ -3,8 +3,10 @@ package com.techfork.domain.activity.service;
 import com.techfork.domain.activity.converter.ActivityConverter;
 import com.techfork.domain.activity.dto.BookmarkDto;
 import com.techfork.domain.activity.dto.BookmarkListResponse;
+import com.techfork.domain.activity.dto.ReadPostDto;
+import com.techfork.domain.activity.dto.ReadPostListResponse;
+import com.techfork.domain.activity.repository.ReadPostRepository;
 import com.techfork.domain.activity.repository.ScrabPostRepository;
-import com.techfork.domain.post.dto.PostInfoDto;
 import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.post.repository.PostKeywordRepository;
 import com.techfork.domain.user.entity.User;
@@ -17,7 +19,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.awt.print.Book;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,6 +32,7 @@ public class ActivityQueryService {
     private final UserRepository userRepository;
     private final ScrabPostRepository scrabPostRepository;
     private final PostKeywordRepository postKeywordRepository;
+    private final ReadPostRepository readPostRepository;
     private final ActivityConverter activityConverter;
 
     public BookmarkListResponse getBookmarks(Long userId, Long lastBookmarkId, int size) {
@@ -42,6 +44,15 @@ public class ActivityQueryService {
         List<BookmarkDto> bookmarksWithKeywords = attachKeywordsToPostInfoList(bookmarks);
 
         return activityConverter.toBookmarkListResponse(bookmarksWithKeywords, size);
+    }
+
+    public ReadPostListResponse getReadPosts(Long userId, Long lastReadPostId, int size) {
+        PageRequest pageRequest = PageRequest.of(0, size + 1);
+        List<ReadPostDto> readPosts = readPostRepository.findReadPostsWithCursor(userId, lastReadPostId, pageRequest);
+        List<ReadPostDto> readPostsWithKeywords = attachKeywordsToReadPosts(readPosts);
+        List<ReadPostDto> readPostsWithBookmarks = attachBookmarksToReadPosts(readPostsWithKeywords, userId);
+
+        return activityConverter.toReadPostListResponse(readPostsWithBookmarks, size);
     }
 
     private List<BookmarkDto> attachKeywordsToPostInfoList(List<BookmarkDto> bookmarks) {
@@ -74,6 +85,71 @@ public class ActivityQueryService {
                         .viewCount(post.viewCount())
                         .keywords(keywordMap.getOrDefault(post.postId(), List.of()))
                         .isBookmarked(post.isBookmarked())
+                        .build())
+                .toList();
+    }
+
+    private List<ReadPostDto> attachKeywordsToReadPosts(List<ReadPostDto> readPosts) {
+        if (readPosts.isEmpty()) {
+            return readPosts;
+        }
+
+        List<Long> postIds = readPosts.stream()
+                .map(ReadPostDto::postId)
+                .toList();
+
+        Map<Long, List<String>> keywordMap = postKeywordRepository.findByPostIdIn(postIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        pk -> pk.getPost().getId(),
+                        Collectors.mapping(PostKeyword::getKeyword, Collectors.toList())
+                ));
+
+        return readPosts.stream()
+                .map(readPost -> ReadPostDto.builder()
+                        .readPostId(readPost.readPostId())
+                        .postId(readPost.postId())
+                        .title(readPost.title())
+                        .shortSummary(readPost.shortSummary())
+                        .url(readPost.url())
+                        .companyName(readPost.companyName())
+                        .logoUrl(readPost.logoUrl())
+                        .publishedAt(readPost.publishedAt())
+                        .thumbnailUrl(readPost.thumbnailUrl())
+                        .viewCount(readPost.viewCount())
+                        .keywords(keywordMap.getOrDefault(readPost.postId(), List.of()))
+                        .isBookmarked(null)
+                        .readAt(readPost.readAt())
+                        .build())
+                .toList();
+    }
+
+    private List<ReadPostDto> attachBookmarksToReadPosts(List<ReadPostDto> readPosts, Long userId) {
+        if (readPosts.isEmpty()) {
+            return readPosts;
+        }
+
+        List<Long> postIds = readPosts.stream()
+                .map(ReadPostDto::postId)
+                .toList();
+
+        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(userId, postIds);
+
+        return readPosts.stream()
+                .map(readPost -> ReadPostDto.builder()
+                        .readPostId(readPost.readPostId())
+                        .postId(readPost.postId())
+                        .title(readPost.title())
+                        .shortSummary(readPost.shortSummary())
+                        .url(readPost.url())
+                        .companyName(readPost.companyName())
+                        .logoUrl(readPost.logoUrl())
+                        .publishedAt(readPost.publishedAt())
+                        .thumbnailUrl(readPost.thumbnailUrl())
+                        .viewCount(readPost.viewCount())
+                        .keywords(readPost.keywords())
+                        .isBookmarked(bookmarkedPostIds.contains(readPost.postId()))
+                        .readAt(readPost.readAt())
                         .build())
                 .toList();
     }

--- a/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
@@ -458,6 +458,105 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.lastBookmarkId").exists());
     }
 
+    // ===== 읽은 게시글 조회 테스트 =====
+
+    @Test
+    @DisplayName("읽은 게시글 목록 조회 성공 - 빈 목록")
+    void getReadPosts_Success_Empty() throws Exception {
+        // When & Then
+        mockMvc.perform(get("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.readPosts").isArray())
+                .andExpect(jsonPath("$.data.readPosts").isEmpty())
+                .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("읽은 게시글 목록 조회 성공 - 여러 개")
+    void getReadPosts_Success_Multiple() throws Exception {
+        // Given - 읽은 게시글 기록 생성 (순서대로 저장)
+        ReadPost readPost1 = ReadPost.create(testUser, testPost1, LocalDateTime.now().minusHours(2), 300);
+        ReadPost readPost2 = ReadPost.create(testUser, testPost2, LocalDateTime.now().minusHours(1), 150);
+        readPostRepository.save(readPost1);
+        readPostRepository.save(readPost2);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.readPosts").isArray())
+                .andExpect(jsonPath("$.data.readPosts.length()").value(2))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                // 첫 번째 읽은 게시글 DTO 전체 필드 검증 (ID 역순이므로 readPost2)
+                .andExpect(jsonPath("$.data.readPosts[0].readPostId").value(readPost2.getId()))
+                .andExpect(jsonPath("$.data.readPosts[0].postId").value(testPost2.getId()))
+                .andExpect(jsonPath("$.data.readPosts[0].title").value("테스트 게시글 2"))
+                .andExpect(jsonPath("$.data.readPosts[0].shortSummary").value("게시글 2의 짧은 요약"))
+                .andExpect(jsonPath("$.data.readPosts[0].url").value("https://test.com/post/2"))
+                .andExpect(jsonPath("$.data.readPosts[0].companyName").value("테스트회사"))
+                .andExpect(jsonPath("$.data.readPosts[0].logoUrl").value("https://test.com/logo.png"))
+                .andExpect(jsonPath("$.data.readPosts[0].publishedAt").exists())
+                .andExpect(jsonPath("$.data.readPosts[0].thumbnailUrl").value("https://test.com/thumb2.png"))
+                .andExpect(jsonPath("$.data.readPosts[0].viewCount").value(0))
+                .andExpect(jsonPath("$.data.readPosts[0].keywords").isArray())
+                .andExpect(jsonPath("$.data.readPosts[0].isBookmarked").value(false))
+                .andExpect(jsonPath("$.data.readPosts[0].readAt").exists());
+    }
+
+    @Test
+    @DisplayName("읽은 게시글 목록 조회 성공 - 북마크 상태 포함")
+    void getReadPosts_Success_WithBookmarks() throws Exception {
+        // Given - 읽은 게시글 기록 생성 (순서대로 저장)
+        ReadPost readPost1 = ReadPost.create(testUser, testPost1, LocalDateTime.now().minusHours(2), 300);
+        ReadPost readPost2 = ReadPost.create(testUser, testPost2, LocalDateTime.now().minusHours(1), 150);
+        readPostRepository.save(readPost1);
+        readPostRepository.save(readPost2);
+
+        // Given - testPost2만 북마크 (readPost2가 먼저 조회됨)
+        ScrabPost bookmark = ScrabPost.create(testUser, testPost2, LocalDateTime.now());
+        scrabPostRepository.save(bookmark);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.readPosts.length()").value(2))
+                .andExpect(jsonPath("$.data.readPosts[0].postId").value(testPost2.getId()))
+                .andExpect(jsonPath("$.data.readPosts[0].isBookmarked").value(true))  // testPost2
+                .andExpect(jsonPath("$.data.readPosts[1].postId").value(testPost1.getId()))
+                .andExpect(jsonPath("$.data.readPosts[1].isBookmarked").value(false)); // testPost1
+    }
+
+    @Test
+    @DisplayName("읽은 게시글 목록 조회 성공 - 커서 기반 페이징")
+    void getReadPosts_Success_WithCursor() throws Exception {
+        // Given - 여러 개의 읽은 게시글 생성
+        ReadPost readPost1 = ReadPost.create(testUser, testPost1, LocalDateTime.now().minusHours(1), 300);
+        ReadPost readPost2 = ReadPost.create(testUser, testPost2, LocalDateTime.now().minusHours(2), 150);
+        readPostRepository.save(readPost1);
+        readPostRepository.save(readPost2);
+
+        // When & Then - 첫 페이지 조회
+        mockMvc.perform(get("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "1"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.data.readPosts.length()").value(1))
+                .andExpect(jsonPath("$.data.hasNext").value(true))
+                .andExpect(jsonPath("$.data.lastReadPostId").exists());
+    }
+
     // ===== 통합 시나리오 테스트 =====
 
     @Test
@@ -493,5 +592,29 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
                         .param("size", "20"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.bookmarks").isEmpty());
+    }
+
+    @Test
+    @DisplayName("통합 시나리오 - 게시글 읽기 후 읽은 목록 조회")
+    void integrationScenario_ReadPost_GetReadPosts() throws Exception {
+        // 1. 게시글 읽기 기록 저장
+        ReadPostRequest readRequest = new ReadPostRequest(
+                testPost1.getId(),
+                LocalDateTime.now(),
+                300
+        );
+        mockMvc.perform(post("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(readRequest)))
+                .andExpect(status().isCreated());
+
+        // 2. 읽은 게시글 목록 조회
+        mockMvc.perform(get("/api/v1/activities/read-posts")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.readPosts.length()").value(1))
+                .andExpect(jsonPath("$.data.readPosts[0].postId").value(testPost1.getId()));
     }
 }

--- a/src/test/java/com/techfork/domain/activity/service/ActivityQueryServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityQueryServiceTest.java
@@ -3,6 +3,9 @@ package com.techfork.domain.activity.service;
 import com.techfork.domain.activity.converter.ActivityConverter;
 import com.techfork.domain.activity.dto.BookmarkDto;
 import com.techfork.domain.activity.dto.BookmarkListResponse;
+import com.techfork.domain.activity.dto.ReadPostDto;
+import com.techfork.domain.activity.dto.ReadPostListResponse;
+import com.techfork.domain.activity.repository.ReadPostRepository;
 import com.techfork.domain.activity.repository.ScrabPostRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.entity.PostKeyword;
@@ -43,6 +46,9 @@ class ActivityQueryServiceTest {
     private ScrabPostRepository scrabPostRepository;
 
     @Mock
+    private ReadPostRepository readPostRepository;
+
+    @Mock
     private PostKeywordRepository postKeywordRepository;
 
     @Mock
@@ -54,6 +60,7 @@ class ActivityQueryServiceTest {
     private User mockUser;
     private List<BookmarkDto> mockBookmarksFirstPage;
     private List<BookmarkDto> mockBookmarksSecondPage;
+    private List<ReadPostDto> mockReadPostsFirstPage;
 
     @BeforeEach
     void setUp() {
@@ -344,5 +351,216 @@ class ActivityQueryServiceTest {
         verify(scrabPostRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
         verify(postKeywordRepository, times(1)).findByPostIdIn(any());
         verify(activityConverter, times(1)).toBookmarkListResponse(any(), eq(size));
+    }
+
+    // ===== 읽은 게시글 조회 테스트 =====
+
+    @Test
+    @DisplayName("읽은 게시글 목록 조회 성공 - 첫 페이지")
+    void getReadPosts_Success_FirstPage() {
+        // Given
+        Long userId = 1L;
+        Long lastReadPostId = null;
+        int size = 20;
+
+        LocalDateTime now = LocalDateTime.now();
+        List<ReadPostDto> mockReadPosts = Arrays.asList(
+                ReadPostDto.builder()
+                        .readPostId(3L)
+                        .postId(103L)
+                        .title("읽은 게시글 3")
+                        .shortSummary("요약 3")
+                        .url("https://test.com/3")
+                        .companyName("회사A")
+                        .logoUrl("logo.png")
+                        .publishedAt(now.minusDays(3))
+                        .thumbnailUrl("thumb3.png")
+                        .viewCount(100L)
+                        .keywords(null)
+                        .isBookmarked(null)
+                        .readAt(now.minusHours(1))
+                        .build(),
+                ReadPostDto.builder()
+                        .readPostId(2L)
+                        .postId(102L)
+                        .title("읽은 게시글 2")
+                        .shortSummary("요약 2")
+                        .url("https://test.com/2")
+                        .companyName("회사B")
+                        .logoUrl("logo.png")
+                        .publishedAt(now.minusDays(2))
+                        .thumbnailUrl("thumb2.png")
+                        .viewCount(200L)
+                        .keywords(null)
+                        .isBookmarked(null)
+                        .readAt(now.minusHours(2))
+                        .build()
+        );
+
+        given(readPostRepository.findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class)))
+                .willReturn(mockReadPosts);
+        given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
+        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(List.of());
+
+        ReadPostListResponse expectedResponse = new ReadPostListResponse(mockReadPosts, 2L, false);
+        given(activityConverter.toReadPostListResponse(any(), eq(size))).willReturn(expectedResponse);
+
+        // When
+        ReadPostListResponse response = activityQueryService.getReadPosts(userId, lastReadPostId, size);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.readPosts()).hasSize(2);
+        assertThat(response.lastReadPostId()).isEqualTo(2L);
+        assertThat(response.hasNext()).isFalse();
+
+        verify(readPostRepository, times(1)).findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class));
+        verify(postKeywordRepository, times(1)).findByPostIdIn(any());
+        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+        verify(activityConverter, times(1)).toReadPostListResponse(any(), eq(size));
+    }
+
+    @Test
+    @DisplayName("읽은 게시글 목록 조회 성공 - 키워드 및 북마크 상태 포함")
+    void getReadPosts_Success_WithKeywordsAndBookmarks() {
+        // Given
+        Long userId = 1L;
+        Long lastReadPostId = null;
+        int size = 20;
+
+        LocalDateTime now = LocalDateTime.now();
+        List<ReadPostDto> mockReadPosts = Arrays.asList(
+                ReadPostDto.builder()
+                        .readPostId(3L)
+                        .postId(103L)
+                        .title("읽은 게시글 3")
+                        .shortSummary("요약 3")
+                        .url("https://test.com/3")
+                        .companyName("회사A")
+                        .logoUrl("logo.png")
+                        .publishedAt(now.minusDays(3))
+                        .thumbnailUrl("thumb3.png")
+                        .viewCount(100L)
+                        .keywords(null)
+                        .isBookmarked(null)
+                        .readAt(now.minusHours(1))
+                        .build(),
+                ReadPostDto.builder()
+                        .readPostId(2L)
+                        .postId(102L)
+                        .title("읽은 게시글 2")
+                        .shortSummary("요약 2")
+                        .url("https://test.com/2")
+                        .companyName("회사B")
+                        .logoUrl("logo.png")
+                        .publishedAt(now.minusDays(2))
+                        .thumbnailUrl("thumb2.png")
+                        .viewCount(200L)
+                        .keywords(null)
+                        .isBookmarked(null)
+                        .readAt(now.minusHours(2))
+                        .build()
+        );
+
+        given(readPostRepository.findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class)))
+                .willReturn(mockReadPosts);
+
+        // PostKeyword 목 객체 생성
+        Post mockPost1 = mock(Post.class);
+        given(mockPost1.getId()).willReturn(103L);
+        PostKeyword keyword1 = PostKeyword.builder()
+                .keyword("Java")
+                .post(mockPost1)
+                .build();
+        PostKeyword keyword2 = PostKeyword.builder()
+                .keyword("Spring")
+                .post(mockPost1)
+                .build();
+
+        given(postKeywordRepository.findByPostIdIn(any()))
+                .willReturn(List.of(keyword1, keyword2));
+
+        // 103L 게시글만 북마크됨
+        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(List.of(103L));
+
+        List<ReadPostDto> expectedReadPostsWithMetadata = Arrays.asList(
+                ReadPostDto.builder()
+                        .readPostId(3L)
+                        .postId(103L)
+                        .title("읽은 게시글 3")
+                        .shortSummary("요약 3")
+                        .url("https://test.com/3")
+                        .companyName("회사A")
+                        .logoUrl("logo.png")
+                        .publishedAt(mockReadPosts.get(0).publishedAt())
+                        .thumbnailUrl("thumb3.png")
+                        .viewCount(100L)
+                        .keywords(List.of("Java", "Spring"))
+                        .isBookmarked(true)
+                        .readAt(mockReadPosts.get(0).readAt())
+                        .build(),
+                ReadPostDto.builder()
+                        .readPostId(2L)
+                        .postId(102L)
+                        .title("읽은 게시글 2")
+                        .shortSummary("요약 2")
+                        .url("https://test.com/2")
+                        .companyName("회사B")
+                        .logoUrl("logo.png")
+                        .publishedAt(mockReadPosts.get(1).publishedAt())
+                        .thumbnailUrl("thumb2.png")
+                        .viewCount(200L)
+                        .keywords(List.of())
+                        .isBookmarked(false)
+                        .readAt(mockReadPosts.get(1).readAt())
+                        .build()
+        );
+
+        ReadPostListResponse expectedResponse = new ReadPostListResponse(expectedReadPostsWithMetadata, 2L, false);
+        given(activityConverter.toReadPostListResponse(any(), eq(size))).willReturn(expectedResponse);
+
+        // When
+        ReadPostListResponse response = activityQueryService.getReadPosts(userId, lastReadPostId, size);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.readPosts()).hasSize(2);
+        assertThat(response.readPosts().get(0).keywords()).containsExactlyInAnyOrder("Java", "Spring");
+        assertThat(response.readPosts().get(0).isBookmarked()).isTrue();
+        assertThat(response.readPosts().get(1).keywords()).isEmpty();
+        assertThat(response.readPosts().get(1).isBookmarked()).isFalse();
+
+        verify(readPostRepository, times(1)).findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class));
+        verify(postKeywordRepository, times(1)).findByPostIdIn(any());
+        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+    }
+
+    @Test
+    @DisplayName("읽은 게시글 목록 조회 성공 - 빈 목록")
+    void getReadPosts_Success_EmptyList() {
+        // Given
+        Long userId = 1L;
+        Long lastReadPostId = null;
+        int size = 20;
+
+        List<ReadPostDto> emptyReadPosts = List.of();
+        given(readPostRepository.findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class)))
+                .willReturn(emptyReadPosts);
+
+        ReadPostListResponse expectedResponse = new ReadPostListResponse(emptyReadPosts, null, false);
+        given(activityConverter.toReadPostListResponse(emptyReadPosts, size)).willReturn(expectedResponse);
+
+        // When
+        ReadPostListResponse response = activityQueryService.getReadPosts(userId, lastReadPostId, size);
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.readPosts()).isEmpty();
+        assertThat(response.lastReadPostId()).isNull();
+        assertThat(response.hasNext()).isFalse();
+
+        verify(readPostRepository, times(1)).findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class));
+        verify(postKeywordRepository, never()).findByPostIdIn(any());
+        verify(scrabPostRepository, never()).findBookmarkedPostIds(any(), any());
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명
내가 읽은 게시글의 목록을 최신순으로 조회하는 API를 구현했습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #229 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
