### PR TITLE
[refactor/#359] ScrapPost 엔티티를 Bookmark로 변경

### DIFF
--- a/src/main/java/com/techfork/domain/activity/entity/Bookmark.java
+++ b/src/main/java/com/techfork/domain/activity/entity/Bookmark.java
@@ -14,16 +14,17 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "scrap_posts",
+        name = "bookmarks",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"user_id", "post_id"})
+                @UniqueConstraint(name = "uk_bookmarks_user_post", columnNames = {"user_id", "post_id"})
         }
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ScrabPost extends BaseEntity {
+public class Bookmark extends BaseEntity {
 
-    private LocalDateTime scrappedAt;
+    @Column(name = "bookmarked_at")
+    private LocalDateTime bookmarkedAt;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -35,17 +36,17 @@ public class ScrabPost extends BaseEntity {
 
     @PersistenceCreator
     @Builder
-    ScrabPost(User user, Post post, LocalDateTime scrappedAt) {
+    Bookmark(User user, Post post, LocalDateTime bookmarkedAt) {
         this.user = user;
         this.post = post;
-        this.scrappedAt = scrappedAt;
+        this.bookmarkedAt = bookmarkedAt;
     }
 
-    public static ScrabPost create(User user, Post post, LocalDateTime scrappedAt) {
-        return ScrabPost.builder()
+    public static Bookmark create(User user, Post post, LocalDateTime bookmarkedAt) {
+        return Bookmark.builder()
                 .user(user)
                 .post(post)
-                .scrappedAt(scrappedAt)
+                .bookmarkedAt(bookmarkedAt)
                 .build();
     }
 }

--- a/src/main/java/com/techfork/domain/activity/repository/BookmarkRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/BookmarkRepository.java
@@ -1,7 +1,7 @@
 package com.techfork.domain.activity.repository;
 
 import com.techfork.domain.activity.dto.BookmarkDto;
-import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.Bookmark;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
@@ -12,14 +12,14 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface ScrabPostRepository extends JpaRepository<ScrabPost, Long> {
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.activity.dto.BookmarkDto(
                 s.id, p.id, p.title, p.shortSummary, p.url, t.companyName, t.logoUrl,
                             p.publishedAt, p.thumbnailUrl, p.viewCount, null, true
             )
-            FROM ScrabPost s
+            FROM Bookmark s
             JOIN s.post p
             JOIN p.techBlog t
             WHERE s.user = :user
@@ -34,14 +34,14 @@ public interface ScrabPostRepository extends JpaRepository<ScrabPost, Long> {
 
     boolean existsByUserAndPost(User user, Post post);
 
-    Optional<ScrabPost> findByUserAndPost(User user, Post post);
+    Optional<Bookmark> findByUserAndPost(User user, Post post);
 
-    @Query("SELECT sp FROM ScrabPost sp JOIN FETCH sp.post WHERE sp.user.id = :userId ORDER BY sp.scrappedAt DESC")
-    List<ScrabPost> findRecentScrapPostsByUserId(@Param("userId") Long userId, Pageable pageable);
+    @Query("SELECT sp FROM Bookmark sp JOIN FETCH sp.post WHERE sp.user.id = :userId ORDER BY sp.bookmarkedAt DESC")
+    List<Bookmark> findRecentBookmarksByUserId(@Param("userId") Long userId, Pageable pageable);
 
     @Query("""
             SELECT sp.post.id
-            FROM ScrabPost sp
+            FROM Bookmark sp
             WHERE sp.user.id = :userId
             AND sp.post.id IN :postIds
             """)

--- a/src/main/java/com/techfork/domain/activity/repository/BookmarkRepository.java
+++ b/src/main/java/com/techfork/domain/activity/repository/BookmarkRepository.java
@@ -16,15 +16,15 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     @Query("""
             SELECT new com.techfork.domain.activity.dto.BookmarkDto(
-                s.id, p.id, p.title, p.shortSummary, p.url, t.companyName, t.logoUrl,
+                b.id, p.id, p.title, p.shortSummary, p.url, t.companyName, t.logoUrl,
                             p.publishedAt, p.thumbnailUrl, p.viewCount, null, true
             )
-            FROM Bookmark s
-            JOIN s.post p
+            FROM Bookmark b
+            JOIN b.post p
             JOIN p.techBlog t
-            WHERE s.user = :user
-            AND (:lastBookmarkId IS NULL OR s.id < :lastBookmarkId)
-            ORDER BY s.id DESC
+            WHERE b.user = :user
+            AND (:lastBookmarkId IS NULL OR b.id < :lastBookmarkId)
+            ORDER BY b.id DESC
             """)
     List<BookmarkDto> findBookmarksWithCursor(
             @Param("user") User user,
@@ -36,14 +36,14 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     Optional<Bookmark> findByUserAndPost(User user, Post post);
 
-    @Query("SELECT sp FROM Bookmark sp JOIN FETCH sp.post WHERE sp.user.id = :userId ORDER BY sp.bookmarkedAt DESC")
+    @Query("SELECT b FROM Bookmark b JOIN FETCH b.post WHERE b.user.id = :userId ORDER BY b.bookmarkedAt DESC")
     List<Bookmark> findRecentBookmarksByUserId(@Param("userId") Long userId, Pageable pageable);
 
     @Query("""
-            SELECT sp.post.id
-            FROM Bookmark sp
-            WHERE sp.user.id = :userId
-            AND sp.post.id IN :postIds
+            SELECT b.post.id
+            FROM Bookmark b
+            WHERE b.user.id = :userId
+            AND b.post.id IN :postIds
             """)
     List<Long> findBookmarkedPostIds(@Param("userId") Long userId, @Param("postIds") List<Long> postIds);
 }

--- a/src/main/java/com/techfork/domain/activity/service/ActivityCommandService.java
+++ b/src/main/java/com/techfork/domain/activity/service/ActivityCommandService.java
@@ -4,11 +4,11 @@ import com.techfork.domain.activity.dto.BookmarkRequest;
 import com.techfork.domain.activity.dto.ReadPostRequest;
 import com.techfork.domain.activity.dto.SearchHistoryRequest;
 import com.techfork.domain.activity.entity.ReadPost;
-import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.Bookmark;
 import com.techfork.domain.activity.entity.SearchHistory;
 import com.techfork.domain.activity.exception.ActivityErrorCode;
 import com.techfork.domain.activity.repository.ReadPostRepository;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.activity.repository.SearchHistoryRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.exception.PostErrorCode;
@@ -33,7 +33,7 @@ public class ActivityCommandService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final SearchHistoryRepository searchHistoryRepository;
-    private final ScrabPostRepository scrabPostRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     @Transactional
     public void saveReadPost(Long userId, ReadPostRequest request) {
@@ -83,12 +83,12 @@ public class ActivityCommandService {
         Post post = postRepository.findById(request.postId())
                 .orElseThrow(() -> new GeneralException(PostErrorCode.POST_NOT_FOUND));
 
-        if (scrabPostRepository.existsByUserAndPost(user, post)) {
+        if (bookmarkRepository.existsByUserAndPost(user, post)) {
             throw new GeneralException(ActivityErrorCode.BOOKMARK_ALREADY_EXISTS);
         }
 
-        ScrabPost scrabPost = ScrabPost.create(user, post, LocalDateTime.now());
-        scrabPostRepository.save(scrabPost);
+        Bookmark bookmark = Bookmark.create(user, post, LocalDateTime.now());
+        bookmarkRepository.save(bookmark);
 
         log.info("Saved bookmark for user {} and post {}", userId, request.postId());
     }
@@ -101,10 +101,10 @@ public class ActivityCommandService {
         Post post = postRepository.findById(request.postId())
                 .orElseThrow(() -> new GeneralException(PostErrorCode.POST_NOT_FOUND));
 
-        ScrabPost scrabPost = scrabPostRepository.findByUserAndPost(user, post)
+        Bookmark bookmark = bookmarkRepository.findByUserAndPost(user, post)
                 .orElseThrow(() -> new GeneralException(ActivityErrorCode.BOOKMARK_NOT_FOUND));
 
-        scrabPostRepository.delete(scrabPost);
+        bookmarkRepository.delete(bookmark);
         log.info("Deleted bookmark for user {} and post {}", userId, request.postId());
     }
 

--- a/src/main/java/com/techfork/domain/activity/service/ActivityQueryService.java
+++ b/src/main/java/com/techfork/domain/activity/service/ActivityQueryService.java
@@ -6,7 +6,7 @@ import com.techfork.domain.activity.dto.BookmarkListResponse;
 import com.techfork.domain.activity.dto.ReadPostDto;
 import com.techfork.domain.activity.dto.ReadPostListResponse;
 import com.techfork.domain.activity.repository.ReadPostRepository;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.post.repository.PostKeywordRepository;
 import com.techfork.domain.user.entity.User;
@@ -31,7 +31,7 @@ import java.util.stream.Collectors;
 public class ActivityQueryService {
 
     private final UserRepository userRepository;
-    private final ScrabPostRepository scrabPostRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final PostKeywordRepository postKeywordRepository;
     private final ReadPostRepository readPostRepository;
     private final ActivityConverter activityConverter;
@@ -42,7 +42,7 @@ public class ActivityQueryService {
                 .orElseThrow(() -> new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         PageRequest pageRequest = PageRequest.of(0, size + 1);
-        List<BookmarkDto> bookmarks = scrabPostRepository.findBookmarksWithCursor(user, lastBookmarkId, pageRequest);
+        List<BookmarkDto> bookmarks = bookmarkRepository.findBookmarksWithCursor(user, lastBookmarkId, pageRequest);
         List<BookmarkDto> bookmarksWithKeywords = attachKeywordsToPostInfoList(bookmarks);
 
         return activityConverter.toBookmarkListResponse(bookmarksWithKeywords, size);
@@ -135,7 +135,7 @@ public class ActivityQueryService {
                 .map(ReadPostDto::postId)
                 .toList();
 
-        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(userId, postIds);
+        List<Long> bookmarkedPostIds = bookmarkRepository.findBookmarkedPostIds(userId, postIds);
 
         return readPosts.stream()
                 .map(readPost -> ReadPostDto.builder()

--- a/src/main/java/com/techfork/domain/post/service/PostQueryService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostQueryService.java
@@ -1,6 +1,6 @@
 package com.techfork.domain.post.service;
 
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.converter.PostConverter;
 import com.techfork.domain.post.dto.*;
 import com.techfork.domain.post.entity.PostKeyword;
@@ -30,7 +30,7 @@ public class PostQueryService {
 
     private final PostRepository postRepository;
     private final PostKeywordRepository postKeywordRepository;
-    private final ScrabPostRepository scrabPostRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final PostConverter postConverter;
     private final CloudflareThirdPartyThumbnailOptimizer thumbnailOptimizer;
 
@@ -117,7 +117,7 @@ public class PostQueryService {
 
         Boolean isBookmarked = null;
         if (userId != null) {
-            isBookmarked = !scrabPostRepository.findBookmarkedPostIds(userId, List.of(postId)).isEmpty();
+            isBookmarked = !bookmarkRepository.findBookmarkedPostIds(userId, List.of(postId)).isEmpty();
         }
 
         return postConverter.toPostDetailDto(postDetail, keywords, isBookmarked);
@@ -165,7 +165,7 @@ public class PostQueryService {
                 .map(PostInfoDto::id)
                 .toList();
 
-        Set<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(userId, postIds)
+        Set<Long> bookmarkedPostIds = bookmarkRepository.findBookmarkedPostIds(userId, postIds)
                 .stream()
                 .collect(Collectors.toSet());
 

--- a/src/main/java/com/techfork/domain/recommendation/service/RecommendationQueryService.java
+++ b/src/main/java/com/techfork/domain/recommendation/service/RecommendationQueryService.java
@@ -1,6 +1,6 @@
 package com.techfork.domain.recommendation.service;
 
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.recommendation.converter.RecommendationConverter;
 import com.techfork.domain.recommendation.dto.RecommendationListResponse;
 import com.techfork.domain.recommendation.dto.RecommendedPostDto;
@@ -24,7 +24,7 @@ public class RecommendationQueryService {
     private final RecommendedPostRepository recommendedPostRepository;
     private final UserRepository userRepository;
     private final RecommendationConverter recommendationConverter;
-    private final ScrabPostRepository scrabPostRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     public RecommendationListResponse getRecommendations(Long userId) {
         User user = userRepository.getReferenceById(userId);
@@ -45,7 +45,7 @@ public class RecommendationQueryService {
         List<Long> postIds = response.recommendations().stream()
                 .map(RecommendedPostDto::postId)
                 .toList();
-        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(userId, postIds);
+        List<Long> bookmarkedPostIds = bookmarkRepository.findBookmarkedPostIds(userId, postIds);
 
         List<RecommendedPostDto> updatedRecommendations = response.recommendations().stream()
                 .map(dto -> dto.withBookmarkStatus(bookmarkedPostIds.contains(dto.postId())))

--- a/src/main/java/com/techfork/domain/search/service/SearchServiceImpl.java
+++ b/src/main/java/com/techfork/domain/search/service/SearchServiceImpl.java
@@ -6,7 +6,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.document.PostDocument;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
@@ -54,7 +54,7 @@ public class SearchServiceImpl implements SearchService {
     private final GeneralSearchProperties generalSearchProperties;
     private final UserProfileDocumentRepository userProfileDocumentRepository;
     private final PostRepository postRepository;
-    private final ScrabPostRepository scrabPostRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final Executor searchAsyncExecutor;
     private final CloudflareThirdPartyThumbnailOptimizer thumbnailOptimizer;
 
@@ -391,7 +391,7 @@ public class SearchServiceImpl implements SearchService {
 
         // Fetch bookmark status if userId is provided
         List<Long> bookmarkedPostIds = userId != null
-                ? scrabPostRepository.findBookmarkedPostIds(userId, postIds)
+                ? bookmarkRepository.findBookmarkedPostIds(userId, postIds)
                 : List.of();
 
         // Attach metadata to results

--- a/src/main/java/com/techfork/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/techfork/domain/user/repository/UserRepository.java
@@ -32,7 +32,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             AND (EXISTS (
                 SELECT 1 FROM ReadPost rp WHERE rp.user = u AND rp.readAt >= :since
             ) OR EXISTS (
-                SELECT 1 FROM Bookmark sp WHERE sp.user = u AND sp.bookmarkedAt >= :since
+                SELECT 1 FROM Bookmark b WHERE b.user = u AND b.bookmarkedAt >= :since
             ) OR EXISTS (
                 SELECT 1 FROM SearchHistory sh WHERE sh.user = u AND sh.searchedAt >= :since
             ))

--- a/src/main/java/com/techfork/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/techfork/domain/user/repository/UserRepository.java
@@ -23,7 +23,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     /**
      * 최근 특정 시간 이후 활동한 사용자 조회
-     * (읽은 포스트, 스크랩, 검색 기록 중 하나라도 있으면 활성 사용자)
+     * (읽은 포스트, 북마크, 검색 기록 중 하나라도 있으면 활성 사용자)
      * 탈퇴한 사용자는 제외
      */
     @Query("""
@@ -32,7 +32,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             AND (EXISTS (
                 SELECT 1 FROM ReadPost rp WHERE rp.user = u AND rp.readAt >= :since
             ) OR EXISTS (
-                SELECT 1 FROM ScrabPost sp WHERE sp.user = u AND sp.scrappedAt >= :since
+                SELECT 1 FROM Bookmark sp WHERE sp.user = u AND sp.bookmarkedAt >= :since
             ) OR EXISTS (
                 SELECT 1 FROM SearchHistory sh WHERE sh.user = u AND sh.searchedAt >= :since
             ))

--- a/src/main/java/com/techfork/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/techfork/domain/user/service/UserProfileService.java
@@ -1,10 +1,10 @@
 package com.techfork.domain.user.service;
 
 import com.techfork.domain.activity.entity.ReadPost;
-import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.Bookmark;
 import com.techfork.domain.activity.entity.SearchHistory;
 import com.techfork.domain.activity.repository.ReadPostRepository;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.activity.repository.SearchHistoryRepository;
 import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.recommendation.service.RecommendationService;
@@ -36,7 +36,7 @@ public class UserProfileService {
 
     private final UserInterestCategoryRepository userInterestCategoryRepository;
     private final ReadPostRepository readPostRepository;
-    private final ScrabPostRepository scrabPostRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final SearchHistoryRepository searchHistoryRepository;
     private final UserProfileDocumentRepository userProfileDocumentRepository;
     private final UserRepository userRepository;
@@ -120,8 +120,8 @@ public class UserProfileService {
                 ))
                 .toList();
 
-        List<ScrabPost> scrapPosts = scrabPostRepository.findRecentScrapPostsByUserId(userId, PageRequest.of(0, 20));
-        List<PostData> scrapPostData = scrapPosts.stream()
+        List<Bookmark> bookmarks = bookmarkRepository.findRecentBookmarksByUserId(userId, PageRequest.of(0, 20));
+        List<PostData> bookmarkedPostData = bookmarks.stream()
                 .map(sp -> new PostData(
                         sp.getPost().getTitle(),
                         sp.getPost().getKeywords().stream()
@@ -136,7 +136,7 @@ public class UserProfileService {
                 .map(SearchHistory::getSearchWord)
                 .toList();
 
-        return new UserActivityData(interests, readPostData, scrapPostData, searchWords);
+        return new UserActivityData(interests, readPostData, bookmarkedPostData, searchWords);
     }
 
     private String generateProfileTextWithLLM(UserActivityData data) {
@@ -193,7 +193,7 @@ public class UserProfileService {
                 """,
                 formatList(data.interests),
                 formatPostDataList(data.readPostData),
-                formatPostDataList(data.scrapPostData),
+                formatPostDataList(data.bookmarkedPostData),
                 formatList(data.searchWords)
         );
     }
@@ -292,7 +292,7 @@ public class UserProfileService {
     private record UserActivityData(
             List<String> interests,
             List<PostData> readPostData,
-            List<PostData> scrapPostData,
+            List<PostData> bookmarkedPostData,
             List<String> searchWords
     ) {}
 

--- a/src/main/resources/db/migration/V3__rename_scrap_posts_to_bookmarks.sql
+++ b/src/main/resources/db/migration/V3__rename_scrap_posts_to_bookmarks.sql
@@ -1,0 +1,44 @@
+-- Rename bookmark storage to the ubiquitous language.
+-- Constraint/index symbols are intentionally left untouched because existing
+-- environments can have different physical FK names. JPA validates the table
+-- and column names, not FK/index symbol names.
+
+SET @rename_bookmark_table = IF(
+    EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = DATABASE()
+          AND table_name = 'scrap_posts'
+    ) AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.tables
+        WHERE table_schema = DATABASE()
+          AND table_name = 'bookmarks'
+    ),
+    'RENAME TABLE scrap_posts TO bookmarks',
+    'SELECT 1'
+);
+PREPARE rename_bookmark_table_stmt FROM @rename_bookmark_table;
+EXECUTE rename_bookmark_table_stmt;
+DEALLOCATE PREPARE rename_bookmark_table_stmt;
+
+SET @rename_bookmarked_at_column = IF(
+    EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = DATABASE()
+          AND table_name = 'bookmarks'
+          AND column_name = 'scrapped_at'
+    ) AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = DATABASE()
+          AND table_name = 'bookmarks'
+          AND column_name = 'bookmarked_at'
+    ),
+    'ALTER TABLE bookmarks RENAME COLUMN scrapped_at TO bookmarked_at',
+    'SELECT 1'
+);
+PREPARE rename_bookmarked_at_column_stmt FROM @rename_bookmarked_at_column;
+EXECUTE rename_bookmarked_at_column_stmt;
+DEALLOCATE PREPARE rename_bookmarked_at_column_stmt;

--- a/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
@@ -5,10 +5,10 @@ import com.techfork.domain.activity.dto.BookmarkRequest;
 import com.techfork.domain.activity.dto.ReadPostRequest;
 import com.techfork.domain.activity.dto.SearchHistoryRequest;
 import com.techfork.domain.activity.entity.ReadPost;
-import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.Bookmark;
 import com.techfork.domain.activity.entity.SearchHistory;
 import com.techfork.domain.activity.repository.ReadPostRepository;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.activity.repository.SearchHistoryRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
@@ -62,7 +62,7 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
     private SearchHistoryRepository searchHistoryRepository;
 
     @Autowired
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -134,7 +134,7 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
     void tearDown() {
         readPostRepository.deleteAll();
         searchHistoryRepository.deleteAll();
-        scrabPostRepository.deleteAll();
+        bookmarkRepository.deleteAll();
         postRepository.deleteAll();
         techBlogRepository.deleteAll();
         userRepository.deleteAll();
@@ -302,7 +302,7 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.isSuccess").value(true));
 
         // DB 검증
-        List<ScrabPost> bookmarks = scrabPostRepository.findAll();
+        List<Bookmark> bookmarks = bookmarkRepository.findAll();
         assertThat(bookmarks).hasSize(1);
         assertThat(bookmarks.get(0).getUser().getId()).isEqualTo(testUser.getId());
         assertThat(bookmarks.get(0).getPost().getId()).isEqualTo(testPost1.getId());
@@ -312,8 +312,8 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
     @DisplayName("북마크 추가 실패 - 이미 북마크한 게시글")
     void addBookmark_Fail_AlreadyExists() throws Exception {
         // Given - 이미 북마크 생성
-        ScrabPost existingBookmark = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
-        scrabPostRepository.save(existingBookmark);
+        Bookmark existingBookmark = Bookmark.create(testUser, testPost1, LocalDateTime.now());
+        bookmarkRepository.save(existingBookmark);
 
         BookmarkRequest request = new BookmarkRequest(testPost1.getId());
 
@@ -350,8 +350,8 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
     @DisplayName("북마크 삭제 성공")
     void deleteBookmark_Success() throws Exception {
         // Given - 북마크 생성
-        ScrabPost bookmark = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
-        scrabPostRepository.save(bookmark);
+        Bookmark bookmark = Bookmark.create(testUser, testPost1, LocalDateTime.now());
+        bookmarkRepository.save(bookmark);
 
         BookmarkRequest request = new BookmarkRequest(testPost1.getId());
 
@@ -365,7 +365,7 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.isSuccess").value(true));
 
         // DB 검증 - 삭제되었는지 확인
-        List<ScrabPost> bookmarks = scrabPostRepository.findAll();
+        List<Bookmark> bookmarks = bookmarkRepository.findAll();
         assertThat(bookmarks).isEmpty();
     }
 
@@ -407,10 +407,10 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
     @DisplayName("북마크 목록 조회 성공 - 여러 개")
     void getBookmarks_Success_Multiple() throws Exception {
         // Given - 여러 개의 북마크 생성
-        ScrabPost bookmark1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now().minusHours(1));
-        ScrabPost bookmark2 = ScrabPost.create(testUser, testPost2, LocalDateTime.now());
-        scrabPostRepository.save(bookmark1);
-        scrabPostRepository.save(bookmark2);
+        Bookmark bookmark1 = Bookmark.create(testUser, testPost1, LocalDateTime.now().minusHours(1));
+        Bookmark bookmark2 = Bookmark.create(testUser, testPost2, LocalDateTime.now());
+        bookmarkRepository.save(bookmark1);
+        bookmarkRepository.save(bookmark2);
 
         // When & Then
         mockMvc.perform(get("/api/v1/activities/bookmarks")
@@ -441,10 +441,10 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
     @DisplayName("북마크 목록 조회 성공 - 커서 기반 페이징")
     void getBookmarks_Success_WithCursor() throws Exception {
         // Given - 여러 개의 북마크 생성
-        ScrabPost bookmark1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now().minusHours(2));
-        ScrabPost bookmark2 = ScrabPost.create(testUser, testPost2, LocalDateTime.now().minusHours(1));
-        scrabPostRepository.save(bookmark1);
-        scrabPostRepository.save(bookmark2);
+        Bookmark bookmark1 = Bookmark.create(testUser, testPost1, LocalDateTime.now().minusHours(2));
+        Bookmark bookmark2 = Bookmark.create(testUser, testPost2, LocalDateTime.now().minusHours(1));
+        bookmarkRepository.save(bookmark1);
+        bookmarkRepository.save(bookmark2);
 
         // When & Then - 첫 페이지 조회
         mockMvc.perform(get("/api/v1/activities/bookmarks")
@@ -543,8 +543,8 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
         readPostRepository.save(readPost2);
 
         // Given - testPost2만 북마크 (readPost2가 먼저 조회됨)
-        ScrabPost bookmark = ScrabPost.create(testUser, testPost2, LocalDateTime.now());
-        scrabPostRepository.save(bookmark);
+        Bookmark bookmark = Bookmark.create(testUser, testPost2, LocalDateTime.now());
+        bookmarkRepository.save(bookmark);
 
         // When & Then
         mockMvc.perform(get("/api/v1/activities/read-posts")

--- a/src/test/java/com/techfork/domain/activity/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/activity/repository/BookmarkRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.techfork.domain.activity.repository;
 
 import com.techfork.domain.activity.dto.BookmarkDto;
-import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.Bookmark;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
@@ -25,10 +25,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @ActiveProfiles("test")
-class ScrabPostRepositoryTest {
+class BookmarkRepositoryTest {
 
     @Autowired
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Autowired
     private UserRepository userRepository;
@@ -97,7 +97,7 @@ class ScrabPostRepositoryTest {
 
     @AfterEach
     void tearDown() {
-        scrabPostRepository.deleteAll();
+        bookmarkRepository.deleteAll();
         postRepository.deleteAll();
         techBlogRepository.deleteAll();
         userRepository.deleteAll();
@@ -107,17 +107,17 @@ class ScrabPostRepositoryTest {
     @DisplayName("북마크 목록 조회 - 커서 기반 페이징")
     void findBookmarksWithCursor() {
         // Given
-        ScrabPost scrab1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now().minusHours(3));
-        ScrabPost scrab2 = ScrabPost.create(testUser, testPost2, LocalDateTime.now().minusHours(2));
-        ScrabPost scrab3 = ScrabPost.create(testUser, testPost3, LocalDateTime.now().minusHours(1));
-        scrab1 = scrabPostRepository.save(scrab1);
-        scrab2 = scrabPostRepository.save(scrab2);
-        scrab3 = scrabPostRepository.save(scrab3);
+        Bookmark bookmark1 = Bookmark.create(testUser, testPost1, LocalDateTime.now().minusHours(3));
+        Bookmark bookmark2 = Bookmark.create(testUser, testPost2, LocalDateTime.now().minusHours(2));
+        Bookmark bookmark3 = Bookmark.create(testUser, testPost3, LocalDateTime.now().minusHours(1));
+        bookmark1 = bookmarkRepository.save(bookmark1);
+        bookmark2 = bookmarkRepository.save(bookmark2);
+        bookmark3 = bookmarkRepository.save(bookmark3);
 
         PageRequest pageRequest = PageRequest.of(0, 10);
 
         // When - 커서 없이 첫 페이지
-        List<BookmarkDto> firstPage = scrabPostRepository.findBookmarksWithCursor(testUser, null, pageRequest);
+        List<BookmarkDto> firstPage = bookmarkRepository.findBookmarksWithCursor(testUser, null, pageRequest);
 
         // Then
         assertThat(firstPage).hasSize(3);
@@ -126,8 +126,8 @@ class ScrabPostRepositoryTest {
         assertThat(firstPage.get(2).postId()).isEqualTo(testPost1.getId());
 
         // When - 커서를 사용한 다음 페이지
-        Long lastBookmarkId = scrab3.getId();
-        List<BookmarkDto> nextPage = scrabPostRepository.findBookmarksWithCursor(testUser, lastBookmarkId, pageRequest);
+        Long lastBookmarkId = bookmark3.getId();
+        List<BookmarkDto> nextPage = bookmarkRepository.findBookmarksWithCursor(testUser, lastBookmarkId, pageRequest);
 
         // Then
         assertThat(nextPage).hasSize(2);
@@ -139,15 +139,15 @@ class ScrabPostRepositoryTest {
     @DisplayName("북마크된 게시글 ID 목록 조회")
     void findBookmarkedPostIds() {
         // Given
-        ScrabPost scrab1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
-        ScrabPost scrab3 = ScrabPost.create(testUser, testPost3, LocalDateTime.now());
-        scrabPostRepository.save(scrab1);
-        scrabPostRepository.save(scrab3);
+        Bookmark bookmark1 = Bookmark.create(testUser, testPost1, LocalDateTime.now());
+        Bookmark bookmark3 = Bookmark.create(testUser, testPost3, LocalDateTime.now());
+        bookmarkRepository.save(bookmark1);
+        bookmarkRepository.save(bookmark3);
 
         List<Long> postIds = List.of(testPost1.getId(), testPost2.getId(), testPost3.getId());
 
         // When
-        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(testUser.getId(), postIds);
+        List<Long> bookmarkedPostIds = bookmarkRepository.findBookmarkedPostIds(testUser.getId(), postIds);
 
         // Then
         assertThat(bookmarkedPostIds).hasSize(2);
@@ -162,7 +162,7 @@ class ScrabPostRepositoryTest {
         List<Long> postIds = List.of(testPost1.getId(), testPost2.getId(), testPost3.getId());
 
         // When
-        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(testUser.getId(), postIds);
+        List<Long> bookmarkedPostIds = bookmarkRepository.findBookmarkedPostIds(testUser.getId(), postIds);
 
         // Then
         assertThat(bookmarkedPostIds).isEmpty();
@@ -175,15 +175,15 @@ class ScrabPostRepositoryTest {
         User anotherUser = User.createSocialUser(SocialType.KAKAO, "anotherSocialId", "another@example.com", "another.jpg");
         anotherUser = userRepository.save(anotherUser);
 
-        ScrabPost scrab1 = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
-        ScrabPost scrab2 = ScrabPost.create(anotherUser, testPost2, LocalDateTime.now());
-        scrabPostRepository.save(scrab1);
-        scrabPostRepository.save(scrab2);
+        Bookmark bookmark1 = Bookmark.create(testUser, testPost1, LocalDateTime.now());
+        Bookmark bookmark2 = Bookmark.create(anotherUser, testPost2, LocalDateTime.now());
+        bookmarkRepository.save(bookmark1);
+        bookmarkRepository.save(bookmark2);
 
         List<Long> postIds = List.of(testPost1.getId(), testPost2.getId());
 
         // When
-        List<Long> bookmarkedPostIds = scrabPostRepository.findBookmarkedPostIds(testUser.getId(), postIds);
+        List<Long> bookmarkedPostIds = bookmarkRepository.findBookmarkedPostIds(testUser.getId(), postIds);
 
         // Then
         assertThat(bookmarkedPostIds).hasSize(1);

--- a/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
@@ -4,11 +4,11 @@ import com.techfork.domain.activity.dto.BookmarkRequest;
 import com.techfork.domain.activity.dto.ReadPostRequest;
 import com.techfork.domain.activity.dto.SearchHistoryRequest;
 import com.techfork.domain.activity.entity.ReadPost;
-import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.Bookmark;
 import com.techfork.domain.activity.entity.SearchHistory;
 import com.techfork.domain.activity.exception.ActivityErrorCode;
 import com.techfork.domain.activity.repository.ReadPostRepository;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.activity.repository.SearchHistoryRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.exception.PostErrorCode;
@@ -47,7 +47,7 @@ class ActivityCommandServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Mock
     private SearchHistoryRepository searchHistoryRepository;
@@ -182,8 +182,8 @@ class ActivityCommandServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(postRepository.findById(postId)).willReturn(Optional.of(mockPost));
-        given(scrabPostRepository.existsByUserAndPost(mockUser, mockPost)).willReturn(false);
-        given(scrabPostRepository.save(any(ScrabPost.class))).willReturn(mock(ScrabPost.class));
+        given(bookmarkRepository.existsByUserAndPost(mockUser, mockPost)).willReturn(false);
+        given(bookmarkRepository.save(any(Bookmark.class))).willReturn(mock(Bookmark.class));
 
         // When
         activityCommandService.addBookmark(userId, request);
@@ -191,8 +191,8 @@ class ActivityCommandServiceTest {
         // Then
         verify(userRepository, times(1)).findById(userId);
         verify(postRepository, times(1)).findById(postId);
-        verify(scrabPostRepository, times(1)).existsByUserAndPost(mockUser, mockPost);
-        verify(scrabPostRepository, times(1)).save(any(ScrabPost.class));
+        verify(bookmarkRepository, times(1)).existsByUserAndPost(mockUser, mockPost);
+        verify(bookmarkRepository, times(1)).save(any(Bookmark.class));
     }
 
     @Test
@@ -208,14 +208,14 @@ class ActivityCommandServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(postRepository.findById(postId)).willReturn(Optional.of(mockPost));
-        given(scrabPostRepository.existsByUserAndPost(mockUser, mockPost)).willReturn(true);
+        given(bookmarkRepository.existsByUserAndPost(mockUser, mockPost)).willReturn(true);
 
         // When & Then
         assertThatThrownBy(() -> activityCommandService.addBookmark(userId, request))
                 .isInstanceOf(GeneralException.class)
                 .hasFieldOrPropertyWithValue("code", ActivityErrorCode.BOOKMARK_ALREADY_EXISTS);
 
-        verify(scrabPostRepository, never()).save(any());
+        verify(bookmarkRepository, never()).save(any());
     }
 
     @Test
@@ -235,7 +235,7 @@ class ActivityCommandServiceTest {
                 .isInstanceOf(GeneralException.class)
                 .hasFieldOrPropertyWithValue("code", PostErrorCode.POST_NOT_FOUND);
 
-        verify(scrabPostRepository, never()).save(any());
+        verify(bookmarkRepository, never()).save(any());
     }
 
     // ===== 북마크 삭제 테스트 =====
@@ -250,11 +250,11 @@ class ActivityCommandServiceTest {
 
         User mockUser = mock(User.class);
         Post mockPost = mock(Post.class);
-        ScrabPost mockScrabPost = mock(ScrabPost.class);
+        Bookmark mockBookmark = mock(Bookmark.class);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(postRepository.findById(postId)).willReturn(Optional.of(mockPost));
-        given(scrabPostRepository.findByUserAndPost(mockUser, mockPost)).willReturn(Optional.of(mockScrabPost));
+        given(bookmarkRepository.findByUserAndPost(mockUser, mockPost)).willReturn(Optional.of(mockBookmark));
 
         // When
         activityCommandService.deleteBookmark(userId, request);
@@ -262,8 +262,8 @@ class ActivityCommandServiceTest {
         // Then
         verify(userRepository, times(1)).findById(userId);
         verify(postRepository, times(1)).findById(postId);
-        verify(scrabPostRepository, times(1)).findByUserAndPost(mockUser, mockPost);
-        verify(scrabPostRepository, times(1)).delete(mockScrabPost);
+        verify(bookmarkRepository, times(1)).findByUserAndPost(mockUser, mockPost);
+        verify(bookmarkRepository, times(1)).delete(mockBookmark);
     }
 
     @Test
@@ -279,14 +279,14 @@ class ActivityCommandServiceTest {
 
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
         given(postRepository.findById(postId)).willReturn(Optional.of(mockPost));
-        given(scrabPostRepository.findByUserAndPost(mockUser, mockPost)).willReturn(Optional.empty());
+        given(bookmarkRepository.findByUserAndPost(mockUser, mockPost)).willReturn(Optional.empty());
 
         // When & Then
         assertThatThrownBy(() -> activityCommandService.deleteBookmark(userId, request))
                 .isInstanceOf(GeneralException.class)
                 .hasFieldOrPropertyWithValue("code", ActivityErrorCode.BOOKMARK_NOT_FOUND);
 
-        verify(scrabPostRepository, never()).delete(any());
+        verify(bookmarkRepository, never()).delete(any());
     }
 
     @Test
@@ -304,7 +304,7 @@ class ActivityCommandServiceTest {
                 .isInstanceOf(GeneralException.class)
                 .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
 
-        verify(scrabPostRepository, never()).delete(any());
+        verify(bookmarkRepository, never()).delete(any());
     }
 
     @Test

--- a/src/test/java/com/techfork/domain/activity/service/ActivityQueryServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityQueryServiceTest.java
@@ -6,7 +6,7 @@ import com.techfork.domain.activity.dto.BookmarkListResponse;
 import com.techfork.domain.activity.dto.ReadPostDto;
 import com.techfork.domain.activity.dto.ReadPostListResponse;
 import com.techfork.domain.activity.repository.ReadPostRepository;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.post.repository.PostKeywordRepository;
@@ -45,7 +45,7 @@ class ActivityQueryServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Mock
     private ReadPostRepository readPostRepository;
@@ -163,7 +163,7 @@ class ActivityQueryServiceTest {
         int size = 20;
 
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
-        given(scrabPostRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
+        given(bookmarkRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
                 .willReturn(mockBookmarksFirstPage);
         given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
 
@@ -180,7 +180,7 @@ class ActivityQueryServiceTest {
         assertThat(response.hasNext()).isTrue();
 
         verify(userRepository, times(1)).findById(userId);
-        verify(scrabPostRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
+        verify(bookmarkRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
         verify(activityConverter, times(1)).toBookmarkListResponse(mockBookmarksFirstPage, size);
     }
 
@@ -193,7 +193,7 @@ class ActivityQueryServiceTest {
         int size = 20;
 
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
-        given(scrabPostRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
+        given(bookmarkRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
                 .willReturn(mockBookmarksSecondPage);
         given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
 
@@ -209,7 +209,7 @@ class ActivityQueryServiceTest {
         assertThat(response.lastBookmarkId()).isNull();
         assertThat(response.hasNext()).isFalse();
 
-        verify(scrabPostRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
+        verify(bookmarkRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
     }
 
     @Test
@@ -228,7 +228,7 @@ class ActivityQueryServiceTest {
                 .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
 
         verify(userRepository, times(1)).findById(userId);
-        verify(scrabPostRepository, never()).findBookmarksWithCursor(any(), any(), any());
+        verify(bookmarkRepository, never()).findBookmarksWithCursor(any(), any(), any());
     }
 
     @Test
@@ -242,7 +242,7 @@ class ActivityQueryServiceTest {
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
 
         List<BookmarkDto> emptyBookmarks = List.of();
-        given(scrabPostRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
+        given(bookmarkRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
                 .willReturn(emptyBookmarks);
 
         BookmarkListResponse expectedResponse = new BookmarkListResponse(emptyBookmarks, null, false);
@@ -257,7 +257,7 @@ class ActivityQueryServiceTest {
         assertThat(response.lastBookmarkId()).isNull();
         assertThat(response.hasNext()).isFalse();
 
-        verify(scrabPostRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
+        verify(bookmarkRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
     }
 
     @Test
@@ -269,7 +269,7 @@ class ActivityQueryServiceTest {
         int size = 20;
 
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
-        given(scrabPostRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
+        given(bookmarkRepository.findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class)))
                 .willReturn(mockBookmarksFirstPage);
 
         // PostKeyword 목 객체 생성
@@ -354,7 +354,7 @@ class ActivityQueryServiceTest {
         assertThat(response.bookmarks().get(2).keywords()).isEmpty();
 
         verify(userRepository, times(1)).findById(userId);
-        verify(scrabPostRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
+        verify(bookmarkRepository, times(1)).findBookmarksWithCursor(eq(mockUser), eq(lastBookmarkId), any(PageRequest.class));
         verify(postKeywordRepository, times(1)).findByPostIdIn(any());
         verify(activityConverter, times(1)).toBookmarkListResponse(any(), eq(size));
     }
@@ -406,7 +406,7 @@ class ActivityQueryServiceTest {
         given(readPostRepository.findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class)))
                 .willReturn(mockReadPosts);
         given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
-        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(List.of());
+        given(bookmarkRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(List.of());
 
         ReadPostListResponse expectedResponse = new ReadPostListResponse(mockReadPosts, 2L, false);
         given(activityConverter.toReadPostListResponse(any(), eq(size))).willReturn(expectedResponse);
@@ -422,7 +422,7 @@ class ActivityQueryServiceTest {
 
         verify(readPostRepository, times(1)).findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class));
         verify(postKeywordRepository, times(1)).findByPostIdIn(any());
-        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+        verify(bookmarkRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
         verify(activityConverter, times(1)).toReadPostListResponse(any(), eq(size));
     }
 
@@ -487,7 +487,7 @@ class ActivityQueryServiceTest {
                 .willReturn(List.of(keyword1, keyword2));
 
         // 103L 게시글만 북마크됨
-        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(List.of(103L));
+        given(bookmarkRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(List.of(103L));
 
         List<ReadPostDto> expectedReadPostsWithMetadata = Arrays.asList(
                 ReadPostDto.builder()
@@ -538,7 +538,7 @@ class ActivityQueryServiceTest {
 
         verify(readPostRepository, times(1)).findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class));
         verify(postKeywordRepository, times(1)).findByPostIdIn(any());
-        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+        verify(bookmarkRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
     }
 
     @Test
@@ -567,6 +567,6 @@ class ActivityQueryServiceTest {
 
         verify(readPostRepository, times(1)).findReadPostsWithCursor(eq(userId), eq(lastReadPostId), any(PageRequest.class));
         verify(postKeywordRepository, never()).findByPostIdIn(any());
-        verify(scrabPostRepository, never()).findBookmarkedPostIds(any(), any());
+        verify(bookmarkRepository, never()).findBookmarkedPostIds(any(), any());
     }
 }

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.techfork.domain.post.controller;
 
-import com.techfork.domain.activity.entity.ScrabPost;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.entity.Bookmark;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.entity.PostKeyword;
 import com.techfork.domain.post.repository.PostKeywordRepository;
@@ -48,7 +48,7 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
     private TechBlogRepository techBlogRepository;
 
     @Autowired
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Autowired
     private UserRepository userRepository;
@@ -123,14 +123,14 @@ class PostControllerIntegrationTest extends IntegrationTestBase {
         accessToken = jwtUtil.generateTokens(testUser.getId(), Role.USER).accessToken();
 
         // testUser가 testPost1을 북마크
-        ScrabPost scrabPost = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
-        scrabPostRepository.save(scrabPost);
+        Bookmark bookmark = Bookmark.create(testUser, testPost1, LocalDateTime.now());
+        bookmarkRepository.save(bookmark);
     }
 
     @AfterEach
     void tearDown() {
         // 테스트 데이터 정리 (외래키 제약조건 순서 고려)
-        scrabPostRepository.deleteAll();
+        bookmarkRepository.deleteAll();
         postKeywordRepository.deleteAll();
         postRepository.deleteAll();
         techBlogRepository.deleteAll();

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerV2IntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerV2IntegrationTest.java
@@ -1,7 +1,7 @@
 package com.techfork.domain.post.controller;
 
-import com.techfork.domain.activity.entity.ScrabPost;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.entity.Bookmark;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.source.entity.TechBlog;
@@ -45,7 +45,7 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     private TechBlogRepository techBlogRepository;
 
     @Autowired
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Autowired
     private UserRepository userRepository;
@@ -120,14 +120,14 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
         postRepository.save(oldPost);
 
         // testUser가 todayPost를 북마크
-        ScrabPost scrabPost = ScrabPost.create(testUser, todayPost, LocalDateTime.now());
-        scrabPostRepository.save(scrabPost);
+        Bookmark bookmark = Bookmark.create(testUser, todayPost, LocalDateTime.now());
+        bookmarkRepository.save(bookmark);
     }
 
     @AfterEach
     void tearDown() {
         // 테스트 데이터 정리 (외래키 제약조건 순서 고려)
-        scrabPostRepository.deleteAll();
+        bookmarkRepository.deleteAll();
         postRepository.deleteAll();
         techBlogRepository.deleteAll();
         userRepository.deleteAll();
@@ -154,7 +154,7 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     @DisplayName("GET /api/v2/posts/companies - 게시글이 없는 경우 빈 배열 반환")
     void getCompanies_EmptyWhenNoPosts() throws Exception {
         // Given: 모든 게시글 삭제
-        scrabPostRepository.deleteAll();
+        bookmarkRepository.deleteAll();
         postRepository.deleteAll();
 
         // When & Then: 빈 배열 반환 확인
@@ -499,7 +499,7 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     @DisplayName("GET /api/v2/posts/recent - 게시글이 없으면 빈 배열 반환")
     void getRecentPosts_EmptyWhenNoPosts() throws Exception {
         // Given: 모든 게시글 삭제
-        scrabPostRepository.deleteAll();
+        bookmarkRepository.deleteAll();
         postRepository.deleteAll();
 
         // When & Then: 빈 배열 반환

--- a/src/test/java/com/techfork/domain/post/service/PostQueryServiceTest.java
+++ b/src/test/java/com/techfork/domain/post/service/PostQueryServiceTest.java
@@ -1,6 +1,6 @@
 package com.techfork.domain.post.service;
 
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.converter.PostConverter;
 import com.techfork.domain.post.dto.*;
 import com.techfork.domain.post.entity.PostKeyword;
@@ -45,7 +45,7 @@ class PostQueryServiceTest {
     private PostKeywordRepository postKeywordRepository;
 
     @Mock
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Mock
     private PostConverter postConverter;
@@ -189,7 +189,7 @@ class PostQueryServiceTest {
         verify(postRepository, times(1)).findByIdWithTechBlog(postId);
         verify(postKeywordRepository, times(1)).findByPostIdIn(List.of(postId));
         verify(postConverter, times(1)).toPostDetailDto(mockPostDetail, keywordStrings, null);
-        verify(scrabPostRepository, never()).findBookmarkedPostIds(any(), any());
+        verify(bookmarkRepository, never()).findBookmarkedPostIds(any(), any());
     }
 
     @Test
@@ -232,7 +232,7 @@ class PostQueryServiceTest {
 
         given(postRepository.findByIdWithTechBlog(postId)).willReturn(Optional.of(mockPostDetail));
         given(postKeywordRepository.findByPostIdIn(List.of(postId))).willReturn(mockKeywords);
-        given(scrabPostRepository.findBookmarkedPostIds(userId, List.of(postId))).willReturn(List.of(postId));
+        given(bookmarkRepository.findBookmarkedPostIds(userId, List.of(postId))).willReturn(List.of(postId));
         given(postConverter.toPostDetailDto(mockPostDetail, keywordStrings, true)).willReturn(expectedResponse);
 
         // When
@@ -245,7 +245,7 @@ class PostQueryServiceTest {
 
         verify(postRepository, times(1)).findByIdWithTechBlog(postId);
         verify(postKeywordRepository, times(1)).findByPostIdIn(List.of(postId));
-        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(userId, List.of(postId));
+        verify(bookmarkRepository, times(1)).findBookmarkedPostIds(userId, List.of(postId));
         verify(postConverter, times(1)).toPostDetailDto(mockPostDetail, keywordStrings, true);
     }
 
@@ -289,7 +289,7 @@ class PostQueryServiceTest {
 
         given(postRepository.findByIdWithTechBlog(postId)).willReturn(Optional.of(mockPostDetail));
         given(postKeywordRepository.findByPostIdIn(List.of(postId))).willReturn(mockKeywords);
-        given(scrabPostRepository.findBookmarkedPostIds(userId, List.of(postId))).willReturn(List.of());
+        given(bookmarkRepository.findBookmarkedPostIds(userId, List.of(postId))).willReturn(List.of());
         given(postConverter.toPostDetailDto(mockPostDetail, keywordStrings, false)).willReturn(expectedResponse);
 
         // When
@@ -302,7 +302,7 @@ class PostQueryServiceTest {
 
         verify(postRepository, times(1)).findByIdWithTechBlog(postId);
         verify(postKeywordRepository, times(1)).findByPostIdIn(List.of(postId));
-        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(userId, List.of(postId));
+        verify(bookmarkRepository, times(1)).findBookmarkedPostIds(userId, List.of(postId));
         verify(postConverter, times(1)).toPostDetailDto(mockPostDetail, keywordStrings, false);
     }
 
@@ -910,7 +910,7 @@ class PostQueryServiceTest {
         given(postRepository.findByCompanyWithCursor(eq(company), eq(lastPostId), any(PageRequest.class)))
                 .willReturn(mockPosts);
         given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
-        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(bookmarkRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
@@ -923,7 +923,7 @@ class PostQueryServiceTest {
         assertThat(result.posts().get(1).isBookmarked()).isFalse();
 
         verify(postRepository, times(1)).findByCompanyWithCursor(eq(company), eq(lastPostId), any(PageRequest.class));
-        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+        verify(bookmarkRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
     }
 
     @Test
@@ -969,7 +969,7 @@ class PostQueryServiceTest {
         assertThat(result.posts().get(0).isBookmarked()).isNull();
 
         verify(postRepository, times(1)).findByCompanyWithCursor(eq(company), eq(lastPostId), any(PageRequest.class));
-        verify(scrabPostRepository, never()).findBookmarkedPostIds(any(), any());
+        verify(bookmarkRepository, never()).findBookmarkedPostIds(any(), any());
     }
 
     @Test
@@ -1020,7 +1020,7 @@ class PostQueryServiceTest {
         given(postRepository.findRecentPostsWithCursor(eq(lastPostId), any(PageRequest.class)))
                 .willReturn(mockPosts);
         given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
-        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(bookmarkRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
@@ -1033,7 +1033,7 @@ class PostQueryServiceTest {
         assertThat(result.posts().get(1).isBookmarked()).isTrue();
 
         verify(postRepository, times(1)).findRecentPostsWithCursor(eq(lastPostId), any(PageRequest.class));
-        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+        verify(bookmarkRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
     }
 
     @Test
@@ -1086,7 +1086,7 @@ class PostQueryServiceTest {
         given(postRepository.findByCompanyNamesWithCursor(eq(companies), eq(lastPublishedAt), eq(lastPostId), any(PageRequest.class)))
                 .willReturn(mockPosts);
         given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
-        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(bookmarkRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
@@ -1099,7 +1099,7 @@ class PostQueryServiceTest {
         assertThat(result.posts().get(1).isBookmarked()).isTrue();
 
         verify(postRepository, times(1)).findByCompanyNamesWithCursor(eq(companies), eq(lastPublishedAt), eq(lastPostId), any(PageRequest.class));
-        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+        verify(bookmarkRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
     }
 
     @Test
@@ -1141,7 +1141,7 @@ class PostQueryServiceTest {
         given(postRepository.findPopularPostsWithCursorV2(eq(lastViewCount), eq(lastPostId), any(PageRequest.class)))
                 .willReturn(mockPosts);
         given(postKeywordRepository.findByPostIdIn(any())).willReturn(List.of());
-        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(bookmarkRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
         given(postConverter.toPostListResponse(any(), eq(size))).willReturn(expectedResponse);
 
         // When
@@ -1153,6 +1153,6 @@ class PostQueryServiceTest {
         assertThat(result.posts().get(0).isBookmarked()).isFalse();
 
         verify(postRepository, times(1)).findPopularPostsWithCursorV2(eq(lastViewCount), eq(lastPostId), any(PageRequest.class));
-        verify(scrabPostRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
+        verify(bookmarkRepository, times(1)).findBookmarkedPostIds(eq(userId), any());
     }
 }

--- a/src/test/java/com/techfork/domain/recommendation/controller/RecommendationControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/recommendation/controller/RecommendationControllerIntegrationTest.java
@@ -1,8 +1,8 @@
 package com.techfork.domain.recommendation.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.techfork.domain.activity.entity.ScrabPost;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.entity.Bookmark;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.recommendation.entity.RecommendedPost;
@@ -54,7 +54,7 @@ class RecommendationControllerIntegrationTest extends IntegrationTestBase {
     private RecommendedPostRepository recommendedPostRepository;
 
     @Autowired
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -147,7 +147,7 @@ class RecommendationControllerIntegrationTest extends IntegrationTestBase {
     @AfterEach
     void tearDown() {
         recommendedPostRepository.deleteAll();
-        scrabPostRepository.deleteAll();
+        bookmarkRepository.deleteAll();
         postRepository.deleteAll();
         techBlogRepository.deleteAll();
         userRepository.deleteAll();
@@ -247,8 +247,8 @@ class RecommendationControllerIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.recommendations[0].isBookmarked").value(false));
 
         // 3. 북마크 추가
-        ScrabPost bookmark = ScrabPost.create(testUser, testPost1, LocalDateTime.now());
-        scrabPostRepository.save(bookmark);
+        Bookmark bookmark = Bookmark.create(testUser, testPost1, LocalDateTime.now());
+        bookmarkRepository.save(bookmark);
 
         // 4. 다시 조회 - 북마크됨
         mockMvc.perform(get("/api/v1/recommendations")

--- a/src/test/java/com/techfork/domain/recommendation/service/RecommendationQueryServiceTest.java
+++ b/src/test/java/com/techfork/domain/recommendation/service/RecommendationQueryServiceTest.java
@@ -1,6 +1,6 @@
 package com.techfork.domain.recommendation.service;
 
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.recommendation.converter.RecommendationConverter;
 import com.techfork.domain.recommendation.dto.RecommendationListResponse;
@@ -43,7 +43,7 @@ class RecommendationQueryServiceTest {
     private RecommendationConverter recommendationConverter;
 
     @Mock
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @InjectMocks
     private RecommendationQueryService recommendationQueryService;
@@ -133,7 +133,7 @@ class RecommendationQueryServiceTest {
         given(userRepository.getReferenceById(userId)).willReturn(testUser);
         given(recommendedPostRepository.findByUserOrderByRankAsc(testUser)).willReturn(recommendedPosts);
         given(recommendationConverter.toRecommendationListResponse(recommendedPosts)).willReturn(initialResponse);
-        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(List.of());
+        given(bookmarkRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(List.of());
 
         // when
         RecommendationListResponse response = recommendationQueryService.getRecommendations(userId);
@@ -147,7 +147,7 @@ class RecommendationQueryServiceTest {
         verify(userRepository).getReferenceById(userId);
         verify(recommendedPostRepository).findByUserOrderByRankAsc(testUser);
         verify(recommendationConverter).toRecommendationListResponse(recommendedPosts);
-        verify(scrabPostRepository).findBookmarkedPostIds(eq(userId), any());
+        verify(bookmarkRepository).findBookmarkedPostIds(eq(userId), any());
     }
 
     @Test
@@ -174,7 +174,7 @@ class RecommendationQueryServiceTest {
         given(userRepository.getReferenceById(userId)).willReturn(testUser);
         given(recommendedPostRepository.findByUserOrderByRankAsc(testUser)).willReturn(recommendedPosts);
         given(recommendationConverter.toRecommendationListResponse(recommendedPosts)).willReturn(initialResponse);
-        given(scrabPostRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
+        given(bookmarkRepository.findBookmarkedPostIds(eq(userId), any())).willReturn(bookmarkedPostIds);
 
         // when
         RecommendationListResponse response = recommendationQueryService.getRecommendations(userId);
@@ -215,7 +215,7 @@ class RecommendationQueryServiceTest {
         verify(userRepository).getReferenceById(userId);
         verify(recommendedPostRepository).findByUserOrderByRankAsc(testUser);
         verify(recommendationConverter).toRecommendationListResponse(emptyList);
-        verify(scrabPostRepository, never()).findBookmarkedPostIds(any(), any());
+        verify(bookmarkRepository, never()).findBookmarkedPostIds(any(), any());
     }
 
     private RecommendedPostDto createRecommendedPostDto(

--- a/src/test/java/com/techfork/domain/user/repository/UserRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/user/repository/UserRepositoryTest.java
@@ -1,10 +1,10 @@
 package com.techfork.domain.user.repository;
 
 import com.techfork.domain.activity.entity.ReadPost;
-import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.Bookmark;
 import com.techfork.domain.activity.entity.SearchHistory;
 import com.techfork.domain.activity.repository.ReadPostRepository;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.activity.repository.SearchHistoryRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.repository.PostRepository;
@@ -42,7 +42,7 @@ class UserRepositoryTest {
     private ReadPostRepository readPostRepository;
 
     @Autowired
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Autowired
     private SearchHistoryRepository searchHistoryRepository;
@@ -131,14 +131,14 @@ class UserRepositoryTest {
     }
 
     @Test
-    @DisplayName("findActiveUsersSince - 최근 스크랩한 포스트가 있는 유저 조회")
-    void findActiveUsersSince_WithScrapPost_ReturnsActiveUsers() {
+    @DisplayName("findActiveUsersSince - 최근 북마크한 포스트가 있는 유저 조회")
+    void findActiveUsersSince_WithBookmark_ReturnsActiveUsers() {
         // Given
         LocalDateTime since = LocalDateTime.now().minusDays(7);
 
         Post post = createPost();
-        ScrabPost scrabPost = ScrabPost.create(testUser, post, LocalDateTime.now());
-        scrabPostRepository.save(scrabPost);
+        Bookmark bookmark = Bookmark.create(testUser, post, LocalDateTime.now());
+        bookmarkRepository.save(bookmark);
 
         // When
         List<User> activeUsers = userRepository.findActiveUsersSince(since);
@@ -193,11 +193,11 @@ class UserRepositoryTest {
         Post post2 = createPost();
 
         ReadPost readPost = ReadPost.create(testUser, post1, LocalDateTime.now(), 100);
-        ScrabPost scrabPost = ScrabPost.create(testUser, post2, LocalDateTime.now());
+        Bookmark bookmark = Bookmark.create(testUser, post2, LocalDateTime.now());
         SearchHistory searchHistory = SearchHistory.create(testUser, "검색", LocalDateTime.now());
 
         readPostRepository.save(readPost);
-        scrabPostRepository.save(scrabPost);
+        bookmarkRepository.save(bookmark);
         searchHistoryRepository.save(searchHistory);
 
         // When

--- a/src/test/java/com/techfork/evaluation/recommendation/setup/components/TestDataGenerator.java
+++ b/src/test/java/com/techfork/evaluation/recommendation/setup/components/TestDataGenerator.java
@@ -110,10 +110,10 @@ public class TestDataGenerator {
         log.info("읽은 글 구성: 공통 {} 개 + 개인화 {} 개 = 총 {} 개",
                 sharedReadPosts.size(), actualPersonalCount, readPosts.size());
 
-        // 4. 스크랩한 글 생성 (읽은 글 중 25% 정도를 스크랩)
-        int scrapCount = Math.max(5, readPosts.size() / 4); // 최소 5개
-        userTestDataBuilder.createScrapPosts(user, readPosts, scrapCount);
-        log.info("스크랩한 글: {} 개 생성", scrapCount);
+        // 4. 북마크한 글 생성 (읽은 글 중 25% 정도를 북마크)
+        int bookmarkCount = Math.max(5, readPosts.size() / 4); // 최소 5개
+        userTestDataBuilder.createBookmarks(user, readPosts, bookmarkCount);
+        log.info("북마크한 글: {} 개 생성", bookmarkCount);
 
         // 5. 검색 기록 생성 (관심사 키워드 기반)
         List<String> searchKeywords = generateSearchKeywords(interestCategories);

--- a/src/test/java/com/techfork/evaluation/recommendation/setup/components/UserTestDataBuilder.java
+++ b/src/test/java/com/techfork/evaluation/recommendation/setup/components/UserTestDataBuilder.java
@@ -1,10 +1,10 @@
 package com.techfork.evaluation.recommendation.setup.components;
 
 import com.techfork.domain.activity.entity.ReadPost;
-import com.techfork.domain.activity.entity.ScrabPost;
+import com.techfork.domain.activity.entity.Bookmark;
 import com.techfork.domain.activity.entity.SearchHistory;
 import com.techfork.domain.activity.repository.ReadPostRepository;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.activity.repository.SearchHistoryRepository;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.user.entity.User;
@@ -31,7 +31,7 @@ public class UserTestDataBuilder {
     private final UserRepository userRepository;
     private final UserInterestCategoryRepository userInterestCategoryRepository;
     private final ReadPostRepository readPostRepository;
-    private final ScrabPostRepository scrabPostRepository;
+    private final BookmarkRepository bookmarkRepository;
     private final SearchHistoryRepository searchHistoryRepository;
 
     public User createUserWithInterests(List<EInterestCategory> interestCategories) {
@@ -93,29 +93,29 @@ public class UserTestDataBuilder {
     }
 
 
-    public void createScrapPosts(User user, List<Post> readPosts, int scrapCount) {
+    public void createBookmarks(User user, List<Post> readPosts, int bookmarkCount) {
         LocalDateTime now = LocalDateTime.now();
 
-        List<Post> postsToScrap = readPosts.stream()
+        List<Post> postsToBookmark = readPosts.stream()
                 .distinct()
                 .collect(Collectors.toList());
-        Collections.shuffle(postsToScrap);
+        Collections.shuffle(postsToBookmark);
 
-        int actualScrapCount = Math.min(scrapCount, postsToScrap.size());
+        int actualBookmarkCount = Math.min(bookmarkCount, postsToBookmark.size());
 
-        List<ScrabPost> scrabPosts = new ArrayList<>();
-        for (int i = 0; i < actualScrapCount; i++) {
-            Post post = postsToScrap.get(i);
-            ScrabPost scrabPost = ScrabPost.create(
+        List<Bookmark> bookmarks = new ArrayList<>();
+        for (int i = 0; i < actualBookmarkCount; i++) {
+            Post post = postsToBookmark.get(i);
+            Bookmark bookmark = Bookmark.create(
                     user,
                     post,
-                    now.minusDays(readPosts.size() - i - 5) // 읽은 시점보다 약간 후에 스크랩
+                    now.minusDays(readPosts.size() - i - 5) // 읽은 시점보다 약간 후에 북마크
             );
-            scrabPosts.add(scrabPost);
+            bookmarks.add(bookmark);
         }
 
-        scrabPostRepository.saveAll(scrabPosts);
-        log.debug("스크랩한 글 {} 개 생성 완료", actualScrapCount);
+        bookmarkRepository.saveAll(bookmarks);
+        log.debug("북마크한 글 {} 개 생성 완료", actualBookmarkCount);
     }
 
     public void createSearchHistories(User user, List<String> searchKeywords, int searchHistoryCount) {

--- a/src/test/java/com/techfork/evaluation/search/SearchEvaluationTestBase.java
+++ b/src/test/java/com/techfork/evaluation/search/SearchEvaluationTestBase.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.search.dto.SearchResult;
 import com.techfork.domain.search.config.GeneralSearchProperties;
@@ -50,7 +50,7 @@ public abstract class SearchEvaluationTestBase {
     @Autowired protected EmbeddingClient embeddingClient;
     @Autowired protected UserProfileDocumentRepository userProfileDocumentRepository;
     @Autowired protected PostRepository postRepository;
-    @Autowired protected ScrabPostRepository scrabPostRepository;
+    @Autowired protected BookmarkRepository bookmarkRepository;
     @Autowired @Qualifier("searchAsyncExecutor") protected Executor searchAsyncExecutor;
     @Autowired protected ObjectMapper objectMapper;
 
@@ -110,7 +110,7 @@ public abstract class SearchEvaluationTestBase {
             SearchService svc = new SearchServiceImpl(
                     elasticsearchClient, embeddingClient, props,
                     userProfileDocumentRepository, postRepository,
-                    scrabPostRepository, searchAsyncExecutor, thumbnailOptimizer);
+                    bookmarkRepository, searchAsyncExecutor, thumbnailOptimizer);
 
             // index: [nDCG@4, nDCG@8, nDCG@20, Recall@4, Recall@8, Recall@20, latency]
             double[] sums = new double[7];

--- a/src/test/java/com/techfork/evaluation/search/setup/SearchGroundTruthGenerator.java
+++ b/src/test/java/com/techfork/evaluation/search/setup/SearchGroundTruthGenerator.java
@@ -2,7 +2,7 @@ package com.techfork.evaluation.search.setup;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
-import com.techfork.domain.activity.repository.ScrabPostRepository;
+import com.techfork.domain.activity.repository.BookmarkRepository;
 import com.techfork.domain.post.document.PostDocument;
 import com.techfork.domain.post.repository.PostRepository;
 import com.techfork.domain.search.dto.SearchResult;
@@ -108,7 +108,7 @@ class SearchGroundTruthGenerator {
     private PostRepository postRepository;
 
     @Autowired
-    private ScrabPostRepository scrabPostRepository;
+    private BookmarkRepository bookmarkRepository;
 
     @Autowired
     @Qualifier("searchAsyncExecutor")
@@ -145,7 +145,7 @@ class SearchGroundTruthGenerator {
         );
         SearchServiceImpl searchService = new SearchServiceImpl(
                 elasticsearchClient, embeddingClient, generalSearchProperties,
-                userProfileDocumentRepository, postRepository, scrabPostRepository, searchAsyncExecutor, thumbnailOptimizer);
+                userProfileDocumentRepository, postRepository, bookmarkRepository, searchAsyncExecutor, thumbnailOptimizer);
 
         List<GroundTruthItem> groundTruthItems = scoreAllQueries(uniqueQueryMap, searchService);
         log.info("최종 ground-truth 항목 수: {}", groundTruthItems.size());


### PR DESCRIPTION
## ❤️ 기능 설명

기능 변경 없이 북마크 도메인의 내부 네이밍을 유비쿼터스 언어에 맞게 정리했습니다.

- `ScrabPost` 엔티티를 `Bookmark`로, `ScrabPostRepository`를 `BookmarkRepository`로 변경
- DB 테이블/컬럼명을 `scrap_posts` / `scrapped_at` → `bookmarks` / `bookmarked_at`으로 변경하는 Flyway V3 마이그레이션 추가
- Activity/Post/Recommendation/Search/UserProfile 로직에서 기존 scrap/scrab 의존성 제거
- 관련 단위 테스트, 통합 테스트, 평가 테스트 데이터 생성 코드의 네이밍 반영

### 테스트 결과

- `./gradlew test` 성공
  - 46개 test suite / 304개 test
  - failures 0, errors 0, skipped 0
  - BUILD SUCCESSFUL in 5m 6s

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #359
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (Swagger 스크린샷 대신 Gradle 테스트 결과를 본문에 기재)
- [x] 이슈넘버를 적었는가?
