### PR TITLE
[improve/#308] 크롤링 후 Elasticsearch warmup 유지

### DIFF
--- a/src/main/java/com/techfork/domain/source/listener/RssCrawlingJobListener.java
+++ b/src/main/java/com/techfork/domain/source/listener/RssCrawlingJobListener.java
@@ -1,6 +1,7 @@
 package com.techfork.domain.source.listener;
 
 import com.techfork.domain.source.service.WebhookNotificationService;
+import com.techfork.global.config.ElasticsearchCacheManager;
 import com.techfork.global.constant.MdcKey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,7 @@ import java.util.Map;
 public class RssCrawlingJobListener implements JobExecutionListener {
 
     private final WebhookNotificationService webhookNotificationService;
+    private final ElasticsearchCacheManager elasticsearchCacheManager;
 
     @Override
     public void beforeJob(JobExecution jobExecution) {
@@ -64,6 +66,8 @@ public class RssCrawlingJobListener implements JobExecutionListener {
 
         log.info("RSS crawling completed successfully: jobExecutionId={}, total={}, success={}, failed={}, duration={}ms",
                 jobExecution.getId(), readCount, writeCount, skipCount, durationMs);
+
+        elasticsearchCacheManager.forceMergeAndWarmupPosts();
     }
 
     /**

--- a/src/main/java/com/techfork/global/config/ElasticsearchCacheManager.java
+++ b/src/main/java/com/techfork/global/config/ElasticsearchCacheManager.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
@@ -57,6 +58,22 @@ public class ElasticsearchCacheManager implements ApplicationRunner {
         } catch (Exception e) {
             log.warn("[ES Index] preload failed for '{}': {}", index, e.getMessage());
         }
+    }
+
+    public void forceMergeAndWarmupPosts() {
+        CompletableFuture.runAsync(() -> {
+            try {
+                long start = System.currentTimeMillis();
+                elasticsearchClient.indices().forcemerge(f -> f
+                        .index(POSTS_INDEX)
+                        .maxNumSegments(1L)
+                );
+                log.info("[ES ForceMerge] posts index merged to 1 segment. Time={}ms", System.currentTimeMillis() - start);
+            } catch (Exception e) {
+                log.warn("[ES ForceMerge] posts force merge failed: {}", e.getMessage());
+            }
+            warmupPostsKnn();
+        });
     }
 
     private void warmupPostsKnn() {


### PR DESCRIPTION
## ❤️ 기능 설명
RSS 크롤링 배치 완료 후 posts 인덱스를 Force Merge하고 즉시 kNN 웜업을 실행합니다.

### 문제

Elasticsearch는 세그먼트 단위로 HNSW 그래프를 관리합니다. 배치로 새 데이터가 인덱싱될 때마다 새 세그먼트가 생성되는데, 이 세그먼트는 cold 상태라 기존 5분 주기 웜업이 돌기 전까지 디스크 I/O를 유발하여 검색 latency spike가 발생합니다.

### 해결

**`ElasticsearchCacheManager`에 `forceMergeAndWarmupPosts()` 추가**

Force Merge (max_num_segments=1)  ← 세그먼트를 1개로 압축
        ↓
warmupPostsKnn()  ← 새 단일 HNSW 그래프를 OS 캐시에 로드
        ↓
이후 검색 요청은 메모리에서 처리

Force Merge가 블로킹 작업이므로 `CompletableFuture.runAsync()`로 비동기 실행.
merge 실패 시에도 warmup은 반드시 실행되도록 try-catch 밖에 배치.

**`RssCrawlingJobListener.handleJobSuccess()`에서 호출**

배치 3단계(RSS 수집 → 요약 → 임베딩+ES 저장) 완료 직후 자동 실행.
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #308
<br>
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
