### PR TITLE
[chore/#272] Dependabot으로 GitHub Actions 의존성 자동 관리

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## ❤️ 기능 설명
`.github/dependabot.yml`을 추가하여 GitHub Actions 의존성을 Dependabot이 매주 자동으로 감지하고 업데이트 PR을 올리도록 설정했습니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #272 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
