### PR TITLE
[deploy/#258] CD 스크립트에서 외부 환경에서 인스턴스로 헬스 체크하는 프로세스 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -106,18 +106,3 @@ jobs:
             cd ~/deploy
             chmod +x scripts/deploy.sh
             ./scripts/deploy.sh
-
-      - name: Health check
-        run: |
-          echo "🚀 Starting health check..."
-          for i in {1..18}; do
-            response=$(curl -s -o /dev/null -w "%{http_code}" https://techfork.shop/actuator/health || echo "000")
-            if [ "$response" = "200" ]; then
-              echo "✅ (Attempt $i/18) Health check successful!"
-              exit 0
-            fi
-            echo "🟡 (Attempt $i/18) Health check failed with status $response. Retrying in 5 seconds..."
-            sleep 5
-          done
-          echo "❌ Health check failed after 90 seconds."
-          exit 1


### PR DESCRIPTION
## ❤️ 기능 설명
현재 인스턴스에 대한 헬스 체크가 deploy.sh로 진행되고 있음에도 불구하고,
외부에서 인스턴스로 접근이 원활하게 되는 것을 확인하기 위해 CD 스크립트에서도 체크를 진행하고 있었습니다.

하지만 Cloudflare의 bot fight mode를 활성화하며, 이 헬스체크가 봇으로 인식되었습니다.
deploy.sh의 헬스 체크만으로 인스턴스의 헬스 체크는 원활하게 진행되므로 이를 삭제합니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #258 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
