### PR TITLE
[deploy/#290] Dockerfile ENTRYPOINT에 exec 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 
 # 애플리케이션 실행
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
## ❤️ 기능 설명
Dockerfile ENTRYPOINT에 exec 추가

- ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+ ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

exec를 추가하면 sh가 JVM 프로세스로 교체되어 PID 1이 Java가 됩니다.
덕분에 docker stop 시 SIGTERM이 JVM에 직접 전달되어 Spring의 Graceful Shutdown이 정상 동작합니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #290 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] docker stop 후 컨테이너 로그에서 Spring Graceful Shutdown 메시지 확인

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
