### PR TITLE
[chore/#283] HicariCP 부하테스트 전 기본 설정 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,17 +4,6 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
-    hikari:
-      # 풀 크기
-      maximum-pool-size: 20
-      minimum-idle: 20
-      # 타임아웃
-      connection-timeout: 5000
-      max-lifetime: 1800000
-      # 커넥션 유효성
-      keepalive-time: 60000
-      # 모니터링
-      pool-name: TechFork-HikariCP
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
       maximum-pool-size: 20
       minimum-idle: 20
 
-      connection-timeout: 20000
+      connection-timeout: 5000
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -8,8 +8,9 @@ spring:
       # 풀 크기
       maximum-pool-size: 20
       minimum-idle: 20
-
+      # 타임아웃
       connection-timeout: 5000
+      max-lifetime: 1800000
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -13,6 +13,8 @@ spring:
       max-lifetime: 1800000
       # 커넥션 유효성
       keepalive-time: 60000
+      # 모니터링
+      pool-name: TechFork-HikariCP
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,6 +11,8 @@ spring:
       # 타임아웃
       connection-timeout: 5000
       max-lifetime: 1800000
+      # 커넥션 유효성
+      keepalive-time: 60000
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,8 +5,10 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     hikari:
+      # 풀 크기
       maximum-pool-size: 20
-      minimum-idle: 10
+      minimum-idle: 20
+
       connection-timeout: 20000
   jpa:
     hibernate:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -4,10 +4,6 @@ spring:
     url: jdbc:mysql://localhost:3306/techblog?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
     username: techfork
     password: techfork1234
-    hikari:
-      maximum-pool-size: 10
-      minimum-idle: 5
-      connection-timeout: 20000
   jpa:
     hibernate:
       ddl-auto: validate

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,19 @@ spring:
           model: gpt-4o-mini
           temperature: 0.3
           max-tokens: 8192
+  datasource:
+    hikari:
+      # 풀 크기
+      maximum-pool-size: 10
+      minimum-idle: 10
+      # 타임아웃
+      connection-timeout: 5000
+      idle-timeout: 600000
+      max-lifetime: 1800000
+      # 커넥션 유효성
+      keepalive-time: 60000
+      # 모니터링
+      pool-name: TechFork-HikariCP
   jpa:
     open-in-view: false
   devtools:


### PR DESCRIPTION
## ❤️ 기능 설명
HikariCP 설정을 튜닝하고 프로파일별로 흩어져 있던 설정을 `application.yml`로 공통화했습니다.

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| `connection-timeout` | 20000ms | 5000ms |
| `max-lifetime` | 미설정 (기본 30분) | 1800000ms (명시) |
| `idle-timeout` | 미설정 | 600000ms |
| `keepalive-time` | 미설정 | 60000ms |
| `pool-name` | 미설정 | TechFork-HikariCP |
| 설정 위치 | 프로파일별 분산 | application.yml 공통 |

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #283 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
