### PR TITLE
[refactor/#365] 사용하지 않는 EDifficultyLevel 제거

### DIFF
--- a/docs/ddd-test-refactoring-roadmap.md
+++ b/docs/ddd-test-refactoring-roadmap.md
@@ -98,7 +98,7 @@ DDD 목표 지도 작성
 - 프로필 대표어는 **핵심 키워드/KeyKeyword**로 부른다.
 - 게시글 대표어는 **게시글 키워드/PostKeyword**로 부른다.
 - 전략 문서와 glossary에서는 **`User Account`** 와 **`Personalization Profile`** 을 분리한다.
-- `EDifficultyLevel`은 현재 제거 후보로 본다.
+- `EDifficultyLevel`은 실제 사용처가 없어 제거 완료된 상태로 본다.
 
 ---
 
@@ -280,13 +280,13 @@ PostKeyword
 
 ### 3.4 4순위: `EDifficultyLevel` 제거
 
-현재 핵심 흐름에서 사용처가 약하다.
+2026-04-28 기준 실제 사용처가 없음을 확인했고, enum 삭제를 완료했다.
 
-권장 순서:
+처리 결과:
 
 ```text
-1. 실제 사용처가 없는지 확인
-2. 삭제
+1. 실제 사용처 없음 확인
+2. `src/main/java/com/techfork/domain/post/enums/EDifficultyLevel.java` 삭제 완료
 3. 난이도 기능이 필요해질 때 정책과 함께 재도입
 ```
 

--- a/docs/test-gap-analysis.md
+++ b/docs/test-gap-analysis.md
@@ -588,7 +588,7 @@ src/main/java/com/techfork/domain/notification/entity/NotificationToken.java
 
 작업 2: Post 애그리거트 테스트
 - PostTest 추가
-- EDifficultyLevel 제거 전 사용처 확인
+- EDifficultyLevel 제거 후 문서 정리 및 회귀 확인
 
 작업 3: Personalization Profile 테스트
 - PersonalizationProfileServiceTest 추가

--- a/docs/ubiquitous-language/README.md
+++ b/docs/ubiquitous-language/README.md
@@ -73,7 +73,7 @@
 | `TechBlog.markCrawled()` 추가 | [`source-ingestion.md`](./source-ingestion.md) | 미반영 | 도메인 메서드 추가 + 호출부 연결 |
 | `User.replaceInterests()` 추가 | [`user-account.md`](./user-account.md) | 미반영 | aggregate 불변식 검증을 도메인 메서드로 이동 |
 | `Post.incrementViewCount()` SQL atomic UPDATE | [`post-content.md`](./post-content.md) | 미반영 | Repository atomic update 도입 |
-| `EDifficultyLevel` 제거 여부 결정 | [`post-content.md`](./post-content.md) | 미반영 | 사용처 조사 후 제거 또는 재정의 |
+| `EDifficultyLevel` 제거 | [`post-content.md`](./post-content.md) | 반영 | 필요 시 정책과 함께 재도입 검토 |
 
 ---
 

--- a/docs/ubiquitous-language/post-content.md
+++ b/docs/ubiquitous-language/post-content.md
@@ -31,7 +31,7 @@
 - 도메인/기획 문서에서는 `Post`를 **기술 게시글**로 부른다.
 - `PostDocument`, `ContentChunk`는 aggregate가 아니라 **검색/추천용 projection**이다.
 - `Post.company`는 Source 컨텍스트의 출처명을 복사한 조회용 스냅샷이다.
-- `EDifficultyLevel`은 현재 핵심 흐름에서 역할이 약하므로 제거 후보로 본다.
+- `EDifficultyLevel`은 실제 사용처가 없어 제거되었다. 필요해지면 정책과 함께 재도입한다.
 
 ## 내부 glossary
 

--- a/src/main/java/com/techfork/domain/post/enums/EDifficultyLevel.java
+++ b/src/main/java/com/techfork/domain/post/enums/EDifficultyLevel.java
@@ -1,7 +1,0 @@
-package com.techfork.domain.post.enums;
-
-public enum EDifficultyLevel {
-    BEGINNER,
-    INTERMEDIATE,
-    ADVANCED
-}


### PR DESCRIPTION
## ❤️ 기능 설명

사용하지 않던 `EDifficultyLevel` enum을 제거하고, DDD 로드맵/용어 문서에 삭제 완료 사실을 반영했습니다.

- `src/main/java/com/techfork/domain/post/enums/EDifficultyLevel.java` 삭제
- `docs/ddd-test-refactoring-roadmap.md`에 제거 완료 반영
- `docs/ubiquitous-language/post-content.md`, `docs/ubiquitous-language/README.md`, `docs/test-gap-analysis.md` 최소 동기화

swagger 테스트 성공 결과 스크린샷 첨부
- 이번 PR은 내부 리팩터링/문서 정리라 Swagger 화면 변경은 없습니다.
- 대신 아래 명령으로 검증했습니다.
  - `./gradlew compileJava compileTestJava --console=plain`

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #365
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
