### PR TITLE
[fix/#314] Actuator 포트를 9090으로 바꾼 뒤, health check를 8080으로 보내던 에러 해결

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -57,7 +57,7 @@ health_check() {
 
     log "Waiting for ${container} to become healthy..."
     for i in $(seq 1 "$HEALTH_CHECK_RETRIES"); do
-        if docker exec techfork-nginx curl -sf "http://${container}:8080/actuator/health" > /dev/null 2>&1; then
+        if docker exec techfork-nginx curl -sf "http://${container}:9090/actuator/health" > /dev/null 2>&1; then
             log "Health check passed (attempt ${i}/${HEALTH_CHECK_RETRIES})"
             return 0
         fi


### PR DESCRIPTION
## ❤️ 기능 설명
Actuator 포트를 9090으로 바꾼 뒤 deploy.sh에 반영하지 않았던 문제를 해결했습니다.
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #314 
<br>
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
