### PR TITLE
[deploy/#268] Dockerfile JDK → JRE 전환 및 JAVA_OPTS 환경변수 미적용 버그 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Java 17
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:17-jre
 
 RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
 # 애플리케이션 실행
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
## ❤️ 기능 설명
Dockerfile 베이스 이미지를 JRE로 교체해 이미지 크기를 줄이고,
  `JAVA_OPTS` 환경변수가 실제로 적용되지 않던 문제를 수정합니다.

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #268 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
