### PR TITLE
[feat/#249] ElasticsearchWarmupManager 신규 구현

### DIFF
--- a/src/main/java/com/techfork/global/config/ElasticsearchWarmupManager.java
+++ b/src/main/java/com/techfork/global/config/ElasticsearchWarmupManager.java
@@ -26,15 +26,18 @@ public class ElasticsearchWarmupManager implements ApplicationRunner {
     private static final String POSTS_INDEX = "posts";
     private static final String USER_PROFILES_INDEX = "user_profiles";
     private static final int EMBEDDING_DIMENSION = 3072;
+    private static final int JIT_C1_WARMUP_ITERATIONS = 100;
 
     private final ElasticsearchClient elasticsearchClient;
     private final RecommendationProperties recommendationProperties;
 
     @Override
     public void run(ApplicationArguments args) {
-        log.info("[ES Warmup] Starting initial warmup...");
+        log.info("[ES Warmup] Starting initial warmup ({} iterations)...", JIT_C1_WARMUP_ITERATIONS);
         warmupClusterHealth();
-        warmupIndex();
+        for (int i = 0; i < JIT_C1_WARMUP_ITERATIONS; i++) {
+            warmupIndex();
+        }
         log.info("[ES Warmup] Initial warmup completed");
     }
 

--- a/src/main/java/com/techfork/global/config/ElasticsearchWarmupManager.java
+++ b/src/main/java/com/techfork/global/config/ElasticsearchWarmupManager.java
@@ -1,0 +1,134 @@
+package com.techfork.global.config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.KnnSearch;
+import com.techfork.domain.post.document.PostDocument;
+import com.techfork.domain.recommendation.config.RecommendationProperties;
+import com.techfork.domain.user.document.UserProfileDocument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Component
+@Order(1)
+@RequiredArgsConstructor
+public class ElasticsearchWarmupManager implements ApplicationRunner {
+
+    private static final String POSTS_INDEX = "posts";
+    private static final String USER_PROFILES_INDEX = "user_profiles";
+    private static final int EMBEDDING_DIMENSION = 3072;
+
+    private final ElasticsearchClient elasticsearchClient;
+    private final RecommendationProperties recommendationProperties;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("[ES Warmup] Starting initial warmup...");
+        warmupClusterHealth();
+        warmupIndex();
+        log.info("[ES Warmup] Initial warmup completed");
+    }
+
+    @Scheduled(fixedDelay = 30 * 60 * 1000)
+    public void keepAliveWarmup() {
+        log.debug("[ES Warmup] Keep-alive warmup starting...");
+        warmupIndex();
+        log.debug("[ES Warmup] Keep-alive warmup completed");
+    }
+
+    private void warmupClusterHealth() {
+        try {
+            elasticsearchClient.cluster().health();
+            log.debug("[ES Warmup] Cluster health check OK");
+        } catch (Exception e) {
+            log.warn("[ES Warmup] Cluster health check failed: {}", e.getMessage());
+        }
+    }
+
+    private void warmupIndex() {
+        warmupLexicalSearch();
+        warmupPostsKnnSearch();
+        warmupUserProfilesKnnSearch();
+    }
+
+    private void warmupLexicalSearch() {
+        try {
+            elasticsearchClient.search(s -> s
+                            .index(POSTS_INDEX)
+                            .size(1)
+                            .query(q -> q
+                                    .multiMatch(m -> m
+                                            .query("technology")
+                                            .fields("title^3.0", "summary^1.5", "contentChunks.chunkText")
+                                    )
+                            ),
+                    PostDocument.class
+            );
+            log.debug("[ES Warmup] posts lexical warmup OK");
+        } catch (Exception e) {
+            log.warn("[ES Warmup] posts lexical warmup failed: {}", e.getMessage());
+        }
+    }
+
+    private void warmupPostsKnnSearch() {
+        List<Float> dummyVector = createDummyVector();
+        List<KnnSearch> knnSearches = List.of(
+                createKnn("titleEmbedding", dummyVector),
+                createKnn("summaryEmbedding", dummyVector),
+                createKnn("contentChunks.embedding", dummyVector)
+        );
+        try {
+            elasticsearchClient.search(s -> s
+                            .index(POSTS_INDEX)
+                            .size(1)
+                            .knn(knnSearches),
+                    PostDocument.class
+            );
+            log.debug("[ES Warmup] posts kNN warmup OK");
+        } catch (Exception e) {
+            log.warn("[ES Warmup] posts kNN warmup failed: {}", e.getMessage());
+        }
+    }
+
+    private void warmupUserProfilesKnnSearch() {
+        try {
+            List<Float> dummyVector = createDummyVector();
+            elasticsearchClient.search(s -> s
+                            .index(USER_PROFILES_INDEX)
+                            .size(1)
+                            .knn(List.of(createKnn("profileVector", dummyVector))),
+                    UserProfileDocument.class
+            );
+            log.debug("[ES Warmup] user_profiles kNN warmup OK");
+        } catch (Exception e) {
+            log.warn("[ES Warmup] user_profiles kNN warmup failed: {}", e.getMessage());
+        }
+    }
+
+    private KnnSearch createKnn(String field, List<Float> vector) {
+        return KnnSearch.of(ks -> ks
+                .field(field)
+                .queryVector(vector)
+                .k(recommendationProperties.getKnnSearchSize())
+                .numCandidates(recommendationProperties.getNumCandidates())
+        );
+    }
+
+    private List<Float> createDummyVector() {
+        List<Float> vector = new ArrayList<>(EMBEDDING_DIMENSION);
+        ThreadLocalRandom random = ThreadLocalRandom.current();
+        for (int i = 0; i < EMBEDDING_DIMENSION; i++) {
+            vector.add(random.nextFloat() * 2 - 1);
+        }
+        return vector;
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

서버 기동 직후 첫 검색/추천 요청의 응답 지연을 줄이기 위해 `ElasticsearchWarmupManager`를 신규 구현합니다.                                                                                                                        
                                                                                                                                                                                                                                  
**지연 원인**
- HNSW 그래프 파일: 첫 쿼리 시 디스크 → OS 페이지 캐시로 로드
- ES JVM JIT: 처음 실행되는 코드는 인터프리터 모드로 동작

**웜업 전략**
- 기동 시 100회 반복 실행으로 페이지 캐시 로드 + ES JVM C1 컴파일 유도
- 30분 주기 keep-alive로 페이지 캐시 유지

**웜업 대상**
- posts lexical: title, summary, contentChunks.chunkText
- posts kNN: titleEmbedding, summaryEmbedding, contentChunks.embedding
- user_profiles kNN: profileVector

**기타**
- kNN 파라미터(k, numCandidates)는 RecommendationProperties 주입으로 추천 서비스와 동기화
- 더미 벡터: [-1, 1] 랜덤 float 사용 (zero 벡터는 코사인 유사도 undefined로 실질적 탐색 유발 안 됨)
- 웜업 실패 시 warn 로그만 남기고 기동 중단 없음
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #249 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
