### PR TITLE
[deploy/#292] MySQL/Elasticsearch 자동 백업 시스템 구축

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,46 @@
+name: Backup - MySQL & Elasticsearch
+
+on:
+  schedule:
+    - cron: '0 17 * * *'  # 매일 02:00 KST (17:00 UTC)
+  workflow_dispatch:        # 수동 실행
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run backup on server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          command_timeout: 30m
+          script: |
+            bash /home/ubuntu/deploy/docker/backup/backup.sh
+
+      - name: Notify Discord on failure
+        if: failure()
+        run: |
+          curl -s -X POST "${{ secrets.DISCORD_WEBHOOK_URL }}" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "❌ 백업 실패",
+                "description": "MySQL 또는 Elasticsearch 백업 중 오류가 발생했습니다.",
+                "color": 15158332,
+                "fields": [
+                  {
+                    "name": "워크플로우",
+                    "value": "'"${{ github.workflow }}"'",
+                    "inline": true
+                  },
+                  {
+                    "name": "실행 링크",
+                    "value": "[확인하기]('"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"')",
+                    "inline": true
+                  }
+                ]
+              }]
+            }'

--- a/docker/backup/backup.sh
+++ b/docker/backup/backup.sh
@@ -1,0 +1,271 @@
+#!/bin/bash
+# ===========================================
+# TechFork 데이터베이스 백업 스크립트
+#
+# 대상: MySQL(mysqldump), Elasticsearch(Snapshot API)
+# 저장소: OCI Object Storage (Instance Principal 인증)
+# 실행: 크론잡 (매일 02:00 KST = 17:00 UTC)
+#
+# 디렉토리 구조 (버킷 내부):
+#   mysql/mysql_YYYYMMDD_HHMMSS.sql.gz
+#   elasticsearch/elasticsearch_YYYYMMDD_HHMMSS.tar.gz
+# ===========================================
+set -euo pipefail
+
+# ===========================================
+# 환경 변수 로드 (.env 파일에서 DB_PASSWORD 등)
+# ===========================================
+ENV_FILE="/home/ubuntu/deploy/docker/.env"
+if [ -f "${ENV_FILE}" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+  set +a
+fi
+
+# ===========================================
+# 설정
+# ===========================================
+DATE=$(date +%Y%m%d_%H%M%S)
+TEMP_DIR=$(mktemp -d)
+LOG_FILE="/var/log/techfork-backup.log"
+
+MYSQL_CONTAINER="techfork-mysql"
+DB_ROOT_PASSWORD="${DB_PASSWORD:-}"
+
+ES_HOST="http://localhost:9200"
+ES_REPO_NAME="techfork_backup"
+ES_SNAPSHOT_HOST_DIR="/home/ubuntu/deploy/es-snapshots"
+
+OCI_BUCKET="${PROJECT_NAME:-tech-fork}-${ENVIRONMENT:-prod}-backups"
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
+
+# OCI CLI 경로 (기본 설치 위치 또는 시스템 PATH)
+OCI_CLI=$(command -v oci 2>/dev/null || echo "/home/ubuntu/bin/oci")
+
+# ===========================================
+# 로깅 함수
+# ===========================================
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "${LOG_FILE}"
+}
+
+error_exit() {
+  log "ERROR: $*"
+  exit 1
+}
+
+# ===========================================
+# 사전 검증
+# ===========================================
+check_prerequisites() {
+  if [ ! -x "${OCI_CLI}" ]; then
+    error_exit "OCI CLI를 찾을 수 없습니다. setup-cron.sh를 먼저 실행하세요."
+  fi
+
+  if ! docker info > /dev/null 2>&1; then
+    error_exit "Docker가 실행 중이지 않습니다."
+  fi
+
+  # OCI Instance Principal 인증 확인
+  OCI_NAMESPACE=$(${OCI_CLI} os ns get --auth instance_principal --query 'data' --raw-output 2>/dev/null) \
+    || error_exit "OCI Instance Principal 인증 실패. Dynamic Group 및 IAM Policy 설정을 확인하세요."
+
+  log "OCI 네임스페이스: ${OCI_NAMESPACE}"
+}
+
+# ===========================================
+# OCI Object Storage 업로드
+# ===========================================
+upload_to_oci() {
+  local local_file="$1"
+  local remote_path="$2"
+
+  log "OCI 업로드 중: ${OCI_BUCKET}/${remote_path}"
+  ${OCI_CLI} os object put \
+    --auth instance_principal \
+    --namespace "${OCI_NAMESPACE}" \
+    --bucket-name "${OCI_BUCKET}" \
+    --name "${remote_path}" \
+    --file "${local_file}" \
+    --force
+  log "OCI 업로드 완료"
+}
+
+# ===========================================
+# MySQL 백업
+# mysqldump → gzip → OCI Object Storage
+# ===========================================
+backup_mysql() {
+  log "===== MySQL 백업 시작 ====="
+  local backup_file="${TEMP_DIR}/mysql_${DATE}.sql.gz"
+
+  if ! docker ps --format '{{.Names}}' | grep -q "^${MYSQL_CONTAINER}$"; then
+    error_exit "MySQL 컨테이너(${MYSQL_CONTAINER})가 실행 중이지 않습니다."
+  fi
+
+  if [ -z "${DB_ROOT_PASSWORD}" ]; then
+    error_exit "DB_PASSWORD 환경변수가 설정되지 않았습니다. ${ENV_FILE} 파일을 확인하세요."
+  fi
+
+  log "mysqldump 실행 중..."
+  docker exec "${MYSQL_CONTAINER}" \
+    mysqldump \
+      -u root \
+      -p"${DB_ROOT_PASSWORD}" \
+      --single-transaction \
+      --routines \
+      --triggers \
+      --all-databases \
+      2>/dev/null \
+    | gzip > "${backup_file}"
+
+  local size
+  size=$(du -sh "${backup_file}" | cut -f1)
+  log "MySQL 백업 파일 생성 완료: ${size}"
+
+  upload_to_oci "${backup_file}" "mysql/mysql_${DATE}.sql.gz"
+  log "===== MySQL 백업 완료 ====="
+}
+
+# ===========================================
+# Elasticsearch 백업
+# Snapshot API → tar.gz → OCI Object Storage
+# ===========================================
+backup_elasticsearch() {
+  log "===== Elasticsearch 백업 시작 ====="
+  local backup_file="${TEMP_DIR}/elasticsearch_${DATE}.tar.gz"
+  local snap_name="snapshot_${DATE}"
+
+  # ES 상태 확인
+  if ! curl -sf "${ES_HOST}/_cluster/health" > /dev/null 2>&1; then
+    error_exit "Elasticsearch가 응답하지 않습니다."
+  fi
+
+  # 스냅샷 호스트 디렉토리 확인
+  if [ ! -d "${ES_SNAPSHOT_HOST_DIR}" ]; then
+    error_exit "ES 스냅샷 디렉토리가 없습니다: ${ES_SNAPSHOT_HOST_DIR}. setup-cron.sh를 먼저 실행하세요."
+  fi
+
+  # 스냅샷 저장소 등록 (없으면 생성, 있으면 덮어쓰기)
+  log "Elasticsearch 스냅샷 저장소 설정..."
+  curl -sf -X PUT "${ES_HOST}/_snapshot/${ES_REPO_NAME}" \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "type": "fs",
+      "settings": {
+        "location": "/usr/share/elasticsearch/snapshots",
+        "compress": true
+      }
+    }' > /dev/null
+
+  # 동일 이름 스냅샷 사전 정리
+  curl -sf -X DELETE "${ES_HOST}/_snapshot/${ES_REPO_NAME}/${snap_name}" \
+    > /dev/null 2>&1 || true
+
+  # 스냅샷 생성 (완료까지 동기 대기)
+  log "Elasticsearch 스냅샷 생성 중 (완료까지 대기)..."
+  local response
+  response=$(curl -sf -X PUT \
+    "${ES_HOST}/_snapshot/${ES_REPO_NAME}/${snap_name}?wait_for_completion=true" \
+    -H 'Content-Type: application/json' \
+    -d '{"indices": "*", "ignore_unavailable": true, "include_global_state": false}')
+
+  if ! echo "${response}" | grep -q '"state":"SUCCESS"'; then
+    error_exit "스냅샷 생성 실패: ${response}"
+  fi
+  log "스냅샷 생성 완료"
+
+  # 스냅샷 파일 압축
+  tar czf "${backup_file}" -C "${ES_SNAPSHOT_HOST_DIR}" .
+
+  local size
+  size=$(du -sh "${backup_file}" | cut -f1)
+  log "Elasticsearch 백업 파일 생성 완료: ${size}"
+
+  upload_to_oci "${backup_file}" "elasticsearch/elasticsearch_${DATE}.tar.gz"
+
+  # 로컬 스냅샷 파일 정리 (OCI 업로드 후 불필요)
+  rm -rf "${ES_SNAPSHOT_HOST_DIR:?}"/*
+  log "===== Elasticsearch 백업 완료 ====="
+}
+
+# ===========================================
+# 오래된 백업 삭제 (OCI Lifecycle Policy 대신 직접 처리)
+# OCI API의 time-created 기준으로 N일 이상된 객체 삭제
+# ===========================================
+cleanup_old_backups() {
+  local prefix="$1"
+  log "오래된 ${prefix}/ 백업 정리 중 (${BACKUP_RETENTION_DAYS}일 초과)..."
+
+  local old_objects
+  old_objects=$(${OCI_CLI} os object list \
+    --auth instance_principal \
+    --namespace "${OCI_NAMESPACE}" \
+    --bucket-name "${OCI_BUCKET}" \
+    --prefix "${prefix}/" \
+    --all \
+    --output json 2>/dev/null \
+    | python3 -c "
+import sys, json
+from datetime import datetime, timedelta, timezone
+
+data = json.load(sys.stdin)
+cutoff = datetime.now(timezone.utc) - timedelta(days=${BACKUP_RETENTION_DAYS})
+
+for obj in data.get('data', []):
+    try:
+        created = datetime.fromisoformat(obj['time-created'])
+        if created < cutoff:
+            print(obj['name'])
+    except Exception:
+        pass
+")
+
+  if [ -z "${old_objects}" ]; then
+    log "삭제할 오래된 백업 없음"
+    return
+  fi
+
+  echo "${old_objects}" | while read -r obj_name; do
+    [ -z "${obj_name}" ] && continue
+    log "삭제: ${obj_name}"
+    ${OCI_CLI} os object delete \
+      --auth instance_principal \
+      --namespace "${OCI_NAMESPACE}" \
+      --bucket-name "${OCI_BUCKET}" \
+      --object-name "${obj_name}" \
+      --force
+  done
+  log "${prefix}/ 정리 완료"
+}
+
+# ===========================================
+# 임시 파일 정리 (EXIT 시 자동 실행)
+# ===========================================
+cleanup() {
+  rm -rf "${TEMP_DIR}"
+}
+
+# ===========================================
+# 메인
+# ===========================================
+main() {
+  log "========================================"
+  log "TechFork 백업 시작"
+  log "========================================"
+
+  trap cleanup EXIT
+
+  check_prerequisites
+  backup_mysql
+  backup_elasticsearch
+  cleanup_old_backups "mysql"
+  cleanup_old_backups "elasticsearch"
+
+  log "========================================"
+  log "TechFork 백업 완료"
+  log "========================================"
+}
+
+main "$@"

--- a/docker/backup/setup-cron.sh
+++ b/docker/backup/setup-cron.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# ===========================================
+# TechFork 백업 초기 설정 스크립트 (서버 최초 1회 실행)
+#
+# 역할:
+#   1. OCI CLI 설치 (Instance Principal 인증용)
+#   2. ES 스냅샷 디렉토리 생성
+#   3. OCI 인증 확인
+#
+# 백업 실행은 GitHub Actions (backup.yml)이 담당
+#
+# 실행 방법:
+#   ssh ubuntu@<SERVER_IP>
+#   bash ~/deploy/docker/backup/setup-cron.sh
+# ===========================================
+set -euo pipefail
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+}
+
+# ===========================================
+# 1. OCI CLI 설치
+# ===========================================
+install_oci_cli() {
+  if command -v oci > /dev/null 2>&1 || [ -x "/home/ubuntu/bin/oci" ]; then
+    log "OCI CLI 이미 설치됨: $(oci --version 2>/dev/null || echo 'version unknown')"
+    return
+  fi
+
+  log "OCI CLI 설치 중..."
+  curl -fsSL https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh \
+    | bash -s -- --accept-all-defaults
+
+  export PATH="$PATH:/home/ubuntu/bin"
+  log "OCI CLI 설치 완료: $(oci --version)"
+}
+
+# ===========================================
+# 2. ES 스냅샷 디렉토리 생성
+# ===========================================
+setup_es_snapshot_dir() {
+  local snapshot_dir="/home/ubuntu/deploy/es-snapshots"
+
+  mkdir -p "${snapshot_dir}"
+  chmod 777 "${snapshot_dir}"  # ES 컨테이너(UID 1000)가 쓸 수 있도록
+  log "ES 스냅샷 디렉토리 준비 완료: ${snapshot_dir}"
+}
+
+# ===========================================
+# 3. OCI Instance Principal 인증 테스트
+# ===========================================
+test_oci_auth() {
+  log "OCI Instance Principal 인증 테스트..."
+  local oci_cli
+  oci_cli=$(command -v oci 2>/dev/null || echo "/home/ubuntu/bin/oci")
+
+  if ${oci_cli} os ns get --auth instance_principal > /dev/null 2>&1; then
+    local ns
+    ns=$(${oci_cli} os ns get --auth instance_principal --query 'data' --raw-output)
+    log "OCI 인증 성공! 네임스페이스: ${ns}"
+  else
+    log "WARNING: OCI Instance Principal 인증 실패"
+    log "  → terraform apply가 완료되었는지 확인하세요"
+    log "  → Dynamic Group / IAM Policy 생성 후 최대 2분 소요됩니다"
+  fi
+}
+
+# ===========================================
+# 메인
+# ===========================================
+main() {
+  log "========================================"
+  log "TechFork 백업 초기 설정 시작"
+  log "========================================"
+
+  install_oci_cli
+  setup_es_snapshot_dir
+  test_oci_auth
+
+  log "========================================"
+  log "초기 설정 완료!"
+  log ""
+  log "다음 단계:"
+  log "  1. Elasticsearch 재시작 (path.repo 설정 반영)"
+  log "     cd ~/deploy && docker compose -f docker/docker-compose.infra.yml restart elasticsearch"
+  log ""
+  log "  2. 백업 수동 실행 테스트"
+  log "     bash ~/deploy/docker/backup/backup.sh"
+  log ""
+  log "  3. 이후 백업은 GitHub Actions (backup.yml)이 매일 02:00 KST에 자동 실행"
+  log "========================================"
+}
+
+main "$@"

--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -63,8 +63,10 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - "ES_JAVA_OPTS=-Xms8g -Xmx8g"
+      - path.repo=/usr/share/elasticsearch/snapshots  # 백업 스냅샷 저장 경로
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
+      - /home/ubuntu/deploy/es-snapshots:/usr/share/elasticsearch/snapshots  # 백업용 바인드 마운트
     networks:
       techfork-network:
         aliases:

--- a/infra/oracle/.terraform.lock.hcl
+++ b/infra/oracle/.terraform.lock.hcl
@@ -24,6 +24,25 @@ provider "registry.terraform.io/cloudflare/cloudflare" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/time" {
+  version = "0.13.1"
+  hashes = [
+    "h1:+W+DMrVoVnoXo3f3M4W+OpZbkCrUn6PnqDF33D2Cuf0=",
+    "zh:02cb9aab1002f0f2a94a4f85acec8893297dc75915f7404c165983f720a54b74",
+    "zh:04429b2b31a492d19e5ecf999b116d396dac0b24bba0d0fb19ecaefe193fdb8f",
+    "zh:26f8e51bb7c275c404ba6028c1b530312066009194db721a8427a7bc5cdbc83a",
+    "zh:772ff8dbdbef968651ab3ae76d04afd355c32f8a868d03244db3f8496e462690",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:898db5d2b6bd6ca5457dccb52eedbc7c5b1a71e4a4658381bcbb38cedbbda328",
+    "zh:8de913bf09a3fa7bedc29fec18c47c571d0c7a3d0644322c46f3aa648cf30cd8",
+    "zh:9402102c86a87bdfe7e501ffbb9c685c32bbcefcfcf897fd7d53df414c36877b",
+    "zh:b18b9bb1726bb8cfbefc0a29cf3657c82578001f514bcf4c079839b6776c47f0",
+    "zh:b9d31fdc4faecb909d7c5ce41d2479dd0536862a963df434be4b16e8e4edc94d",
+    "zh:c951e9f39cca3446c060bd63933ebb89cedde9523904813973fbc3d11863ba75",
+    "zh:e5b773c0d07e962291be0e9b413c7a22c044b8c7b58c76e8aa91d1659990dfb5",
+  ]
+}
+
 provider "registry.terraform.io/oracle/oci" {
   version     = "5.47.0"
   constraints = "~> 5.0"

--- a/infra/oracle/backup.tf
+++ b/infra/oracle/backup.tf
@@ -1,0 +1,61 @@
+# ===========================================
+# Object Storage Namespace 조회
+# ===========================================
+data "oci_objectstorage_namespace" "ns" {
+  compartment_id = var.compartment_ocid
+}
+
+# ===========================================
+# 백업 버킷 (OCI Always Free: 20GB 포함)
+# 오래된 파일 삭제는 backup.sh 내 cleanup 함수가 처리
+# ===========================================
+resource "oci_objectstorage_bucket" "backup" {
+  compartment_id = var.compartment_ocid
+  namespace      = data.oci_objectstorage_namespace.ns.namespace
+  name           = "${var.project_name}-${var.environment}-backups"
+  access_type    = "NoPublicAccess"
+  storage_tier   = "Standard"
+
+  freeform_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+    Purpose     = "backup"
+  }
+}
+
+# ===========================================
+# Dynamic Group - Instance Principal 인증
+# (인스턴스가 자격증명 없이 OCI 서비스 사용 가능)
+# Dynamic Group은 반드시 tenancy 루트에 생성
+# ===========================================
+resource "oci_identity_dynamic_group" "backup" {
+  compartment_id = var.tenancy_ocid
+  name           = "${var.project_name}-${var.environment}-backup-dg"
+  description    = "TechFork 인스턴스가 Object Storage에 백업을 저장하기 위한 Dynamic Group"
+
+  matching_rule = "resource.id = '${oci_core_instance.app.id}'"
+
+  freeform_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}
+
+# ===========================================
+# IAM Policy - Dynamic Group에 버킷 접근 권한 부여
+# ===========================================
+resource "oci_identity_policy" "backup" {
+  compartment_id = var.tenancy_ocid
+  name           = "${var.project_name}-${var.environment}-backup-policy"
+  description    = "TechFork 백업 인스턴스에 Object Storage 쓰기/삭제 권한 부여"
+
+  statements = [
+    "Allow dynamic-group ${oci_identity_dynamic_group.backup.name} to manage objects in compartment id ${var.compartment_ocid} where target.bucket.name = '${oci_objectstorage_bucket.backup.name}'",
+    "Allow dynamic-group ${oci_identity_dynamic_group.backup.name} to read buckets in compartment id ${var.compartment_ocid}",
+  ]
+
+  freeform_tags = {
+    Project     = var.project_name
+    Environment = var.environment
+  }
+}

--- a/infra/oracle/cloud-init.sh
+++ b/infra/oracle/cloud-init.sh
@@ -74,8 +74,22 @@ sysctl -w vm.max_map_count=262144
 # ===========================================
 echo "===== Setup Deployment Structure ====="
 mkdir -p /home/ubuntu/deploy/nginx/conf.d
+mkdir -p /home/ubuntu/deploy/es-snapshots  # ES 스냅샷 저장 경로
+chmod 777 /home/ubuntu/deploy/es-snapshots  # ES 컨테이너(UID 1000)가 쓸 수 있도록
 docker network create techfork-network 2>/dev/null || true
 chown -R ubuntu:ubuntu /home/ubuntu/deploy
+
+# ===========================================
+# OCI CLI 설치 (Instance Principal 백업 인증용)
+# 백업 실행은 GitHub Actions (backup.yml)이 SSH로 트리거
+# ===========================================
+echo "===== Install OCI CLI ====="
+sudo -u ubuntu bash -c '
+  curl -fsSL https://raw.githubusercontent.com/oracle/oci-cli/master/scripts/install/install.sh \
+    | bash -s -- --accept-all-defaults
+  echo "export PATH=\$PATH:/home/ubuntu/bin" >> /home/ubuntu/.bashrc
+'
+echo "OCI CLI 설치 완료"
 
 # ===========================================
 # 방화벽 설정 (iptables)

--- a/infra/oracle/outputs.tf
+++ b/infra/oracle/outputs.tf
@@ -56,6 +56,25 @@ output "api_url" {
 }
 
 # ===========================================
+# Backup Outputs
+# ===========================================
+
+output "backup_bucket_name" {
+  description = "백업 Object Storage 버킷 이름"
+  value       = oci_objectstorage_bucket.backup.name
+}
+
+output "backup_bucket_namespace" {
+  description = "Object Storage 네임스페이스 (OCI CLI 사용 시 필요)"
+  value       = data.oci_objectstorage_namespace.ns.namespace
+}
+
+output "backup_bucket_url" {
+  description = "OCI Console에서 버킷 확인 URL"
+  value       = "https://console.ap-chuncheon-1.oraclecloud.com/object-storage/buckets/${data.oci_objectstorage_namespace.ns.namespace}/${oci_objectstorage_bucket.backup.name}"
+}
+
+# ===========================================
 # Resource Summary
 # ===========================================
 

--- a/infra/oracle/variables.tf
+++ b/infra/oracle/variables.tf
@@ -143,3 +143,12 @@ variable "docker_image" {
   type        = string
   default     = "ghcr.io/your-org/tech-fork"
 }
+
+# ===========================================
+# 백업 설정
+# ===========================================
+variable "backup_retention_days" {
+  description = "백업 파일 보관 기간 (일). OCI Lifecycle Policy로 자동 삭제됨"
+  type        = number
+  default     = 7
+}


### PR DESCRIPTION
## ❤️ 기능 설명
### Terraform
- OCI Object Storage 버킷 생성 및 Instance Principal 인증 구성
- Dynamic Group / IAM Policy로 서버가 자격증명 없이 버킷에 접근 가능하도록 설정

### 백업 스크립트
- **MySQL**: `docker exec` + `mysqldump --single-transaction` → gzip 압축 → OCI 업로드
- **Elasticsearch**: Snapshot API(`wait_for_completion=true`) → tar.gz 압축 → OCI 업로드
- 백업 완료 후 7일 초과 파일 자동 삭제 (OCI API 기준 `time-created`)

### GitHub Actions
- 매일 02:00 KST 스케줄 자동 실행 (`workflow_dispatch`로 수동 실행도 가능)
- 실패 시 Discord Webhook 알림

### Docker Compose
- Elasticsearch `path.repo` 환경변수 및 스냅샷 디렉토리 바인드 마운트 추가

## 배포 순서
1. `cd infra/oracle && terraform apply`
2. 서버에서 `bash ~/deploy/docker/backup/setup-cron.sh` 실행
3. Elasticsearch 재시작: `docker compose -f docker/docker-compose.infra.yml restart elasticsearch`
4. GitHub Actions에서 수동 실행으로 테스트

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #292 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
