### PR TITLE
[fix/#266] Nginx 헤더 설정 오류로 프로토콜 전달 오류 해결

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -30,7 +30,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
 
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;
@@ -60,7 +60,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
 
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;


### PR DESCRIPTION
## ❤️ 기능 설명
현재 소셜 로그인을 진행하고 나서 리다이렉트 경로를 http로 잘못 전달하고 있었습니다.

이는 Nginx에서 TLS를 처리하는 게 아닌 Cloudflare에서 처리함에도 불구하고
`proxy_set_header X-Forwarded-Proto`의 값을 `$scheme`로 사용하여 프로토콜이 제대로 전달되지 않았습니다.

이를 `$http_x_forwarded_proto;`로 변경하여 해결합니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #266 
<br>
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
