### PR TITLE
[improve/#338] 도메인 마이그레이션: techfork.shop → techfork.site

### DIFF
--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -18,7 +18,7 @@ real_ip_header CF-Connecting-IP;
 
 server {
     listen 80;
-    server_name api.techfork.shop techfork.shop;
+    server_name api.techfork.site;
 
     client_max_body_size 10M;
 
@@ -46,7 +46,7 @@ server {
 
 server {
     listen 80;
-    server_name dev.techfork.shop;
+    server_name dev.techfork.site;
 
     client_max_body_size 10M;
 

--- a/src/main/java/com/techfork/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/techfork/global/security/config/SecurityConfig.java
@@ -82,10 +82,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(
                 "http://localhost:5173",
                 "https://localhost",
-                "https://techfork-fe.vercel.app",
-                "https://techfork.shop",
-                "https://api.techfork.shop",
-                "https://dev.techfork.shop",
+                "https://techfork.site",
                 "https://appleid.apple.com"  // Apple Sign In form_post
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));


### PR DESCRIPTION
## ❤️ 기능 설명
도메인을 `techfork.shop`에서 `techfork.site`로 마이그레이션합니다.

### 변경 사항
1. **nginx** (`docker/nginx/conf.d/default.conf`)
 - `server_name api.techfork.shop techfork.shop` → `server_name api.techfork.site`
 - 프론트(`techfork.site`)는 nginx에서 서빙하지 않으므로 제거

2. **CORS** (`SecurityConfig.java`)
 - `https://techfork.site` (프론트 origin) 유지
 - 제거: `techfork-fe.vercel.app`, `api.techfork.shop`, `dev.techfork.shop`
 - 백엔드 도메인은 CORS origin으로 불필요하여 정리
 
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #338 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
