### PR TITLE
[chore/#271] Github Actions 의존성 최신화

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -44,7 +44,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/arm64

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download JAR from CI
         uses: actions/download-artifact@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Copy deployment files to server
         uses: appleboy/scp-action@v0.1.7

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Copy deployment files to server
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@v1
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,7 +93,7 @@ jobs:
           target: "~/deploy/"
 
       - name: Deploy with blue-green strategy
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download JAR from CI
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: tech-fork-jar
           path: build/libs/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: ./gradlew build --no-daemon
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: tech-fork-jar
           path: build/libs/*.jar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew


### PR DESCRIPTION
## ❤️ 기능 설명
GitHub Actions 워크플로우(ci.yml, cd.yml)에서 사용 중인 액션 버전을 최신화했습니다.

| 액션 | 변경 전 | 변경 후 |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-java` | v4 | v5 |
| `gradle/actions/setup-gradle` | v3 | v5 |
| `actions/upload-artifact` | v4 | v6 |
| `actions/download-artifact` | v4 | v7 |
| `docker/build-push-action` | v5 | v6 |
| `appleboy/scp-action` | v0.1.7 | v1 |
| `appleboy/ssh-action` | v1.0.3 | v1 |

`appleboy` 계열 액션은 major 버전 태그(`v1`)를 사용하여 이후 패치 버전이 자동으로 반영됩니다.

swagger 테스트 성공 결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #271 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
