### PR TITLE
[chore/#311] k6 부하 테스트를 위한 Actuator 메트릭 모니터링 환경 구축

### DIFF
--- a/scripts/monitor.sh
+++ b/scripts/monitor.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+ACTUATOR_URL="http://localhost:9090/actuator/metrics"
+
+while true; do
+  clear
+  echo "===== $(date '+%H:%M:%S') ====="
+
+  echo ""
+  echo "[HikariCP]"
+  ACTIVE=$(curl -s $ACTUATOR_URL/hikaricp.connections.active | jq -r '.measurements[0].value')
+  IDLE=$(curl -s $ACTUATOR_URL/hikaricp.connections.idle | jq -r '.measurements[0].value')
+  PENDING=$(curl -s $ACTUATOR_URL/hikaricp.connections.pending | jq -r '.measurements[0].value')
+  MAX=$(curl -s $ACTUATOR_URL/hikaricp.connections.max | jq -r '.measurements[0].value')
+  echo "  active: $ACTIVE / max: $MAX"
+  echo "  idle: $IDLE | pending: $PENDING"
+
+  echo ""
+  echo "[Tomcat]"
+  BUSY=$(curl -s $ACTUATOR_URL/tomcat.threads.busy | jq -r '.measurements[0].value')
+  CURRENT=$(curl -s $ACTUATOR_URL/tomcat.threads.current | jq -r '.measurements[0].value')
+  echo "  busy: $BUSY / current: $CURRENT"
+
+  echo ""
+  echo "[JVM Memory]"
+  HEAP=$(curl -s "$ACTUATOR_URL/jvm.memory.used?tag=area:heap" | jq -r '.measurements[0].value')
+  HEAP_MB=$(echo "scale=0; $HEAP / 1048576" | bc)
+  echo "  heap: ${HEAP_MB}MB"
+
+  sleep 2
+done

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,6 +98,20 @@ server:
   domain: ${SERVER_DOMAIN:localhost}
   forward-headers-strategy: native
 
+management:
+  server:
+    port: 9090
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: techfork
+
 scheduler:
   enabled: true
 


### PR DESCRIPTION
## ❤️ 기능 설명
- application.yml에 Spring Boot Actuator 설정 추가 (관리 포트 9090, health / info / metrics 엔드포인트 노출)
- scripts/monitor.sh 추가: 2초 간격으로 HikariCP 커넥션 현황, Tomcat 스레드, JVM Heap 메모리를 터미널에 출력

```
===== 14:32:01 =====

[HikariCP]
  active: 3 / max: 10
  idle: 7 | pending: 0

[Tomcat]
  busy: 5 / current: 10

[JVM Memory]
  heap: 312MB
```

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #311 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] jq, bc 설치 여부 확인 (sudo apt-get install jq bc)
- [ ] scripts/monitor.sh 실행 권한 부여 확인 (chmod +x scripts/monitor.sh)

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
