### PR TITLE
[refactor/#361] 검색어 용어 정리

### DIFF
--- a/docs/ddd-test-refactoring-roadmap.md
+++ b/docs/ddd-test-refactoring-roadmap.md
@@ -253,7 +253,7 @@ PostKeyword
 1. SearchHistory 동작 테스트 작성
 2. DTO/API 파라미터 문서에서 검색어/SearchQuery로 표현 통일
 3. 코드 내부 변수명 query/searchQuery 정리
-4. DB 컬럼 search_word rename은 후순위로 분리
+4. 운영 중이면 DB 컬럼 rename은 후순위로 분리하고, 초기 정리 단계라면 함께 처리 가능
 ```
 
 ---

--- a/docs/ubiquitous-language/README.md
+++ b/docs/ubiquitous-language/README.md
@@ -43,7 +43,7 @@
 
 | 표준 용어 | 현재 코드상 표현 | 의미 | 기준 문서 |
 |---|---|---|---|
-| 검색어 / SearchQuery | `query`, `searchWord` | 사용자가 직접 입력한 검색 문자열 | [`search.md`](./search.md), [`activity.md`](./activity.md) |
+| 검색어 / SearchQuery | `query` (legacy alias: `searchWord`) | 사용자가 직접 입력한 검색 문자열 | [`search.md`](./search.md), [`activity.md`](./activity.md) |
 | 핵심 키워드 / KeyKeyword | `keyKeywords` | 개인화 프로필에서 추출한 대표 관심 키워드 | [`personalization-profile.md`](./personalization-profile.md) |
 | 게시글 키워드 / PostKeyword | `PostKeyword.keyword` | 기술 게시글 요약 과정에서 추출된 대표 키워드 | [`post-content.md`](./post-content.md) |
 
@@ -67,7 +67,7 @@
 | 결정사항 | 기준 문서 | 코드 반영 여부 | 남은 작업 |
 |---|---|---|---|
 | `ScrabPost → Bookmark` 통일 | [`activity.md`](./activity.md) | 부분 반영 | Entity/Repository/Table rename |
-| `searchWord → query` 통일 | [`activity.md`](./activity.md), [`search.md`](./search.md) | 미반영 | 필드/컬럼 rename 마이그레이션 |
+| `searchWord → query` 통일 | [`activity.md`](./activity.md), [`search.md`](./search.md) | 반영 | legacy JSON alias 정리 여부 결정 |
 | `RecommendationSet` 표준 용어 확정 | [`recommendation.md`](./recommendation.md) | 미반영 | 현재 추천 목록 aggregate 정리 |
 | `markAsisClicked → markAsClicked` 오타 수정 | [`recommendation.md`](./recommendation.md) | 미반영 | 메서드명/호출부 수정 |
 | `TechBlog.markCrawled()` 추가 | [`source-ingestion.md`](./source-ingestion.md) | 미반영 | 도메인 메서드 추가 + 호출부 연결 |

--- a/docs/ubiquitous-language/activity.md
+++ b/docs/ubiquitous-language/activity.md
@@ -15,7 +15,7 @@
 | 읽기 몰입도 | `convertReadingDurationToNaturalLanguage` | 읽은 시간을 `가볍게 훑어봄`, `빠르게 읽음`, `읽음`, `정독함`, `깊게 읽음`으로 해석한 값 |
 | 첫 읽기 | `isFirstRead` | 특정 기술 게시글을 처음 읽은 경우 |
 | 검색 기록 | `SearchHistory` | 사용자가 입력한 검색어와 검색 시각 |
-| 검색어 | `SearchQuery`, 현재 `searchWord` | 검색 기록에 저장되는 사용자 입력 |
+| 검색어 | `query` (legacy alias: `searchWord`) | 검색 기록에 저장되는 사용자 입력 |
 | 북마크 | `Bookmark`, 현재 `ScrabPost` | 사용자가 기술 게시글을 저장하는 행위 |
 | 북마크 여부 | `isBookmarked` | 목록/검색/추천 응답에 붙는 사용자별 저장 여부 |
 
@@ -23,7 +23,7 @@
 
 - 제품/API/문서 언어 기준으로 **북마크**로 통일한다.
 - 레거시 이름 `ScrabPost`, `scrap_posts`는 코드/DB 잔존 용어로만 취급한다.
-- `SearchHistory.searchWord`는 장기적으로 `searchQuery` 또는 `query`로 변경한다.
+- `SearchHistory`의 코드/DB 필드명은 `query`로 맞춘다.
 
 ## 내부 glossary
 
@@ -46,7 +46,7 @@
 | 금지/비권장 표현 | 권장 표현 | 이유 |
 |---|---|---|
 | 스크랩 | 북마크 | 제품/API 언어와 맞추기 위해 |
-| searchWord | 검색어 / SearchQuery | 코드 레거시 필드명보다 표준 용어를 우선한다 |
+| searchWord | 검색어 / SearchQuery, 코드에서는 `query` | 문서에는 표준 용어를, 코드에는 canonical name을 사용한다 |
 | 읽은 포스트 | 읽은 게시글 | Post 컨텍스트 표준 용어와 맞춘다 |
 | bookmarked 필드 | 북마크 여부 | 응답 조합값이라는 의미를 더 분명히 한다 |
 

--- a/docs/ubiquitous-language/search.md
+++ b/docs/ubiquitous-language/search.md
@@ -11,7 +11,7 @@
 
 | 용어 | 코드상 표현 | 정의 |
 |---|---|---|
-| 검색어 / SearchQuery | `query`, 현재 `searchWord` | 사용자가 찾고 싶은 기술 주제/키워드 |
+| 검색어 / SearchQuery | `query` (Activity legacy alias: `searchWord`) | 사용자가 찾고 싶은 기술 주제/키워드 |
 | BM25 검색 / 어휘 검색 | `searchOnlyBm25`, `performLexicalSearch` | 제목/요약/본문 청크 텍스트 기반 검색 |
 | 시맨틱 검색 | `searchOnlySemantic`, `performSemanticSearch` | 검색어 임베딩과 기술 게시글 임베딩의 k-NN 기반 검색 |
 | 하이브리드 검색 | `performHybridSearch` | BM25 검색과 시맨틱 검색을 병렬 실행한 뒤 결합하는 검색 |

--- a/src/main/java/com/techfork/domain/activity/dto/SearchHistoryRequest.java
+++ b/src/main/java/com/techfork/domain/activity/dto/SearchHistoryRequest.java
@@ -1,5 +1,6 @@
 package com.techfork.domain.activity.dto;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -7,9 +8,10 @@ import jakarta.validation.constraints.Size;
 import java.time.LocalDateTime;
 
 public record SearchHistoryRequest(
+        @JsonAlias("searchWord")
         @NotBlank(message = "검색어는 필수입니다.")
         @Size(max = 200, message = "검색어는 200자 이하여야 합니다.")
-        String searchWord,
+        String query,
 
         @NotNull(message = "검색 시간은 필수입니다.")
         LocalDateTime searchedAt

--- a/src/main/java/com/techfork/domain/activity/entity/SearchHistory.java
+++ b/src/main/java/com/techfork/domain/activity/entity/SearchHistory.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 public class SearchHistory extends BaseEntity {
 
     @Column(nullable = false, length = 200)
-    private String searchWord;
+    private String query;
 
     private LocalDateTime searchedAt;
 
@@ -28,16 +28,16 @@ public class SearchHistory extends BaseEntity {
 
     @PersistenceCreator
     @Builder
-    SearchHistory(User user, String searchWord, LocalDateTime searchedAt) {
+    SearchHistory(User user, String query, LocalDateTime searchedAt) {
         this.user = user;
-        this.searchWord = searchWord;
+        this.query = query;
         this.searchedAt = searchedAt;
     }
 
-    public static SearchHistory create(User user, String searchWord, LocalDateTime searchedAt) {
+    public static SearchHistory create(User user, String query, LocalDateTime searchedAt) {
         return SearchHistory.builder()
                 .user(user)
-                .searchWord(searchWord)
+                .query(query)
                 .searchedAt(searchedAt)
                 .build();
     }

--- a/src/main/java/com/techfork/domain/activity/service/ActivityCommandService.java
+++ b/src/main/java/com/techfork/domain/activity/service/ActivityCommandService.java
@@ -67,12 +67,12 @@ public class ActivityCommandService {
 
         SearchHistory searchHistory = SearchHistory.create(
                 user,
-                request.searchWord(),
+                request.query(),
                 request.searchedAt()
         );
 
         searchHistoryRepository.save(searchHistory);
-        log.info("Saved search history for user {} with keyword: {}", userId, request.searchWord());
+        log.info("Saved search history for user {} with query: {}", userId, request.query());
     }
 
     @Transactional

--- a/src/main/java/com/techfork/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/techfork/domain/user/service/UserProfileService.java
@@ -132,11 +132,11 @@ public class UserProfileService {
                 .toList();
 
         List<SearchHistory> searchHistories = searchHistoryRepository.findRecentSearchHistoriesByUserId(userId, PageRequest.of(0, 30));
-        List<String> searchWords = searchHistories.stream()
-                .map(SearchHistory::getSearchWord)
+        List<String> searchQueries = searchHistories.stream()
+                .map(SearchHistory::getQuery)
                 .toList();
 
-        return new UserActivityData(interests, readPostData, bookmarkedPostData, searchWords);
+        return new UserActivityData(interests, readPostData, bookmarkedPostData, searchQueries);
     }
 
     private String generateProfileTextWithLLM(UserActivityData data) {
@@ -194,7 +194,7 @@ public class UserProfileService {
                 formatList(data.interests),
                 formatPostDataList(data.readPostData),
                 formatPostDataList(data.bookmarkedPostData),
-                formatList(data.searchWords)
+                formatList(data.searchQueries)
         );
     }
 
@@ -293,7 +293,7 @@ public class UserProfileService {
             List<String> interests,
             List<PostData> readPostData,
             List<PostData> bookmarkedPostData,
-            List<String> searchWords
+            List<String> searchQueries
     ) {}
 
     private record PostData(

--- a/src/main/resources/db/migration/V4__rename_search_histories_search_word_to_query.sql
+++ b/src/main/resources/db/migration/V4__rename_search_histories_search_word_to_query.sql
@@ -1,0 +1,24 @@
+-- Align search history storage with the SearchQuery terminology.
+-- This migration is idempotent so environments already adjusted manually
+-- or restored from a newer snapshot do not fail.
+
+SET @rename_search_query_column = IF(
+    EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = DATABASE()
+          AND table_name = 'search_histories'
+          AND column_name = 'search_word'
+    ) AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = DATABASE()
+          AND table_name = 'search_histories'
+          AND column_name = 'query'
+    ),
+    'ALTER TABLE search_histories RENAME COLUMN search_word TO query',
+    'SELECT 1'
+);
+PREPARE rename_search_query_column_stmt FROM @rename_search_query_column;
+EXECUTE rename_search_query_column_stmt;
+DEALLOCATE PREPARE rename_search_query_column_stmt;

--- a/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/domain/activity/controller/ActivityControllerIntegrationTest.java
@@ -249,7 +249,33 @@ class ActivityControllerIntegrationTest extends IntegrationTestBase {
         List<SearchHistory> searchHistories = searchHistoryRepository.findAll();
         assertThat(searchHistories).hasSize(1);
         assertThat(searchHistories.get(0).getUser().getId()).isEqualTo(testUser.getId());
-        assertThat(searchHistories.get(0).getSearchWord()).isEqualTo("Spring Boot");
+        assertThat(searchHistories.get(0).getQuery()).isEqualTo("Spring Boot");
+    }
+
+    @Test
+    @DisplayName("검색 히스토리 저장 성공 - legacy searchWord alias 허용")
+    void saveSearchHistory_Success_WithLegacyAlias() throws Exception {
+        // Given
+        LocalDateTime searchedAt = LocalDateTime.now();
+        String requestJson = """
+                {
+                  "searchWord": "Spring Boot",
+                  "searchedAt": "%s"
+                }
+                """.formatted(searchedAt);
+
+        // When & Then
+        mockMvc.perform(post("/api/v1/activities/searches")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.isSuccess").value(true));
+
+        List<SearchHistory> searchHistories = searchHistoryRepository.findAll();
+        assertThat(searchHistories).hasSize(1);
+        assertThat(searchHistories.get(0).getQuery()).isEqualTo("Spring Boot");
     }
 
     @Test

--- a/src/test/java/com/techfork/domain/activity/dto/SearchHistoryRequestTest.java
+++ b/src/test/java/com/techfork/domain/activity/dto/SearchHistoryRequestTest.java
@@ -1,0 +1,48 @@
+package com.techfork.domain.activity.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchHistoryRequestTest {
+
+    private final ObjectMapper objectMapper = JsonMapper.builder()
+            .findAndAddModules()
+            .build();
+
+    @Test
+    @DisplayName("검색 히스토리 요청은 query 필드로 역직렬화된다")
+    void deserialize_WithQueryField() throws Exception {
+        String requestJson = """
+                {
+                  "query": "Spring Boot",
+                  "searchedAt": "2026-04-24T16:30:00"
+                }
+                """;
+
+        SearchHistoryRequest request = objectMapper.readValue(requestJson, SearchHistoryRequest.class);
+
+        assertThat(request.query()).isEqualTo("Spring Boot");
+        assertThat(request.searchedAt()).isEqualTo(LocalDateTime.of(2026, 4, 24, 16, 30));
+    }
+
+    @Test
+    @DisplayName("검색 히스토리 요청은 legacy searchWord alias도 허용한다")
+    void deserialize_WithLegacySearchWordAlias() throws Exception {
+        String requestJson = """
+                {
+                  "searchWord": "Spring Boot",
+                  "searchedAt": "2026-04-24T16:30:00"
+                }
+                """;
+
+        SearchHistoryRequest request = objectMapper.readValue(requestJson, SearchHistoryRequest.class);
+
+        assertThat(request.query()).isEqualTo("Spring Boot");
+    }
+}

--- a/src/test/java/com/techfork/domain/activity/repository/SearchHistoryRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/activity/repository/SearchHistoryRepositoryTest.java
@@ -58,8 +58,8 @@ class SearchHistoryRepositoryTest {
 
         // Then
         assertThat(result).hasSize(3);
-        assertThat(result.get(0).getSearchWord()).isEqualTo("Kotlin");
-        assertThat(result.get(1).getSearchWord()).isEqualTo("Java");
-        assertThat(result.get(2).getSearchWord()).isEqualTo("Spring Boot");
+        assertThat(result.get(0).getQuery()).isEqualTo("Kotlin");
+        assertThat(result.get(1).getQuery()).isEqualTo("Java");
+        assertThat(result.get(2).getQuery()).isEqualTo("Spring Boot");
     }
 }

--- a/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/activity/service/ActivityCommandServiceTest.java
@@ -21,6 +21,7 @@ import com.techfork.global.exception.GeneralException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -355,9 +356,9 @@ class ActivityCommandServiceTest {
     void saveSearchHistory_Success() {
         // Given
         Long userId = 1L;
-        String searchWord = "Spring Boot";
+        String query = "Spring Boot";
         LocalDateTime searchedAt = LocalDateTime.now();
-        SearchHistoryRequest request = new SearchHistoryRequest(searchWord, searchedAt);
+        SearchHistoryRequest request = new SearchHistoryRequest(query, searchedAt);
 
         User mockUser = mock(User.class);
         given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
@@ -368,7 +369,9 @@ class ActivityCommandServiceTest {
 
         // Then
         verify(userRepository, times(1)).findById(userId);
-        verify(searchHistoryRepository, times(1)).save(any(SearchHistory.class));
+        ArgumentCaptor<SearchHistory> searchHistoryCaptor = ArgumentCaptor.forClass(SearchHistory.class);
+        verify(searchHistoryRepository, times(1)).save(searchHistoryCaptor.capture());
+        assertThat(searchHistoryCaptor.getValue().getQuery()).isEqualTo(query);
     }
 
     @Test

--- a/src/test/java/com/techfork/evaluation/recommendation/setup/components/UserTestDataBuilder.java
+++ b/src/test/java/com/techfork/evaluation/recommendation/setup/components/UserTestDataBuilder.java
@@ -123,10 +123,10 @@ public class UserTestDataBuilder {
         List<SearchHistory> searchHistories = new ArrayList<>();
 
         for (int i = 0; i < searchHistoryCount; i++) {
-            String searchWord = searchKeywords.get(i % searchKeywords.size());
+            String query = searchKeywords.get(i % searchKeywords.size());
             SearchHistory searchHistory = SearchHistory.create(
                     user,
-                    searchWord,
+                    query,
                     now.minusDays(searchHistoryCount - i * 2) // 읽기 활동 사이사이에 검색
             );
             searchHistories.add(searchHistory);


### PR DESCRIPTION
## ❤️ 기능 설명
- Activity 검색 기록 저장 경로의 canonical name을 `query`로 정리했습니다.
- `search_histories.search_word`를 `query`로 바꾸는 Flyway V4 마이그레이션을 추가했습니다.
- `SearchQuery / KeyKeyword / PostKeyword` 구분이 드러나도록 유비쿼터스 언어 문서를 정리했습니다.
- 요청 호환성을 위해 `SearchHistoryRequest`에서는 `searchWord` alias를 계속 허용합니다.

> Swagger 스크린샷: 이번 변경은 내부 용어/DB 마이그레이션 중심이라 별도 Swagger 변화는 없었습니다. 대신 아래 테스트 결과를 남깁니다.
>
> - `./gradlew test --tests 'com.techfork.domain.activity.dto.SearchHistoryRequestTest' --tests 'com.techfork.domain.activity.repository.SearchHistoryRepositoryTest' --tests 'com.techfork.domain.activity.service.ActivityCommandServiceTest' --tests 'com.techfork.domain.user.repository.UserRepositoryTest'`
> - `./gradlew test --tests 'com.techfork.domain.activity.controller.ActivityControllerIntegrationTest'`
> - `./gradlew test`

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #361
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] Flyway V4 (`search_word -> query`)가 기존 개발/운영 DB 이력과 충돌하지 않는지 확인 부탁드립니다.
- [ ] `searchWord` JSON alias를 후속 이슈에서 제거할지 여부를 확인 부탁드립니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
