### PR TITLE
[improve/#321] KNN 벡터 검색 성능 개선을 위한 int8 양자화 적용

### DIFF
--- a/src/main/java/com/techfork/domain/post/document/PostDocument.java
+++ b/src/main/java/com/techfork/domain/post/document/PostDocument.java
@@ -10,11 +10,13 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Document(indexName = "posts")
+@Mapping(mappingPath = "elasticsearch/posts-mapping.json")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/techfork/domain/user/document/UserProfileDocument.java
+++ b/src/main/java/com/techfork/domain/user/document/UserProfileDocument.java
@@ -11,11 +11,13 @@ import org.springframework.data.annotation.Transient;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Mapping;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Document(indexName = "user_profiles")
+@Mapping(mappingPath = "elasticsearch/user-profiles-mapping.json")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/resources/elasticsearch/posts-mapping.json
+++ b/src/main/resources/elasticsearch/posts-mapping.json
@@ -1,0 +1,47 @@
+{
+  "properties": {
+    "postId": { "type": "long" },
+    "title": { "type": "text" },
+    "summary": { "type": "text" },
+    "shortSummary": { "type": "text" },
+    "company": { "type": "keyword" },
+    "url": { "type": "keyword" },
+    "logoUrl": { "type": "keyword" },
+    "thumbnailUrl": { "type": "keyword" },
+    "publishedAt": { "type": "keyword" },
+    "titleEmbedding": {
+      "type": "dense_vector",
+      "dims": 3072,
+      "index": true,
+      "similarity": "cosine",
+      "index_options": {
+        "type": "int8_hnsw"
+      }
+    },
+    "summaryEmbedding": {
+      "type": "dense_vector",
+      "dims": 3072,
+      "index": true,
+      "similarity": "cosine",
+      "index_options": {
+        "type": "int8_hnsw"
+      }
+    },
+    "contentChunks": {
+      "type": "nested",
+      "properties": {
+        "chunkOrder": { "type": "integer" },
+        "chunkText": { "type": "text" },
+        "embedding": {
+          "type": "dense_vector",
+          "dims": 3072,
+          "index": true,
+          "similarity": "cosine",
+          "index_options": {
+            "type": "int8_hnsw"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/elasticsearch/user-profiles-mapping.json
+++ b/src/main/resources/elasticsearch/user-profiles-mapping.json
@@ -1,0 +1,17 @@
+{
+  "properties": {
+    "userId": { "type": "long" },
+    "profileText": { "type": "text" },
+    "profileVector": {
+      "type": "dense_vector",
+      "dims": 3072,
+      "index": true,
+      "similarity": "cosine",
+      "index_options": {
+        "type": "int8_hnsw"
+      }
+    },
+    "interests": { "type": "keyword" },
+    "keyKeywords": { "type": "keyword" }
+  }
+}


### PR DESCRIPTION
## ❤️ 기능 설명
KNN 벡터 검색 int8 양자화 적용                                                                                                                                                                                                                                                                                 
- posts, user_profiles 인덱스의 dense_vector 필드에 int8_hnsw 양자화 적용                                                                                                                                                                                                                                         
- @Mapping 어노테이션으로 JSON 매핑 파일 연결 (elasticsearch/posts-mapping.json, elasticsearch/user-profiles-mapping.json)
- float32 대비 메모리 약 4배 절감, KNN 검색 속도 향상

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #321 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] ES 임베딩 작업 필요
- [ ] 이미 프로필이 있었던 회원의 재생성 필요
<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [ ] 이슈넘버를 적었는가?
