### PR TITLE
[chore/#350] 프론트 preview 도메인을 CORS 허용 경로에 추가

### DIFF
--- a/src/main/java/com/techfork/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/techfork/global/security/config/SecurityConfig.java
@@ -82,6 +82,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of(
                 "http://localhost:5173",
                 "https://localhost",
+                "https://dev2.techfork.site",
                 "https://techfork.site",
                 "https://appleid.apple.com"  // Apple Sign In form_post
         ));


### PR DESCRIPTION
## ❤️ 기능 설명

- Spring Security CORS 허용 origin 목록에 `https://dev2.techfork.site`를 추가했습니다.
- 프론트 preview 도메인에서 백엔드 API 요청이 CORS에 막히지 않도록 수정했습니다.
- 별도 테스트나 스크린샷 첨부는 진행하지 않았습니다.

## 연결된 issue

close #350

## 🩷 Approve 하기 전 확인해주세요!

- preview 환경에서 실제 API 호출 시 CORS 오류가 발생하지 않는지 확인 부탁드립니다.
- 기존 운영 도메인(`https://techfork.site`) 요청 흐름에 영향이 없는지도 함께 봐주시면 됩니다.

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?