### PR TITLE
[test/#313] k6 부하테스트 baseline 측정

### DIFF
--- a/k6/load-test.js
+++ b/k6/load-test.js
@@ -17,6 +17,7 @@ import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 // 총 45 VU 기준
 // crud: 31 VU (69%) / search_anonymous: 7 VU (16%) / search_personalized: 3 VU (7%) / recommendation_read: 4 VU (9%)
 export const options = {
+    summaryTrendStats: ['med', 'p(95)', 'p(99)'],
     scenarios: {
         crud: {
             executor: 'ramping-vus',

--- a/k6/test-crud.js
+++ b/k6/test-crud.js
@@ -4,6 +4,7 @@ import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 const TARGET_VU = parseInt(__ENV.VU || '30');
 
 export const options = {
+    summaryTrendStats: ['med', 'p(95)', 'p(99)'],
     scenarios: {
         crud: {
             executor: 'ramping-vus',

--- a/k6/test-recommendation-read.js
+++ b/k6/test-recommendation-read.js
@@ -6,6 +6,7 @@ import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 const TARGET_VU = parseInt(__ENV.VU || '20');
 
 export const options = {
+    summaryTrendStats: ['med', 'p(95)', 'p(99)'],
     scenarios: {
         recommendation_read: {
             executor: 'ramping-vus',

--- a/k6/test-recommendation-refresh.js
+++ b/k6/test-recommendation-refresh.js
@@ -6,6 +6,7 @@ import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 const TARGET_VU = parseInt(__ENV.VU || '5');
 
 export const options = {
+    summaryTrendStats: ['med', 'p(95)', 'p(99)'],
     scenarios: {
         recommendation_refresh: {
             executor: 'ramping-vus',

--- a/k6/test-search-anonymous.js
+++ b/k6/test-search-anonymous.js
@@ -4,6 +4,7 @@ import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 const TARGET_VU = parseInt(__ENV.VU || '15');
 
 export const options = {
+    summaryTrendStats: ['med', 'p(95)', 'p(99)'],
     scenarios: {
         search_anonymous: {
             executor: 'ramping-vus',

--- a/k6/test-search-personalized.js
+++ b/k6/test-search-personalized.js
@@ -6,6 +6,7 @@ import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.2/index.js';
 const TARGET_VU = parseInt(__ENV.VU || '10');
 
 export const options = {
+    summaryTrendStats: ['med', 'p(95)', 'p(99)'],
     scenarios: {
         search_personalized: {
             executor: 'ramping-vus',


### PR DESCRIPTION
## ❤️ 기능 설명

### 테스트 환경
- Oracle Cloud ARM (24GB RAM)
- MySQL, Redis, ES 동일 인스턴스

### 1. CRUD (목록/상세 조회)

| VU | p50 | p95 | p99 | RPS | 에러율 |
|----|-----|-----|-----|-----|-------|
| 10  | 14.9ms | 82.6ms | 83.4ms | 15.6 | 0% |
| 50 | 12.8ms | 76.9ms | 81.6ms | 78.0 | 0% |
| 100 | 13.1ms | 77.7ms | 82.2ms | 156.6 | 0% |
| 200 | 16.1ms | 80.5ms | 83.9ms | 311.6 | 0% |
| 300 | 31.7ms | 81.9ms | 92.8ms | 464.5 | 0% |
| 400 | 41.2ms | 140.1ms | 230.3ms | 598.8 | 0% |
| 500 | 71.9ms | 420.6ms | 615.1ms | 670.0 | 0% |

**피크 시점 서버 상태 (VU 400)**
- HikariCP 풀이 모자라는 것을 확인
- RPS도 한계처럼 보임.

### 2. 비로그인 검색
| VU | p50 | p95 | p99 | RPS | 에러율 | 비고 |
|----|-----|-----|-----|-----|-------|-------|
| 5 | 494.8ms | 648.8ms | 823.9ms | 1.69 | 0% | chunk kNN 활성화 |
| 10 | 584.8ms | 1254.9ms | 1561.5ms | 3.18 | 0% | chunk kNN 활성화 |
| 5 | 366.0ms | 521.9ms  | 749.0ms | 1.73 | 0% | chunk kNN 비활성화 |
| 10 | 406.0ms | 641.7ms | 857.9ms | 3.48 | 0% | chunk kNN 비활성화 |
| 15 | 644.1ms | 1531.2ms | 1933.6ms | 4.54 | 0% | chunk kNN 비활성화 |

- VU 10→15에서 p95 641ms → 1531ms로 **2.4배 폭등**. chunk kNN 끄기 전 VU 10 패턴과 동일
- ES 스레드 2개 한계로 판단.
- 일단 VU 10, p95 641ms가 한계선으로 보임.

### 3. 로그인 검색
| VU | p50 | p95 | p99 | RPS | 에러율 | 비고 |
|----|-----|-----|-----|-----|-------|------|
| 5 | 410.3ms | 596.6ms | 762.0ms | 1.73 | 0% | chunk kNN 비활성화 |
| 10 | 464.3ms | 798.2ms | 954.3ms | 3.33 | 0% | chunk kNN 비활성화 |
| 15 | 676.8ms | 1651.2ms | 1993.2ms | 4.43 | 0% | chunk kNN 비활성화 |

- VU 10→15에서 p95 798ms → 1651ms로 **2배 폭등**. 일반 검색이랑 동일한 패턴
- **ES 스레드 2개 한계**가 여기서도 동일하게 터짐. VU 15부터 큐 대기 누적
- **결론: 개인화 검색도 VU 10이 한계선**. p95 798ms로 threshold 턱걸이 통과
- 일반 검색(VU 10, p95 641ms)보다 약간 느리지만 재랭킹 오버헤드 감안하면 납득 가능한 수치

### 4. 추천 새로고침

| VU | p50 | p95 | p99 | RPS | 에러율 |
|----|-----|-----|-----|-----|-------|
| 5 | 899.2ms | 1365.8ms | 1668.9ms | 0.96 | 0% |
| 10 | 1203.0ms | 1949.9ms | 2170.5ms | 1.76 | 0% |
| 15 | 2332.5ms | 3410.9ms | 3840.8ms | 2.17 | 0% |

- threshold `p(95)<2000` FAIL, `p(99)<4000` 통과
- VU 10→15에서 p50 1203ms → 2332ms로 **2배 폭등**. 검색과 동일한 패턴으로 ES 스레드 한계 도달
- **결론: 추천 새로고침 한계선은 VU 10**. p95 1949ms로 버튼 새로고침 기준 3초 이내 충족
- RPS는 0.96 → 1.76 → 2.17로 증가폭이 계속 줄어드는 것도 포화 신호<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #313 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] ES 임베딩 양자화로 ES의 성능을 더 올려본 후, HicariCP, Tomcat 튜닝을 진행할 예정입니다.

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
