### PR TITLE
[fix/#298] 백업 스크립트 중 도커 컨테이너 볼륨 제거 로직 수정

### DIFF
--- a/docker/backup/backup.sh
+++ b/docker/backup/backup.sh
@@ -184,8 +184,9 @@ backup_elasticsearch() {
 
   upload_to_oci "${backup_file}" "elasticsearch/elasticsearch_${DATE}.tar.gz"
 
-  # 로컬 스냅샷 파일 정리 (OCI 업로드 후 불필요)
-  rm -rf "${ES_SNAPSHOT_HOST_DIR:?}"/*
+  # 로컬 스냅샷 파일 정리 (ES API로 삭제 - 컨테이너 소유 파일이므로 rm 불가)
+  curl -sf -X DELETE "${ES_HOST}/_snapshot/${ES_REPO_NAME}/${snap_name}" > /dev/null \
+    || log "WARNING: 스냅샷 삭제 실패 (무시 가능)"
   log "===== Elasticsearch 백업 완료 ====="
 }
 


### PR DESCRIPTION
## ❤️ 기능 설명
현재 ES의 스냅샷을 만들어서 업로드한 뒤, 로컬 스냅샷을 제거하는 과정에서
ubuntu 유저로 rm -rf로 지우려다보니 권한 문제가 발생했습니다.

이를 ES의 API를 사용하도록 변경하여 해결합니다.
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #298 
<br>
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
