### PR TITLE
[fix/#294] 자동 백업 스크립트에서 root 권한 경로 대신 임의 경로로 변경

### DIFF
--- a/docker/backup/backup.sh
+++ b/docker/backup/backup.sh
@@ -28,7 +28,7 @@ fi
 # ===========================================
 DATE=$(date +%Y%m%d_%H%M%S)
 TEMP_DIR=$(mktemp -d)
-LOG_FILE="/var/log/techfork-backup.log"
+LOG_FILE="/home/ubuntu/deploy/backup.log"
 
 MYSQL_CONTAINER="techfork-mysql"
 DB_ROOT_PASSWORD="${DB_PASSWORD:-}"

--- a/docker/backup/setup-cron.sh
+++ b/docker/backup/setup-cron.sh
@@ -87,6 +87,7 @@ main() {
   log ""
   log "  2. 백업 수동 실행 테스트"
   log "     bash ~/deploy/docker/backup/backup.sh"
+  log "     tail -f ~/deploy/backup.log"
   log ""
   log "  3. 이후 백업은 GitHub Actions (backup.yml)이 매일 02:00 KST에 자동 실행"
   log "========================================"


### PR DESCRIPTION
## ❤️ 기능 설명
현재 DB/ES 자동 백업 스크립트에서 로그를 찍을 때 `/var/log` 경로로 시도했는데 이는 root 권한의 디렉터리이므로
임의의 `/home/ubuntu/deploy` 경로로 변경합니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #294 
<br>
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
