### PR TITLE
[deploy/#269] Apple .p8 키 파일이 Docker 이미지에 번들링되는 보안 취약점 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,11 +32,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Create Apple Private Key file
-        run: |
-          mkdir -p src/main/resources/keys
-          echo "${{ secrets.APPLE_PRIVATE_KEY }}" > src/main/resources/keys/AuthKey_${{ secrets.APPLE_KEY_ID }}.p8
-
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
@@ -71,7 +66,6 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
       APPLE_CLIENT_ID: ${{ secrets.APPLE_CLIENT_ID }}
-      APPLE_PRIVATE_KEY: ${{ secrets.APPLE_PRIVATE_KEY }}
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
       JWT_REDIRECT_URI: ${{ secrets.JWT_REDIRECT_URI }}
       JWT_REDIRECT_URI_DEV: ${{ secrets.JWT_REDIRECT_URI_DEV }}
@@ -92,6 +86,22 @@ jobs:
           source: "docker/,scripts/deploy.sh"
           target: "~/deploy/"
 
+      - name: Place Apple private key on server
+        uses: appleboy/ssh-action@v1
+        env:
+          APPLE_PRIVATE_KEY: ${{ secrets.APPLE_PRIVATE_KEY }}
+          APPLE_KEY_ID: ${{ secrets.APPLE_KEY_ID }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          envs: APPLE_PRIVATE_KEY,APPLE_KEY_ID
+          script: |
+            mkdir -p ~/keys
+            chmod 700 ~/keys
+            printf '%s' "$APPLE_PRIVATE_KEY" > ~/keys/AuthKey_${APPLE_KEY_ID}.p8
+            chmod 600 ~/keys/AuthKey_${APPLE_KEY_ID}.p8
+
       - name: Deploy with blue-green strategy
         uses: appleboy/ssh-action@v1
         with:
@@ -103,7 +113,7 @@ jobs:
             DOCKER_IMAGE,BRANCH,SPRING_PROFILES_ACTIVE,DB_URL,DB_PASSWORD,REDIS_PASSWORD,
             DISCORD_WEBHOOK_URL,ANTHROPIC_API_KEY,OPENAI_API_KEY,
             KAKAO_REST_API_KEY,KAKAO_CLIENT_SECRET,
-            APPLE_TEAM_ID,APPLE_KEY_ID,APPLE_CLIENT_ID,APPLE_PRIVATE_KEY,
+            APPLE_TEAM_ID,APPLE_KEY_ID,APPLE_CLIENT_ID,
             JWT_SECRET,JWT_REDIRECT_URI,JWT_REDIRECT_URI_DEV,JWT_LOGIN_FAILURE_REDIRECT_URI,JWT_LOGIN_FAILURE_REDIRECT_URI_DEV,SERVER_DOMAIN
           script: |
             cd ~/deploy

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,7 @@ stop-dev-tunnel.sh
 .env
 
 ### Apple Private Keys ###
-src/main/resources/keys/
+/keys
 *.p8
 
 ### Test json files ###

--- a/docker/docker-compose.blue.yml
+++ b/docker/docker-compose.blue.yml
@@ -18,11 +18,13 @@ services:
       - APPLE_TEAM_ID=${APPLE_TEAM_ID}
       - APPLE_KEY_ID=${APPLE_KEY_ID}
       - APPLE_CLIENT_ID=${APPLE_CLIENT_ID}
-      - APPLE_PRIVATE_KEY_PATH=keys/AuthKey_${APPLE_KEY_ID}.p8
+      - APPLE_PRIVATE_KEY_PATH=/app/keys/AuthKey_${APPLE_KEY_ID}.p8
       - JWT_SECRET=${JWT_SECRET}
       - JWT_REDIRECT_URI=${JWT_REDIRECT_URI}
       - JWT_LOGIN_FAILURE_REDIRECT_URI=${JWT_LOGIN_FAILURE_REDIRECT_URI}
       - SERVER_DOMAIN=${SERVER_DOMAIN}
+    volumes:
+      - ~/keys:/app/keys:ro
     networks:
       techfork-network:
         aliases:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -18,11 +18,13 @@ services:
       - APPLE_TEAM_ID=${APPLE_TEAM_ID}
       - APPLE_KEY_ID=${APPLE_KEY_ID}
       - APPLE_CLIENT_ID=${APPLE_CLIENT_ID}
-      - APPLE_PRIVATE_KEY_PATH=keys/AuthKey_${APPLE_KEY_ID}.p8
+      - APPLE_PRIVATE_KEY_PATH=/app/keys/AuthKey_${APPLE_KEY_ID}.p8
       - JWT_SECRET=${JWT_SECRET}
       - JWT_REDIRECT_URI=${JWT_REDIRECT_URI_DEV}
       - JWT_LOGIN_FAILURE_REDIRECT_URI=${JWT_LOGIN_FAILURE_REDIRECT_URI_DEV}
       - SERVER_DOMAIN=${SERVER_DOMAIN}
+    volumes:
+      - ~/keys:/app/keys:ro
     networks:
       techfork-network:
         aliases:

--- a/docker/docker-compose.green.yml
+++ b/docker/docker-compose.green.yml
@@ -18,11 +18,13 @@ services:
       - APPLE_TEAM_ID=${APPLE_TEAM_ID}
       - APPLE_KEY_ID=${APPLE_KEY_ID}
       - APPLE_CLIENT_ID=${APPLE_CLIENT_ID}
-      - APPLE_PRIVATE_KEY_PATH=keys/AuthKey_${APPLE_KEY_ID}.p8
+      - APPLE_PRIVATE_KEY_PATH=/app/keys/AuthKey_${APPLE_KEY_ID}.p8
       - JWT_SECRET=${JWT_SECRET}
       - JWT_REDIRECT_URI=${JWT_REDIRECT_URI}
       - JWT_LOGIN_FAILURE_REDIRECT_URI=${JWT_LOGIN_FAILURE_REDIRECT_URI}
       - SERVER_DOMAIN=${SERVER_DOMAIN}
+    volumes:
+      - ~/keys:/app/keys:ro
     networks:
       techfork-network:
         aliases:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -102,7 +102,7 @@ trap cleanup EXIT
 
 # Generate .env from SSH-injected environment variables
 log "Writing .env file..."
-env | grep -E '^(DOCKER_IMAGE|BRANCH|SPRING_PROFILES_ACTIVE|DB_|REDIS_|ANTHROPIC_|OPENAI_|DISCORD_|KAKAO_|APPLE_|JWT_|SERVER_)' > "${DOCKER_DIR}/.env"
+env | grep -E '^(DOCKER_IMAGE|BRANCH|SPRING_PROFILES_ACTIVE|DB_|REDIS_|ANTHROPIC_|OPENAI_|DISCORD_|KAKAO_|APPLE_TEAM_ID|APPLE_KEY_ID|APPLE_CLIENT_ID|JWT_|SERVER_)' > "${DOCKER_DIR}/.env"
 chmod 600 "${DOCKER_DIR}/.env"
 
 # Step 1: Ensure Docker network exists

--- a/src/main/java/com/techfork/global/security/util/AppleClientSecretGenerator.java
+++ b/src/main/java/com/techfork/global/security/util/AppleClientSecretGenerator.java
@@ -4,11 +4,11 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -65,8 +65,7 @@ public class AppleClientSecretGenerator {
      */
     private PrivateKey getPrivateKey() throws Exception {
         try {
-            ClassPathResource resource = new ClassPathResource(privateKeyPath);
-            String privateKeyContent = new String(Files.readAllBytes(resource.getFile().toPath()));
+            String privateKeyContent = new String(Files.readAllBytes(Paths.get(privateKeyPath)));
 
             // PEM 파일에서 헤더/푸터 제거
             privateKeyContent = privateKeyContent

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -43,3 +43,6 @@ logging:
     org.springframework.batch: INFO
     org.hibernate.SQL: INFO
     org.hibernate.type.descriptor.sql.BasicBinder: WARN
+
+apple:
+  private-key-path: /app/keys/AuthKey_${APPLE_KEY_ID}.p8

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,7 +77,7 @@ jwt:
 apple:
   team-id: ${APPLE_TEAM_ID}
   key-id: ${APPLE_KEY_ID}
-  private-key-path: ${APPLE_PRIVATE_KEY_PATH:keys/AppleAuthKey.p8}
+  private-key-path: keys/AppleAuthKey.p8
 
 server:
   domain: ${SERVER_DOMAIN:localhost}


### PR DESCRIPTION
## ❤️ 기능 설명
Apple Login용 `.p8` Private Key가 Docker 이미지에 번들링되던 보안 취약점을 수정합니다.
  키 파일을 빌드 시점이 아닌 런타임에 EC2 볼륨 마운트로 주입하는 방식으로 변경합니다.

swagger 테스트 성공 결과 스크린샷 첨부
<img width="1331" height="52" alt="image" src="https://github.com/user-attachments/assets/341f76a8-f055-4448-bd2f-e9e045d27051" />

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #269 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] key 폴더가 루트 디렉터리 아래에 오도록 변경해야 합니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
