### PR TITLE
[refactor/#383] 게시글 조회수 증가 원자적 업데이트 적용

### DIFF
--- a/docs/tactical-design.md
+++ b/docs/tactical-design.md
@@ -13,7 +13,7 @@
 | 컨텍스트 | 애그리거트 루트 | 내부 엔티티 / 값 객체 / Projection | 트랜잭션 내 보장 불변식 | 현재 코드 평가 |
 |---|---|---|---|---|
 | Source / Ingestion | `TechBlog` | `RssFeedItem`은 DTO/ACL 결과 | `blogUrl`과 `rssUrl`은 유일해야 한다. `lastCrawledAt`은 `markCrawled(LocalDateTime)`으로만 갱신된다. 기술 블로그는 RSS 수집 대상의 기준이다. | `TechBlog`가 Source 컨텍스트의 루트로 적절하다. **`markCrawled(LocalDateTime)` 도메인 메서드 누락** — 현재 Anemic Model 위험. |
-| Post / Content | `Post` | `PostKeyword`, `PostDocument`, `ContentChunk` | URL은 유일해야 한다. 요약/짧은 요약은 `updateSummaries()`로만 교체된다. 키워드는 `clearKeywords() + addKeyword()` 조합으로만 교체된다. 임베딩 완료 시각은 `markAsEmbedded(LocalDateTime)`으로만 기록된다. `incrementViewCount()`는 비원자적 연산이므로 SQL atomic UPDATE 정책 적용 필요. | `Post`가 핵심 애그리거트 루트다. `PostKeyword`는 `Post` 내부 컬렉션으로 보는 것이 자연스럽다. **`incrementViewCount()` 동시성 정책 미결정** (§1.2 참조). |
+| Post / Content | `Post` | `PostKeyword`, `PostDocument`, `ContentChunk` | URL은 유일해야 한다. 요약/짧은 요약은 `updateSummaries()`로만 교체된다. 키워드는 `clearKeywords() + addKeyword()` 조합으로만 교체된다. 임베딩 완료 시각은 `markAsEmbedded(LocalDateTime)`으로만 기록된다. 조회수 증가는 `PostCommandService`/`PostRepository`의 SQL atomic UPDATE 경로로만 처리한다. | `Post`가 핵심 애그리거트 루트다. `PostKeyword`는 `Post` 내부 컬렉션으로 보는 것이 자연스럽다. 조회수 증가는 aggregate 필드 증가가 아니라 command/repository 경로를 canonical write path로 본다 (§1.2 참조). |
 | User Account | `User` | `UserInterestCategory`, `UserInterestKeyword` | `socialType + socialId` 조합은 유일해야 한다. 상태 전이는 `PENDING → ACTIVE → WITHDRAWN → PENDING(재활성화)` 경로만 허용된다. 관심 키워드는 반드시 선택된 관심 카테고리에 속해야 한다. 관심사 교체는 `replaceInterests()`로 단일 트랜잭션 내 불변식 검증과 함께 처리된다. | `User`가 루트다. 계정/온보딩/관심사 불변식을 소유한다. **`replaceInterests()` 도메인 메서드 누락** — 불변식 검증이 서비스 레이어에 산재. |
 | Personalization Profile | 명시적 쓰기 애그리거트 없음 | `PersonalizationProfileDocument`, `UserActivityData` | 같은 `userId` 기준 현재 개인화 프로필 projection은 하나만 유지된다. 프로필 텍스트, 벡터, 핵심 키워드는 함께 재생성된다. | Personalization Profile은 aggregate보다 read model / application service 중심 컨텍스트다. 현재 `PersonalizationProfileService`가 생성 책임을 가진다. |
 | Activity | `ReadPost`, `Bookmark`, `SearchHistory` | 없음 | `Bookmark`는 `userId + postId` 조합이 유일해야 한다. `ReadPost`는 같은 사용자+게시글 중복 저장을 허용하되 `ReadPostFirstReadPolicy.isFirstRead()`로 최초 읽기를 구분한다. `SearchHistory`는 같은 검색어를 중복 저장한다 (동일 검색어의 반복 횟수 자체가 개인화 관심 신호가 된다). 행동 기록은 삭제되지 않고 보존된다 (북마크 제외). | 각 행동 기록이 독립 record aggregate처럼 동작한다. 현재 브랜치 기준으로 `Bookmark`, `ReadPost`, `SearchHistory`는 모두 `activity/<slice>` 아래에서 `presentation / application / domain / infrastructure` 구조로 정리되었다. `ReadPost`는 `SaveReadPostCommand`, `GetReadPostsQuery`, `ReadPostConverter`, `BookmarkLookupService`를 통해 저장/조회/북마크 여부 조합을 분담하고, 목록 조회 `size`는 HTTP layer에서 `1..100`으로 검증한다. `SearchHistory`는 `SearchHistoryRequest`, `SaveSearchHistoryCommand`, `ReadHistoryCommandService`로 저장 흐름을 분리했다. 또한 Activity application 서비스의 cross-context 조회는 `UserLookupService`, `PostLookupService`, `PostKeywordLookupService`, `BookmarkLookupService`를 통해 application 간 의존으로 정리되었다. aggregate/value object 강화, hexagonal port/adaptor 적용, `ManyToOne -> id reference` 같은 경계 재설계는 후속 단계로 미룬다. |
@@ -43,17 +43,18 @@
 - `PostKeyword`는 독립 루트라기보다 `Post`의 키워드 컬렉션이다.
 - `PostDocument`, `ContentChunk`는 Elasticsearch 검색/추천용 projection이지 RDB 애그리거트 루트가 아니다.
 
-**`incrementViewCount()` 동시성 정책**
+**`viewCount` 동시성 정책**
 
-현재 `viewCount++` 연산은 JPA dirty checking 기반 비원자적 업데이트다. 동시 요청 시 Lost Update가 발생한다.
+기존 `viewCount++` 연산은 JPA dirty checking 기반 비원자적 업데이트라 동시 요청 시 Lost Update가 발생한다.
 
 - **결정**: SQL atomic UPDATE 방식 적용
   ```java
   @Modifying
   @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
-  void incrementViewCount(@Param("id") Long id);
+  int incrementViewCount(@Param("id") Long id);
   ```
 - `@Version` 낙관적 락은 재시도 비용이 발생하고 조회수 같은 통계성 필드에는 부적합하므로 채택하지 않는다.
+- production 경로에서는 `Post.incrementViewCount()` 같은 엔티티 필드 증가를 사용하지 않고 `PostCommandService`/`PostRepository` 경로를 canonical write path로 둔다.
 - 현재 `isFirstRead` 체크로 사용자 중복 카운트는 방지하고 있으나, 다수 사용자 동시 접근 시 레이스 컨디션은 여전히 존재한다.
 
 **누락된 도메인 메서드**
@@ -158,7 +159,7 @@ createSocialUser() → PENDING
 | P0 | 개인화 프로필이 생성됨 | `PersonalizedProfileGenerated` | `PersonalizationProfileService.generatePersonalizationProfileSync` | 추천 생성, 개인화 검색 준비 완료 | 현재 `PersonalizationProfileService`가 추천 생성을 직접 호출한다. 이벤트 분리 우선순위가 높다. |
 | P0 | 추천이 생성됨 | `RecommendationsGenerated` | `LlmRecommendationService.generateRecommendationsForUser` | Notification, Analytics | 사용자에게 보여줄 현재 추천 목록이 바뀌는 핵심 이벤트다. |
 | P1 | 기술 게시글을 읽음 | `TechnicalPostRead` | `ReadPostCommandService.saveReadPost` | 개인화 프로필 갱신, 추천 정책 | 읽기 행동은 개인화 프로필과 읽은 게시글 제외 정책의 핵심 입력이다. |
-| P1 | 기술 게시글을 처음 읽음 | `TechnicalPostFirstRead` | `ReadPostFirstReadPolicy.isFirstRead` + `Post.incrementViewCount` | 인기순 정렬, 분석 | 조회수 증가와 인기순 정렬에 직접 연결된다. |
+| P1 | 기술 게시글을 처음 읽음 | `TechnicalPostFirstRead` | `ReadPostFirstReadPolicy.isFirstRead` + `PostCommandService.incrementViewCount` | 인기순 정렬, 분석 | 조회수 증가와 인기순 정렬에 직접 연결된다. |
 | P1 | 기술 게시글을 북마크함 | `TechnicalPostBookmarked` | `BookmarkCommandService.addBookmark` | 개인화 프로필 갱신, 추천 튜닝 | 강한 선호 신호로 개인화 품질에 중요하다. |
 | P1 | 북마크가 해제됨 | `BookmarkRemoved` | `BookmarkCommandService.deleteBookmark` | 개인화 프로필 갱신, 추천 튜닝 | 선호 신호 제거로 볼 수 있다. |
 | P1 | 검색어가 기록됨 | `SearchQueryRecorded` | `saveSearchHistory` | 개인화 프로필 갱신, 검색 분석 | 검색 의도는 개인화 프로필의 주요 입력이다. |

--- a/docs/ubiquitous-language/README.md
+++ b/docs/ubiquitous-language/README.md
@@ -73,7 +73,7 @@
 | `markAsisClicked → markAsClicked` 오타 수정 | [`recommendation.md`](./recommendation.md) | 미반영 | 메서드명/호출부 수정 |
 | `TechBlog.markCrawled()` 추가 | [`source-ingestion.md`](./source-ingestion.md) | 미반영 | 도메인 메서드 추가 + 호출부 연결 |
 | `User.replaceInterests()` 추가 | [`user-account.md`](./user-account.md) | 미반영 | aggregate 불변식 검증을 도메인 메서드로 이동 |
-| `Post.incrementViewCount()` SQL atomic UPDATE | [`post-content.md`](./post-content.md) | 미반영 | Repository atomic update 도입 |
+| `Post viewCount` SQL atomic UPDATE 경로 정리 | [`post-content.md`](./post-content.md) | 반영 | `isFirstRead` race / idempotency는 별도 이슈로 해결 |
 | `EDifficultyLevel` 제거 | [`post-content.md`](./post-content.md) | 반영 | 필요 시 정책과 함께 재도입 검토 |
 
 ---

--- a/docs/ubiquitous-language/activity.md
+++ b/docs/ubiquitous-language/activity.md
@@ -34,6 +34,7 @@
 |---|---|---|
 | 읽기 기록 | `ReadPost` | 사용자와 기술 게시글의 읽기 이벤트 레코드 |
 | 최초 읽기 판별 | `ReadPostFirstReadPolicy.isFirstRead` | 조회수 증가 여부를 결정하는 정책 |
+| 조회수 증가 위임 | `PostCommandService.incrementViewCount` | 첫 읽기일 때 Post 컨텍스트에 조회수 증가를 위임하는 command 경로 |
 | 북마크 레코드 | `Bookmark` (legacy name: `ScrabPost`) | 북마크 저장 레코드의 현재 표준 이름과 과거 이름을 함께 설명한다 |
 | 검색 기록 레코드 | `SearchHistory` | 사용자 검색어를 시간순으로 남기는 레코드 |
 | 북마크 여부 조합값 | `isBookmarked` | Search/Post/Recommendation 응답 조립 시 붙는 파생 값 |
@@ -56,10 +57,11 @@
 ## 현재 구조 메모
 
 - 현재 브랜치 기준으로 `Bookmark`, `ReadPost`, `SearchHistory`는 모두 `presentation / application / domain / infrastructure` 기준으로 정리되어 있다.
+- `ReadPost` 저장은 `UserLookupService`, `PostLookupService`, `ReadPostFirstReadPolicy`, `PostCommandService`를 조합해 첫 읽기 판별과 조회수 증가를 분리한다.
 - `ReadPost` 조회는 `bookmark.infrastructure.BookmarkRepository`를 직접 참조하지 않고 `bookmark.application.query.lookup.BookmarkLookupService`를 통해 북마크 여부를 조합한다.
 - `ReadPost` 목록 조회 `size`는 HTTP layer에서 `1..100`으로 검증한다.
 - `SearchHistory` 저장은 `SearchHistoryRequest -> SaveSearchHistoryCommand -> ReadHistoryCommandService` 흐름을 따른다.
-- Activity application 서비스의 cross-context 조회는 `UserLookupService`, `PostLookupService`, `PostKeywordLookupService`, `BookmarkLookupService`를 통해 application 간 의존으로 정리되어 있다.
+- Activity application 서비스의 cross-context 조회/명령 의존은 `UserLookupService`, `PostLookupService`, `PostKeywordLookupService`, `BookmarkLookupService`, `PostCommandService`를 통해 application 간 의존으로 정리되어 있다.
 - aggregate/value object 강화, hexagonal architecture(포트/어댑터), `ManyToOne -> ID reference` 전환은 후속 정리 범위다.
 
 ## 주요 근거 파일
@@ -82,6 +84,7 @@
 - `src/main/java/com/techfork/activity/bookmark/presentation/BookmarkController.java`
 - `src/main/java/com/techfork/domain/useraccount/service/UserLookupService.java`
 - `src/main/java/com/techfork/domain/post/service/PostLookupService.java`
+- `src/main/java/com/techfork/domain/post/service/PostCommandService.java`
 - `src/main/java/com/techfork/domain/post/service/PostKeywordLookupService.java`
 - `src/main/java/com/techfork/activity/readhistory/application/command/ReadHistoryCommandService.java`
 - `src/main/java/com/techfork/activity/readhistory/application/command/SaveSearchHistoryCommand.java`

--- a/docs/ubiquitous-language/post-content.md
+++ b/docs/ubiquitous-language/post-content.md
@@ -21,6 +21,7 @@
 | 수집일 | `crawledAt` | TechFork가 해당 기술 게시글을 수집한 시각 |
 | 임베딩 완료일 | `embeddedAt` | 기술 게시글이 임베딩되어 Elasticsearch에 색인된 시각 |
 | 조회수 | `viewCount` | 사용자가 처음 읽은 경우 증가하는 popularity 지표 |
+| 조회수 증가 경로 | `PostCommandService.incrementViewCount()` | production에서 조회수를 증가시키는 canonical command 경로 |
 | 검색 문서 | `PostDocument` | Elasticsearch `posts` 인덱스에 저장되는 기술 게시글 projection |
 | 콘텐츠 청크 | `ContentChunk` | 긴 본문을 임베딩 검색용으로 분할한 단위 |
 | 출처명 | `Post.company`, `TechBlog.companyName` | 기술 게시글이 어느 기술 블로그/회사에서 왔는지 표시하기 위한 이름 |
@@ -31,6 +32,8 @@
 - 도메인/기획 문서에서는 `Post`를 **기술 게시글**로 부른다.
 - `PostDocument`, `ContentChunk`는 aggregate가 아니라 **검색/추천용 projection**이다.
 - `Post.company`는 Source 컨텍스트의 출처명을 복사한 조회용 스냅샷이다.
+- production 경로에서는 `Post.incrementViewCount()` 같은 엔티티 필드 증가를 사용하지 않고 `PostCommandService`/`PostRepository`의 SQL atomic update를 canonical write path로 둔다.
+- `PostCommandService.incrementViewCount()`는 DB 값을 원자적으로 증가시키지만, 이미 로드된 managed `Post`의 `viewCount`를 같은 트랜잭션 안에서 최신 상태로 동기화하지는 않는다.
 - `EDifficultyLevel`은 실제 사용처가 없어 제거되었다. 필요해지면 정책과 함께 재도입한다.
 
 ## 내부 glossary
@@ -43,6 +46,7 @@
 | 청크 projection | `ContentChunk` | 긴 본문을 분할한 임베딩 검색 단위 |
 | 임베딩 완료 시각 | `embeddedAt` | 검색/추천용 색인 준비 완료 시각 |
 | 인기 지표 | `viewCount` | 조회수 기반 popularity 지표 |
+| 조회수 증가 command | `PostCommandService.incrementViewCount` | 조회수 증가를 DB atomic update로 위임하는 application command |
 
 ## 혼동 금지
 
@@ -63,6 +67,8 @@
 
 - `src/main/java/com/techfork/domain/post/entity/Post.java`
 - `src/main/java/com/techfork/domain/post/entity/PostKeyword.java`
+- `src/main/java/com/techfork/domain/post/service/PostCommandService.java`
+- `src/main/java/com/techfork/domain/post/repository/PostRepository.java`
 - `src/main/java/com/techfork/domain/post/document/PostDocument.java`
 - `src/main/java/com/techfork/domain/post/document/ContentChunk.java`
 - `src/main/java/com/techfork/domain/post/batch/PostSummaryProcessor.java`

--- a/src/main/java/com/techfork/activity/readpost/application/command/ReadPostCommandService.java
+++ b/src/main/java/com/techfork/activity/readpost/application/command/ReadPostCommandService.java
@@ -4,6 +4,7 @@ import com.techfork.activity.readpost.domain.ReadPost;
 import com.techfork.activity.readpost.domain.ReadPostFirstReadPolicy;
 import com.techfork.activity.readpost.infrastructure.ReadPostRepository;
 import com.techfork.domain.post.entity.Post;
+import com.techfork.domain.post.service.PostCommandService;
 import com.techfork.domain.post.service.PostLookupService;
 import com.techfork.domain.useraccount.entity.User;
 import com.techfork.domain.useraccount.service.UserLookupService;
@@ -20,6 +21,7 @@ public class ReadPostCommandService {
 
     private final ReadPostRepository readPostRepository;
     private final PostLookupService postLookupService;
+    private final PostCommandService postCommandService;
     private final UserLookupService userLookupService;
     private final ReadPostFirstReadPolicy readPostFirstReadPolicy;
 
@@ -29,7 +31,7 @@ public class ReadPostCommandService {
 
         boolean isFirstRead = readPostFirstReadPolicy.isFirstRead(user, post);
         if (isFirstRead) {
-            post.incrementViewCount();
+            postCommandService.incrementViewCount(post.getId());
         }
 
         ReadPost readPost = ReadPost.create(

--- a/src/main/java/com/techfork/activity/readpost/application/command/ReadPostCommandService.java
+++ b/src/main/java/com/techfork/activity/readpost/application/command/ReadPostCommandService.java
@@ -30,8 +30,9 @@ public class ReadPostCommandService {
         Post post = postLookupService.getPostOrThrow(command.postId());
 
         boolean isFirstRead = readPostFirstReadPolicy.isFirstRead(user, post);
+        boolean viewCountIncremented = false;
         if (isFirstRead) {
-            postCommandService.incrementViewCount(post.getId());
+            viewCountIncremented = postCommandService.incrementViewCount(post.getId());
         }
 
         ReadPost readPost = ReadPost.create(
@@ -42,7 +43,7 @@ public class ReadPostCommandService {
         );
 
         readPostRepository.save(readPost);
-        log.info("Saved read post for user {} and post {} (viewCount incremented: {})",
-                command.userId(), command.postId(), isFirstRead);
+        log.info("Saved read post for user {} and post {} (firstRead: {}, viewCount incremented: {})",
+                command.userId(), command.postId(), isFirstRead, viewCountIncremented);
     }
 }

--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -122,8 +122,4 @@ public class Post extends BaseEntity {
     public void clearKeywords() {
         this.keywords.clear();
     }
-
-    public void incrementViewCount() {
-        this.viewCount++;
-    }
 }

--- a/src/main/java/com/techfork/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/techfork/domain/post/repository/PostRepository.java
@@ -34,6 +34,10 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("UPDATE Post p SET p.embeddedAt = :embeddedAt WHERE p.id IN :ids")
     void bulkUpdateEmbeddedAt(@Param("ids") List<Long> ids, @Param("embeddedAt") LocalDateTime embeddedAt);
 
+    @Modifying(flushAutomatically = true)
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
+    int incrementViewCount(@Param("id") Long id);
+
     @Query("SELECT DISTINCT p.company FROM Post p ORDER BY p.company")
     List<String> findDistinctCompanies();
 

--- a/src/main/java/com/techfork/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostCommandService.java
@@ -1,0 +1,18 @@
+package com.techfork.domain.post.service;
+
+import com.techfork.domain.post.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PostCommandService {
+
+    private final PostRepository postRepository;
+
+    public void incrementViewCount(Long postId) {
+        postRepository.incrementViewCount(postId);
+    }
+}

--- a/src/main/java/com/techfork/domain/post/service/PostCommandService.java
+++ b/src/main/java/com/techfork/domain/post/service/PostCommandService.java
@@ -2,9 +2,11 @@ package com.techfork.domain.post.service;
 
 import com.techfork.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -12,7 +14,24 @@ public class PostCommandService {
 
     private final PostRepository postRepository;
 
-    public void incrementViewCount(Long postId) {
-        postRepository.incrementViewCount(postId);
+    /**
+     * DB atomic update로 조회수를 증가시킨다.
+     *
+     * <p>이 메서드는 현재 영속성 컨텍스트에 이미 로드된 {@code Post} 엔티티의
+     * {@code viewCount} 값을 동기화하지 않는다. 호출자는 같은 트랜잭션 안에서
+     * 기존 managed {@code Post}의 {@code viewCount}가 최신 상태라고 가정하면 안 된다.</p>
+     *
+     * @return 정확히 1건이 증가되면 {@code true}, 아니면 {@code false}
+     */
+    public boolean incrementViewCount(Long postId) {
+        int updatedCount = postRepository.incrementViewCount(postId);
+
+        if (updatedCount != 1) {
+            log.warn("Atomic viewCount increment affected {} rows for postId={}", updatedCount, postId);
+            return false;
+        }
+
+        log.debug("Atomic viewCount increment applied for postId={}", postId);
+        return true;
     }
 }

--- a/src/test/java/com/techfork/activity/readpost/application/command/ReadPostCommandServiceTest.java
+++ b/src/test/java/com/techfork/activity/readpost/application/command/ReadPostCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.techfork.activity.readpost.application.command;
 import com.techfork.activity.readpost.domain.ReadPost;
 import com.techfork.activity.readpost.domain.ReadPostFirstReadPolicy;
 import com.techfork.activity.readpost.infrastructure.ReadPostRepository;
+import com.techfork.domain.post.service.PostCommandService;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.post.exception.PostErrorCode;
 import com.techfork.domain.post.service.PostLookupService;
@@ -20,6 +21,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,6 +40,9 @@ class ReadPostCommandServiceTest {
 
     @Mock
     private PostLookupService postLookupService;
+
+    @Mock
+    private PostCommandService postCommandService;
 
     @Mock
     private UserLookupService userLookupService;
@@ -80,6 +85,7 @@ class ReadPostCommandServiceTest {
                         .crawledAt(LocalDateTime.now())
                         .techBlog(mockTechBlog)
                         .build();
+                ReflectionTestUtils.setField(mockPost, "id", postId);
                 SaveReadPostCommand command = new SaveReadPostCommand(userId, postId, readAt, readDurationSeconds);
 
                 given(userLookupService.getUserOrThrow(userId)).willReturn(mockUser);
@@ -93,10 +99,11 @@ class ReadPostCommandServiceTest {
 
                 ArgumentCaptor<ReadPost> readPostCaptor = ArgumentCaptor.forClass(ReadPost.class);
                 verify(readPostFirstReadPolicy, times(1)).isFirstRead(mockUser, mockPost);
+                verify(postCommandService, times(1)).incrementViewCount(postId);
                 verify(readPostRepository, times(1)).save(readPostCaptor.capture());
                 ReadPost savedReadPost = readPostCaptor.getValue();
 
-                assertThat(mockPost.getViewCount()).isEqualTo(beforeViewCount + 1);
+                assertThat(mockPost.getViewCount()).isEqualTo(beforeViewCount);
                 assertThat(savedReadPost.getUser()).isSameAs(mockUser);
                 assertThat(savedReadPost.getPost()).isSameAs(mockPost);
                 assertThat(savedReadPost.getReadAt()).isEqualTo(readAt);
@@ -140,6 +147,7 @@ class ReadPostCommandServiceTest {
 
                 ArgumentCaptor<ReadPost> readPostCaptor = ArgumentCaptor.forClass(ReadPost.class);
                 verify(readPostFirstReadPolicy, times(1)).isFirstRead(mockUser, mockPost);
+                verify(postCommandService, never()).incrementViewCount(any());
                 verify(readPostRepository, times(1)).save(readPostCaptor.capture());
 
                 assertThat(mockPost.getViewCount()).isEqualTo(beforeViewCount);
@@ -165,6 +173,7 @@ class ReadPostCommandServiceTest {
                         .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
 
                 verify(postLookupService, never()).getPostOrThrow(any());
+                verify(postCommandService, never()).incrementViewCount(any());
                 verify(readPostFirstReadPolicy, never()).isFirstRead(any(), any());
                 verify(readPostRepository, never()).save(any());
             }
@@ -185,6 +194,7 @@ class ReadPostCommandServiceTest {
                         .isInstanceOf(GeneralException.class)
                         .hasFieldOrPropertyWithValue("code", PostErrorCode.POST_NOT_FOUND);
 
+                verify(postCommandService, never()).incrementViewCount(any());
                 verify(readPostFirstReadPolicy, never()).isFirstRead(any(), any());
                 verify(readPostRepository, never()).save(any());
             }

--- a/src/test/java/com/techfork/activity/readpost/application/command/ReadPostCommandServiceTest.java
+++ b/src/test/java/com/techfork/activity/readpost/application/command/ReadPostCommandServiceTest.java
@@ -91,6 +91,7 @@ class ReadPostCommandServiceTest {
                 given(userLookupService.getUserOrThrow(userId)).willReturn(mockUser);
                 given(postLookupService.getPostOrThrow(postId)).willReturn(mockPost);
                 given(readPostFirstReadPolicy.isFirstRead(mockUser, mockPost)).willReturn(true);
+                given(postCommandService.incrementViewCount(postId)).willReturn(true);
                 given(readPostRepository.save(any(ReadPost.class))).willReturn(mock(ReadPost.class));
 
                 Long beforeViewCount = mockPost.getViewCount();

--- a/src/test/java/com/techfork/domain/post/controller/PostControllerV2IntegrationTest.java
+++ b/src/test/java/com/techfork/domain/post/controller/PostControllerV2IntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
@@ -382,12 +383,8 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
     @DisplayName("GET /api/v2/posts/recent - POPULAR 정렬로 인기 게시글 조회")
     void getRecentPosts_Popular_Success() throws Exception {
         // Given: 조회수 증가
-        for (int i = 0; i < 100; i++) {
-            todayPost.incrementViewCount();
-        }
-        for (int i = 0; i < 50; i++) {
-            oldPost.incrementViewCount();
-        }
+        setViewCount(todayPost, 100L);
+        setViewCount(oldPost, 50L);
         postRepository.saveAll(List.of(todayPost, oldPost));
 
         // When & Then: 조회수 높은 순으로 정렬
@@ -467,9 +464,7 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                     .build();
 
             // 조회수 설정
-            for (int j = 0; j < (6 - i) * 100; j++) {
-                post.incrementViewCount();
-            }
+            setViewCount(post, (long) ((6 - i) * 100));
             postRepository.save(post);
         }
 
@@ -511,6 +506,10 @@ class PostControllerV2IntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.posts").isArray())
                 .andExpect(jsonPath("$.data.posts.length()").value(0))
                 .andExpect(jsonPath("$.data.hasNext").value(false));
+    }
+
+    private void setViewCount(Post post, Long viewCount) {
+        ReflectionTestUtils.setField(post, "viewCount", viewCount);
     }
 
     @Test

--- a/src/test/java/com/techfork/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/post/repository/PostRepositoryTest.java
@@ -6,6 +6,7 @@ import com.techfork.domain.post.dto.PostInfoDto;
 import com.techfork.domain.post.entity.Post;
 import com.techfork.domain.source.entity.TechBlog;
 import com.techfork.domain.source.repository.TechBlogRepository;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,6 +39,9 @@ class PostRepositoryTest {
     @Autowired
     private TechBlogRepository techBlogRepository;
 
+    @Autowired
+    private EntityManager entityManager;
+
     private TechBlog techBlog1;
     private TechBlog techBlog2;
     private TechBlog techBlog3;
@@ -65,6 +69,34 @@ class PostRepositoryTest {
                 .rssUrl("https://aws.com/rss")
                 .build();
         techBlogRepository.save(techBlog3);
+    }
+
+    @Test
+    @DisplayName("incrementViewCount - 조회수를 1 증가시킨다")
+    void incrementViewCount_IncreasesViewCount() {
+        Post post = postRepository.save(createPost("조회수 증가 대상", techBlog1, LocalDateTime.now(), 0L));
+
+        int updatedCount = postRepository.incrementViewCount(post.getId());
+
+        entityManager.clear();
+
+        Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+        assertThat(updatedCount).isEqualTo(1);
+        assertThat(updatedPost.getViewCount()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("incrementViewCount - 여러 번 호출하면 누적 증가한다")
+    void incrementViewCount_MultipleCalls_AccumulatesViewCount() {
+        Post post = postRepository.save(createPost("누적 조회수 대상", techBlog1, LocalDateTime.now(), 5L));
+
+        postRepository.incrementViewCount(post.getId());
+        postRepository.incrementViewCount(post.getId());
+
+        entityManager.clear();
+
+        Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+        assertThat(updatedPost.getViewCount()).isEqualTo(7L);
     }
 
     @Test

--- a/src/test/java/com/techfork/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/post/repository/PostRepositoryTest.java
@@ -9,6 +9,7 @@ import com.techfork.domain.source.repository.TechBlogRepository;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -48,7 +49,6 @@ class PostRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        // Given: 테스트용 TechBlog 생성
         techBlog1 = TechBlog.builder()
                 .companyName("카카오")
                 .blogUrl("https://kakao.com/blog")
@@ -71,497 +71,468 @@ class PostRepositoryTest {
         techBlogRepository.save(techBlog3);
     }
 
-    @Test
-    @DisplayName("incrementViewCount - 조회수를 1 증가시킨다")
-    void incrementViewCount_IncreasesViewCount() {
-        Post post = postRepository.save(createPost("조회수 증가 대상", techBlog1, LocalDateTime.now(), 0L));
+    @Nested
+    @DisplayName("조회수 증가")
+    class IncrementViewCount {
 
-        int updatedCount = postRepository.incrementViewCount(post.getId());
+        @Test
+        @DisplayName("조회수를 1 증가시킨다")
+        void incrementViewCount_IncreasesViewCount() {
+            Post post = postRepository.save(createPost("조회수 증가 대상", techBlog1, LocalDateTime.now(), 0L));
 
-        entityManager.clear();
+            int updatedCount = postRepository.incrementViewCount(post.getId());
 
-        Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
-        assertThat(updatedCount).isEqualTo(1);
-        assertThat(updatedPost.getViewCount()).isEqualTo(1L);
-    }
+            entityManager.clear();
 
-    @Test
-    @DisplayName("incrementViewCount - 여러 번 호출하면 누적 증가한다")
-    void incrementViewCount_MultipleCalls_AccumulatesViewCount() {
-        Post post = postRepository.save(createPost("누적 조회수 대상", techBlog1, LocalDateTime.now(), 5L));
-
-        postRepository.incrementViewCount(post.getId());
-        postRepository.incrementViewCount(post.getId());
-
-        entityManager.clear();
-
-        Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
-        assertThat(updatedPost.getViewCount()).isEqualTo(7L);
-    }
-
-    @Test
-    @DisplayName("findPopularPostsWithCursor - lastPostId가 null이면 첫 페이지 조회 (조회수 높은 순)")
-    void findPopularPostsWithCursor_FirstPage_OrderByViewCountDesc() {
-        // Given: 조회수가 다른 게시글 3개
-        Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(3), 100L);
-        Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(2), 500L);
-        Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(1), 300L);
-        postRepository.saveAll(List.of(post1, post2, post3));
-
-        // When: lastPostId = null, size = 10
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<PostInfoDto> result = postRepository.findPopularPostsWithCursor(null, pageRequest);
-
-        // Then: 조회수 높은 순으로 정렬 (500 > 300 > 100)
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).viewCount()).isEqualTo(500L);
-        assertThat(result.get(1).viewCount()).isEqualTo(300L);
-        assertThat(result.get(2).viewCount()).isEqualTo(100L);
-    }
-
-    @Test
-    @DisplayName("findPopularPostsWithCursor - lastPostId 지정 시 해당 ID 이후 게시글만 조회")
-    void findPopularPostsWithCursor_NextPage_FilterByLastPostId() {
-        // Given: 게시글 5개 생성
-        Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(5), 500L);
-        Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(4), 400L);
-        Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(3), 300L);
-        Post post4 = createPost("게시글4", techBlog1, LocalDateTime.now().minusDays(2), 200L);
-        Post post5 = createPost("게시글5", techBlog1, LocalDateTime.now().minusDays(1), 100L);
-        postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
-
-        // When: lastPostId = post3.id (커서 기준)
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<PostInfoDto> result = postRepository.findPopularPostsWithCursor(post3.getId(), pageRequest);
-
-        // Then: post3.id보다 작은 ID만 반환 (post4, post5는 제외)
-        assertThat(result).hasSize(2);
-        assertThat(result).allMatch(dto -> dto.id() < post3.getId());
-    }
-
-    @Test
-    @DisplayName("findRecentPostsWithCursor - 최신 발행일 순으로 정렬")
-    void findRecentPostsWithCursor_OrderByPublishedAtDesc() {
-        // Given: 발행일이 다른 게시글 3개
-        LocalDateTime now = LocalDateTime.now();
-        Post post1 = createPost("게시글1", techBlog1, now.minusDays(3), 100L);
-        Post post2 = createPost("게시글2", techBlog1, now.minusDays(1), 200L);
-        Post post3 = createPost("게시글3", techBlog1, now.minusDays(2), 300L);
-        postRepository.saveAll(List.of(post1, post2, post3));
-
-        // When: 최신순 조회
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<PostInfoDto> result = postRepository.findRecentPostsWithCursor(null, pageRequest);
-
-        // Then: 발행일 최신순 (post2 > post3 > post1)
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).publishedAt()).isAfter(result.get(1).publishedAt());
-        assertThat(result.get(1).publishedAt()).isAfter(result.get(2).publishedAt());
-    }
-
-    @Test
-    @DisplayName("findByCompanyWithCursor - company가 null이면 모든 게시글 조회")
-    void findByCompanyWithCursor_NullCompany_ReturnsAll() {
-        // Given: 다른 회사의 게시글 2개
-        Post kakaoPost = createPost("카카오 게시글", techBlog1, LocalDateTime.now(), 100L);
-        Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 200L);
-        postRepository.saveAll(List.of(kakaoPost, naverPost));
-
-        // When: company = null
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<PostInfoDto> result = postRepository.findByCompanyWithCursor(null, null, pageRequest);
-
-        // Then: 모든 게시글 반환
-        assertThat(result).hasSize(2);
-        assertThat(result).extracting(PostInfoDto::company)
-                .containsExactlyInAnyOrder("카카오", "네이버");
-    }
-
-    @Test
-    @DisplayName("findByCompanyWithCursor - company 지정 시 해당 회사 게시글만 조회")
-    void findByCompanyWithCursor_SpecificCompany_ReturnsFiltered() {
-        // Given: 다른 회사의 게시글 3개
-        Post kakaoPost1 = createPost("카카오 게시글1", techBlog1, LocalDateTime.now().minusDays(2), 100L);
-        Post kakaoPost2 = createPost("카카오 게시글2", techBlog1, LocalDateTime.now().minusDays(1), 200L);
-        Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 300L);
-        postRepository.saveAll(List.of(kakaoPost1, kakaoPost2, naverPost));
-
-        // When: company = "카카오"
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<PostInfoDto> result = postRepository.findByCompanyWithCursor("카카오", null, pageRequest);
-
-        // Then: 카카오 게시글만 반환
-        assertThat(result).hasSize(2);
-        assertThat(result).allMatch(dto -> dto.company().equals("카카오"));
-    }
-
-    @Test
-    @DisplayName("companies가 null이면 모든 회사의 게시글을 조회")
-    void findByCompanyNames_NullCompanies_ReturnsAll() {
-        // Given
-        Post kakaoPost = createPost("카카오 게시글", techBlog1, LocalDateTime.now().minusDays(2), 100L);
-        Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 300L);
-        Post awsPost = createPost("AWS 게시글", techBlog3, LocalDateTime.now(), 500L);
-        postRepository.saveAll(List.of(kakaoPost, naverPost, awsPost));
-
-        // When
-        List<PostInfoDto> result = postRepository.findByCompanyNamesWithCursor(null, null, null, PageRequest.of(0, 10));
-
-        // Then
-        assertThat(result).hasSize(3);
-        assertThat(result).extracting(PostInfoDto::company)
-                .containsExactlyInAnyOrder("카카오", "네이버", "AWS");
-    }
-
-    @Test
-    @DisplayName("findByCompanyNamesWithCursor - companies 지정 시 해당 회사들 게시글만 조회")
-    void findByCompanyNamesWithCursor_SpecificCompanies_ReturnsFiltered() {
-        // Given: 다른 회사의 게시글 4개
-        Post kakaoPost1 = createPost("카카오 게시글1", techBlog1, LocalDateTime.now().minusDays(2), 100L);
-        Post kakaoPost2 = createPost("카카오 게시글2", techBlog1, LocalDateTime.now().minusDays(1), 200L);
-        Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 300L);
-        Post awsPost = createPost("AWS 게시글", techBlog3, LocalDateTime.now(), 500L);
-        postRepository.saveAll(List.of(kakaoPost1, kakaoPost2, naverPost, awsPost));
-
-        // When: companies = {"카카오", "네이버"}
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<String> companyNames = List.of("카카오", "네이버");
-        List<PostInfoDto> result = postRepository.findByCompanyNamesWithCursor(companyNames, null, null,pageRequest);
-
-        // Then: 카카오와 네이버 게시글만 반환
-        assertThat(result).hasSize(3);
-        assertThat(result).extracting(PostInfoDto::company)
-                .containsOnly("카카오", "네이버")
-                .doesNotContain("AWS");
-    }
-
-    @Test
-    @DisplayName("발행일 내림차순으로 정렬되는지 확인")
-    void findByCompanyNames_SortPublishedAtCheck() {
-        // Given: 발행시각 다른 게시글 생성
-        Post recentPost = createPost("최신 글", techBlog1, LocalDateTime.now(), 100L);
-        Post oldPost = createPost("옛날 글", techBlog1, LocalDateTime.now().minusDays(5), 200L);
-        postRepository.saveAll(List.of(recentPost, oldPost));
-
-        // When
-        List<PostInfoDto> result = postRepository.findByCompanyNamesWithCursor(null, null, null, PageRequest.of(0, 10));
-
-        // Then
-        assertThat(result)
-                .extracting(PostInfoDto::title)
-                .containsExactly("최신 글", "옛날 글");
-    }
-
-    @Test
-    @DisplayName("발행일이 같을 경우 ID 내림차순으로 정렬되는지 확인")
-    void findByCompanyNames_SortPublihedAtEqualsCheck() {
-        // Given: 발행시각이 같은 게시글 생성
-        LocalDateTime now = LocalDateTime.now();
-        Post kakaoPost = createPost("카카오 게시글", techBlog1, now, 100L);
-        Post naverPost = createPost("네이버 게시글", techBlog2, now, 300L);
-        Post awsPost = createPost("AWS 게시글", techBlog3, now, 500L);
-        postRepository.saveAll(List.of(kakaoPost, naverPost, awsPost));
-
-        // When
-        List<PostInfoDto> result = postRepository.findByCompanyNamesWithCursor(null, null, null, PageRequest.of(0, 10));
-
-        // Then: insert 쿼리의 역순
-        assertThat(result)
-                .extracting("id")
-                .containsExactly(awsPost.getId(), naverPost.getId(), kakaoPost.getId());
-    }
-
-    @Test
-    @DisplayName("커서 기반 페이징 - 1페이지 조회 후 커서 이용해 2페이지 조회")
-    void findByCompanyNames_CursorPaging() {
-        // Given
-        LocalDateTime now = LocalDateTime.now();
-        List<Post> posts = new ArrayList<>();
-        for (int i = 1; i <= 5; i++) {
-            posts.add(createPost("게시글" + i, techBlog1, now.plusHours(i), 10L));
-        }
-        postRepository.saveAll(posts);
-
-        PageRequest pageRequest = PageRequest.of(0, 2);
-
-        // When
-        List<PostInfoDto> page1 = postRepository.findByCompanyNamesWithCursor(
-                null, null, null, pageRequest
-        );
-
-        PostInfoDto lastPostOfPage1 = page1.get(1);
-
-        List<PostInfoDto> page2 = postRepository.findByCompanyNamesWithCursor(
-                null, lastPostOfPage1.publishedAt(), lastPostOfPage1.id(), pageRequest
-        );
-
-        // Then
-        assertThat(page1).extracting("title")
-                .containsExactly("게시글5", "게시글4");
-
-        assertThat(page2).extracting("title")
-                .containsExactly("게시글3", "게시글2");
-    }
-
-    @Test
-    @DisplayName("findByIdWithTechBlog - JOIN하여 게시글 상세 정보 조회 성공")
-    void findByIdWithTechBlog_Success_ReturnsPostDetailDto() {
-        // Given: 게시글 생성
-        Post post = createPost("테스트 게시글", techBlog1, LocalDateTime.now(), 100L);
-        post = postRepository.save(post);
-
-        // When: ID로 조회
-        Optional<PostDetailDto> result = postRepository.findByIdWithTechBlog(post.getId());
-
-        // Then: PostDetailDto 프로젝션 성공
-        assertThat(result).isPresent();
-        PostDetailDto dto = result.get();
-        assertThat(dto.id()).isEqualTo(post.getId());
-        assertThat(dto.title()).isEqualTo("테스트 게시글");
-        assertThat(dto.company()).isEqualTo("카카오");
-        assertThat(dto.viewCount()).isEqualTo(100L);
-        assertThat(dto.keywords()).isNull(); // 키워드는 별도 조회
-    }
-
-    @Test
-    @DisplayName("findByIdWithTechBlog - 존재하지 않는 ID 조회 시 Empty 반환")
-    void findByIdWithTechBlog_NotFound_ReturnsEmpty() {
-        // When: 존재하지 않는 ID 조회
-        Optional<PostDetailDto> result = postRepository.findByIdWithTechBlog(99999L);
-
-        // Then: Empty 반환
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("findDistinctCompanies - 중복 없이 회사 목록 조회")
-    void findDistinctCompanies_ReturnsUniqueCompanies() {
-        // Given: 같은 회사의 게시글 여러 개
-        Post kakaoPost1 = createPost("카카오 게시글1", techBlog1, LocalDateTime.now(), 100L);
-        Post kakaoPost2 = createPost("카카오 게시글2", techBlog1, LocalDateTime.now(), 200L);
-        Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 300L);
-        postRepository.saveAll(List.of(kakaoPost1, kakaoPost2, naverPost));
-
-        // When: 회사 목록 조회
-        List<String> result = postRepository.findDistinctCompanies();
-
-        // Then: 중복 없이 2개 회사 반환
-        assertThat(result).hasSize(2);
-        assertThat(result).containsExactlyInAnyOrder("카카오", "네이버");
-    }
-
-    @Test
-    @DisplayName("findCompaniesWithDetails - 회사별 상세 정보 조회 성공")
-    void findCompaniesWithDetails_Success() {
-        // Given: 여러 회사의 게시글 생성
-        Post kakaoPost1 = createPost("카카오 게시글1", techBlog1, LocalDate.now().atStartOfDay(), 100L);
-        Post kakaoPost2 = createPost("카카오 게시글2", techBlog1, LocalDate.now().minusDays(1).atStartOfDay(), 200L);
-        Post naverPost = createPost("네이버 게시글", techBlog2, LocalDate.now().minusDays(2).atStartOfDay(), 300L);
-        postRepository.saveAll(List.of(kakaoPost1, kakaoPost2, naverPost));
-
-        // When: 회사 상세 정보 조회
-        List<CompanyDto> result = postRepository.findCompaniesWithDetails();
-
-        // Then: 회사별로 집계된 정보 반환
-        assertThat(result).hasSize(2);
-
-        // 최신 발행일 기준으로 정렬되어야 함 (카카오가 더 최신)
-        CompanyDto firstCompany = result.get(0);
-        assertThat(firstCompany.company()).isEqualTo("카카오");
-        assertThat(firstCompany.hasNewPost()).isTrue(); // 오늘 발행된 게시글 존재
-        assertThat(firstCompany.logoUrl()).isNotNull();
-
-        CompanyDto secondCompany = result.get(1);
-        assertThat(secondCompany.company()).isEqualTo("네이버");
-        assertThat(secondCompany.hasNewPost()).isFalse(); // 오늘 발행된 게시글 없음
-    }
-
-    @Test
-    @DisplayName("findCompaniesWithDetails - 오늘 발행된 게시글 여부 정확히 판단")
-    void findCompaniesWithDetails_HasNewPost_AccurateDetection() {
-        // Given: 오늘과 어제 게시글
-        Post todayPost = createPost("오늘 게시글", techBlog1, LocalDate.now().atTime(14, 30), 100L);
-        Post yesterdayPost = createPost("어제 게시글", techBlog2, LocalDate.now().minusDays(1).atStartOfDay(), 200L);
-        postRepository.saveAll(List.of(todayPost, yesterdayPost));
-
-        // When: 회사 상세 정보 조회
-        List<CompanyDto> result = postRepository.findCompaniesWithDetails();
-
-        // Then: 오늘 게시글 여부 정확히 판단
-        CompanyDto kakaoCompany = result.stream()
-                .filter(c -> c.company().equals("카카오"))
-                .findFirst()
-                .orElseThrow();
-        assertThat(kakaoCompany.hasNewPost()).isTrue();
-
-        CompanyDto naverCompany = result.stream()
-                .filter(c -> c.company().equals("네이버"))
-                .findFirst()
-                .orElseThrow();
-        assertThat(naverCompany.hasNewPost()).isFalse();
-    }
-
-    @Test
-    @DisplayName("findCompaniesWithDetails - 최신 발행일 기준으로 정렬")
-    void findCompaniesWithDetails_OrderByLatestPublishedAtDesc() {
-        // Given: 발행일이 다른 게시글들
-        Post oldPost = createPost("오래된 게시글", techBlog1, LocalDate.now().minusDays(10).atStartOfDay(), 100L);
-        Post recentPost = createPost("최근 게시글", techBlog2, LocalDate.now().minusDays(1).atStartOfDay(), 200L);
-        postRepository.saveAll(List.of(oldPost, recentPost));
-
-        // When: 회사 상세 정보 조회
-        List<CompanyDto> result = postRepository.findCompaniesWithDetails();
-
-        // Then: 최신 발행일 기준 정렬 (네이버가 먼저)
-        assertThat(result).hasSize(2);
-        assertThat(result.get(0).company()).isEqualTo("네이버");
-        assertThat(result.get(1).company()).isEqualTo("카카오");
-    }
-
-    @Test
-    @DisplayName("findCompaniesWithDetails - 게시글이 없으면 빈 리스트 반환")
-    void findCompaniesWithDetails_NoPosts_ReturnsEmptyList() {
-        // Given: 게시글 없음
-
-        // When: 회사 상세 정보 조회
-        List<CompanyDto> result = postRepository.findCompaniesWithDetails();
-
-        // Then: 빈 리스트 반환
-        assertThat(result).isEmpty();
-    }
-
-    @Test
-    @DisplayName("커서 페이징 - size+1 조회하여 hasNext 판단 가능")
-    void cursorPaging_SizePlusOne_CanDetermineHasNext() {
-        // Given: 게시글 5개
-        for (int i = 1; i <= 5; i++) {
-            Post post = createPost("게시글" + i, techBlog1, LocalDateTime.now().minusDays(i), (long) (i * 100));
-            postRepository.save(post);
+            Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+            assertThat(updatedCount).isEqualTo(1);
+            assertThat(updatedPost.getViewCount()).isEqualTo(1L);
         }
 
-        // When: size = 3으로 조회 (실제로는 4개 조회)
-        PageRequest pageRequest = PageRequest.of(0, 4);
-        List<PostInfoDto> result = postRepository.findRecentPostsWithCursor(null, pageRequest);
+        @Test
+        @DisplayName("여러 번 호출하면 누적 증가한다")
+        void incrementViewCount_MultipleCalls_AccumulatesViewCount() {
+            Post post = postRepository.save(createPost("누적 조회수 대상", techBlog1, LocalDateTime.now(), 5L));
 
-        // Then: 4개 조회되면 hasNext = true
-        assertThat(result).hasSize(4);
-        boolean hasNext = result.size() > 3;
-        assertThat(hasNext).isTrue();
+            postRepository.incrementViewCount(post.getId());
+            postRepository.incrementViewCount(post.getId());
+
+            entityManager.clear();
+
+            Post updatedPost = postRepository.findById(post.getId()).orElseThrow();
+            assertThat(updatedPost.getViewCount()).isEqualTo(7L);
+        }
     }
 
-    @Test
-    @DisplayName("findRecentPostsWithCursorV2 - publishedAt과 id로 커서 페이징")
-    void findRecentPostsWithCursorV2_CursorPagingWithPublishedAtAndId() {
-        // Given: 같은 publishedAt을 가진 게시글 3개
-        LocalDateTime now = LocalDateTime.now();
-        Post post1 = createPost("게시글1", techBlog1, now, 100L);
-        Post post2 = createPost("게시글2", techBlog1, now, 200L);
-        Post post3 = createPost("게시글3", techBlog1, now, 300L);
-        postRepository.saveAll(List.of(post1, post2, post3));
+    @Nested
+    @DisplayName("인기 게시글 조회 V1")
+    class FindPopularPostsWithCursor {
 
-        // When: 첫 페이지 조회
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<PostInfoDto> page1 = postRepository.findRecentPostsWithCursorV2(null, null, pageRequest);
+        @Test
+        @DisplayName("lastPostId가 null이면 첫 페이지를 조회한다")
+        void findPopularPostsWithCursor_FirstPage_OrderByViewCountDesc() {
+            Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(3), 100L);
+            Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(2), 500L);
+            Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(1), 300L);
+            postRepository.saveAll(List.of(post1, post2, post3));
 
-        // Then: publishedAt 같으면 id 내림차순으로 정렬
-        assertThat(page1).hasSize(3);
-        assertThat(page1.get(0).id()).isGreaterThan(page1.get(1).id());
-        assertThat(page1.get(1).id()).isGreaterThan(page1.get(2).id());
+            List<PostInfoDto> result = postRepository.findPopularPostsWithCursor(null, PageRequest.of(0, 10));
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).viewCount()).isEqualTo(500L);
+            assertThat(result.get(1).viewCount()).isEqualTo(300L);
+            assertThat(result.get(2).viewCount()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("lastPostId 지정 시 해당 ID 이후 게시글만 조회한다")
+        void findPopularPostsWithCursor_NextPage_FilterByLastPostId() {
+            Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(5), 500L);
+            Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(4), 400L);
+            Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(3), 300L);
+            Post post4 = createPost("게시글4", techBlog1, LocalDateTime.now().minusDays(2), 200L);
+            Post post5 = createPost("게시글5", techBlog1, LocalDateTime.now().minusDays(1), 100L);
+            postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+
+            List<PostInfoDto> result = postRepository.findPopularPostsWithCursor(post3.getId(), PageRequest.of(0, 10));
+
+            assertThat(result).hasSize(2);
+            assertThat(result).allMatch(dto -> dto.id() < post3.getId());
+        }
     }
 
-    @Test
-    @DisplayName("findRecentPostsWithCursorV2 - 커서 기반 다음 페이지 조회")
-    void findRecentPostsWithCursorV2_NextPageWithCursor() {
-        // Given: 발행일이 다른 게시글 5개
-        LocalDateTime now = LocalDateTime.now();
-        Post post1 = createPost("게시글1", techBlog1, now.minusDays(1), 100L);
-        Post post2 = createPost("게시글2", techBlog1, now.minusDays(2), 200L);
-        Post post3 = createPost("게시글3", techBlog1, now.minusDays(3), 300L);
-        Post post4 = createPost("게시글4", techBlog1, now.minusDays(4), 400L);
-        Post post5 = createPost("게시글5", techBlog1, now.minusDays(5), 500L);
-        postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+    @Nested
+    @DisplayName("인기 게시글 조회 V2")
+    class FindPopularPostsWithCursorV2 {
 
-        // When: 첫 페이지 조회 후 두 번째 페이지 조회
-        PageRequest pageRequest = PageRequest.of(0, 2);
-        List<PostInfoDto> page1 = postRepository.findRecentPostsWithCursorV2(null, null, pageRequest);
+        @Test
+        @DisplayName("viewCount와 id로 커서 페이징한다")
+        void findPopularPostsWithCursorV2_CursorPagingWithViewCountAndId() {
+            Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(1), 500L);
+            Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(2), 300L);
+            Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(3), 100L);
+            postRepository.saveAll(List.of(post1, post2, post3));
 
-        PostInfoDto lastPost = page1.get(1);
-        List<PostInfoDto> page2 = postRepository.findRecentPostsWithCursorV2(
-                lastPost.publishedAt(), lastPost.id(), pageRequest
-        );
+            List<PostInfoDto> result = postRepository.findPopularPostsWithCursorV2(null, null, PageRequest.of(0, 10));
 
-        // Then: 커서 이후 게시글만 반환
-        assertThat(page1).hasSize(2);
-        assertThat(page2).hasSize(2);
-        assertThat(page2.get(0).publishedAt()).isBefore(lastPost.publishedAt());
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).viewCount()).isEqualTo(500L);
+            assertThat(result.get(1).viewCount()).isEqualTo(300L);
+            assertThat(result.get(2).viewCount()).isEqualTo(100L);
+        }
+
+        @Test
+        @DisplayName("같은 viewCount일 때 id로 정렬한다")
+        void findPopularPostsWithCursorV2_SameViewCount_OrderById() {
+            Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(1), 500L);
+            Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(2), 500L);
+            Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(3), 500L);
+            postRepository.saveAll(List.of(post1, post2, post3));
+
+            List<PostInfoDto> result = postRepository.findPopularPostsWithCursorV2(null, null, PageRequest.of(0, 10));
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).id()).isGreaterThan(result.get(1).id());
+            assertThat(result.get(1).id()).isGreaterThan(result.get(2).id());
+        }
+
+        @Test
+        @DisplayName("커서 기반으로 다음 페이지를 조회한다")
+        void findPopularPostsWithCursorV2_NextPageWithCursor() {
+            Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(1), 500L);
+            Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(2), 400L);
+            Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(3), 300L);
+            Post post4 = createPost("게시글4", techBlog1, LocalDateTime.now().minusDays(4), 200L);
+            Post post5 = createPost("게시글5", techBlog1, LocalDateTime.now().minusDays(5), 100L);
+            postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+
+            PageRequest pageRequest = PageRequest.of(0, 2);
+            List<PostInfoDto> page1 = postRepository.findPopularPostsWithCursorV2(null, null, pageRequest);
+            PostInfoDto lastPost = page1.get(1);
+            List<PostInfoDto> page2 = postRepository.findPopularPostsWithCursorV2(
+                    lastPost.viewCount().intValue(),
+                    lastPost.id(),
+                    pageRequest
+            );
+
+            assertThat(page1).hasSize(2);
+            assertThat(page2).hasSize(2);
+            assertThat(page2.get(0).viewCount()).isLessThanOrEqualTo(lastPost.viewCount());
+        }
     }
 
-    @Test
-    @DisplayName("findPopularPostsWithCursorV2 - viewCount와 id로 커서 페이징")
-    void findPopularPostsWithCursorV2_CursorPagingWithViewCountAndId() {
-        // Given: 조회수가 다른 게시글 3개
-        Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(1), 500L);
-        Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(2), 300L);
-        Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(3), 100L);
-        postRepository.saveAll(List.of(post1, post2, post3));
+    @Nested
+    @DisplayName("최신 게시글 조회 V1")
+    class FindRecentPostsWithCursor {
 
-        // When: 첫 페이지 조회
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<PostInfoDto> result = postRepository.findPopularPostsWithCursorV2(null, null, pageRequest);
+        @Test
+        @DisplayName("최신 발행일 순으로 정렬한다")
+        void findRecentPostsWithCursor_OrderByPublishedAtDesc() {
+            LocalDateTime now = LocalDateTime.now();
+            Post post1 = createPost("게시글1", techBlog1, now.minusDays(3), 100L);
+            Post post2 = createPost("게시글2", techBlog1, now.minusDays(1), 200L);
+            Post post3 = createPost("게시글3", techBlog1, now.minusDays(2), 300L);
+            postRepository.saveAll(List.of(post1, post2, post3));
 
-        // Then: viewCount 내림차순으로 정렬 (500 > 300 > 100)
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).viewCount()).isEqualTo(500L);
-        assertThat(result.get(1).viewCount()).isEqualTo(300L);
-        assertThat(result.get(2).viewCount()).isEqualTo(100L);
+            List<PostInfoDto> result = postRepository.findRecentPostsWithCursor(null, PageRequest.of(0, 10));
+
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).publishedAt()).isAfter(result.get(1).publishedAt());
+            assertThat(result.get(1).publishedAt()).isAfter(result.get(2).publishedAt());
+        }
+
+        @Test
+        @DisplayName("size+1 조회로 hasNext 판단이 가능하다")
+        void cursorPaging_SizePlusOne_CanDetermineHasNext() {
+            for (int i = 1; i <= 5; i++) {
+                Post post = createPost("게시글" + i, techBlog1, LocalDateTime.now().minusDays(i), (long) (i * 100));
+                postRepository.save(post);
+            }
+
+            List<PostInfoDto> result = postRepository.findRecentPostsWithCursor(null, PageRequest.of(0, 4));
+
+            assertThat(result).hasSize(4);
+            boolean hasNext = result.size() > 3;
+            assertThat(hasNext).isTrue();
+        }
     }
 
-    @Test
-    @DisplayName("findPopularPostsWithCursorV2 - 같은 viewCount일 때 id로 정렬")
-    void findPopularPostsWithCursorV2_SameViewCount_OrderById() {
-        // Given: 같은 조회수를 가진 게시글 3개
-        Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(1), 500L);
-        Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(2), 500L);
-        Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(3), 500L);
-        postRepository.saveAll(List.of(post1, post2, post3));
+    @Nested
+    @DisplayName("최신 게시글 조회 V2")
+    class FindRecentPostsWithCursorV2 {
 
-        // When: 조회
-        PageRequest pageRequest = PageRequest.of(0, 10);
-        List<PostInfoDto> result = postRepository.findPopularPostsWithCursorV2(null, null, pageRequest);
+        @Test
+        @DisplayName("publishedAt과 id로 커서 페이징한다")
+        void findRecentPostsWithCursorV2_CursorPagingWithPublishedAtAndId() {
+            LocalDateTime now = LocalDateTime.now();
+            Post post1 = createPost("게시글1", techBlog1, now, 100L);
+            Post post2 = createPost("게시글2", techBlog1, now, 200L);
+            Post post3 = createPost("게시글3", techBlog1, now, 300L);
+            postRepository.saveAll(List.of(post1, post2, post3));
 
-        // Then: viewCount 같으면 id 내림차순
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).id()).isGreaterThan(result.get(1).id());
-        assertThat(result.get(1).id()).isGreaterThan(result.get(2).id());
+            List<PostInfoDto> page1 = postRepository.findRecentPostsWithCursorV2(null, null, PageRequest.of(0, 10));
+
+            assertThat(page1).hasSize(3);
+            assertThat(page1.get(0).id()).isGreaterThan(page1.get(1).id());
+            assertThat(page1.get(1).id()).isGreaterThan(page1.get(2).id());
+        }
+
+        @Test
+        @DisplayName("커서 기반으로 다음 페이지를 조회한다")
+        void findRecentPostsWithCursorV2_NextPageWithCursor() {
+            LocalDateTime now = LocalDateTime.now();
+            Post post1 = createPost("게시글1", techBlog1, now.minusDays(1), 100L);
+            Post post2 = createPost("게시글2", techBlog1, now.minusDays(2), 200L);
+            Post post3 = createPost("게시글3", techBlog1, now.minusDays(3), 300L);
+            Post post4 = createPost("게시글4", techBlog1, now.minusDays(4), 400L);
+            Post post5 = createPost("게시글5", techBlog1, now.minusDays(5), 500L);
+            postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+
+            PageRequest pageRequest = PageRequest.of(0, 2);
+            List<PostInfoDto> page1 = postRepository.findRecentPostsWithCursorV2(null, null, pageRequest);
+            PostInfoDto lastPost = page1.get(1);
+            List<PostInfoDto> page2 = postRepository.findRecentPostsWithCursorV2(
+                    lastPost.publishedAt(),
+                    lastPost.id(),
+                    pageRequest
+            );
+
+            assertThat(page1).hasSize(2);
+            assertThat(page2).hasSize(2);
+            assertThat(page2.get(0).publishedAt()).isBefore(lastPost.publishedAt());
+        }
     }
 
-    @Test
-    @DisplayName("findPopularPostsWithCursorV2 - 커서 기반 다음 페이지 조회")
-    void findPopularPostsWithCursorV2_NextPageWithCursor() {
-        // Given: 조회수가 다른 게시글 5개
-        Post post1 = createPost("게시글1", techBlog1, LocalDateTime.now().minusDays(1), 500L);
-        Post post2 = createPost("게시글2", techBlog1, LocalDateTime.now().minusDays(2), 400L);
-        Post post3 = createPost("게시글3", techBlog1, LocalDateTime.now().minusDays(3), 300L);
-        Post post4 = createPost("게시글4", techBlog1, LocalDateTime.now().minusDays(4), 200L);
-        Post post5 = createPost("게시글5", techBlog1, LocalDateTime.now().minusDays(5), 100L);
-        postRepository.saveAll(List.of(post1, post2, post3, post4, post5));
+    @Nested
+    @DisplayName("회사별 게시글 조회 V1")
+    class FindByCompanyWithCursor {
 
-        // When: 첫 페이지 조회 후 두 번째 페이지 조회
-        PageRequest pageRequest = PageRequest.of(0, 2);
-        List<PostInfoDto> page1 = postRepository.findPopularPostsWithCursorV2(null, null, pageRequest);
+        @Test
+        @DisplayName("company가 null이면 모든 게시글을 조회한다")
+        void findByCompanyWithCursor_NullCompany_ReturnsAll() {
+            Post kakaoPost = createPost("카카오 게시글", techBlog1, LocalDateTime.now(), 100L);
+            Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 200L);
+            postRepository.saveAll(List.of(kakaoPost, naverPost));
 
-        PostInfoDto lastPost = page1.get(1);
-        List<PostInfoDto> page2 = postRepository.findPopularPostsWithCursorV2(
-                lastPost.viewCount().intValue(), lastPost.id(), pageRequest
-        );
+            List<PostInfoDto> result = postRepository.findByCompanyWithCursor(null, null, PageRequest.of(0, 10));
 
-        // Then: 커서 이후 게시글만 반환
-        assertThat(page1).hasSize(2);
-        assertThat(page2).hasSize(2);
-        assertThat(page2.get(0).viewCount()).isLessThanOrEqualTo(lastPost.viewCount());
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(PostInfoDto::company)
+                    .containsExactlyInAnyOrder("카카오", "네이버");
+        }
+
+        @Test
+        @DisplayName("company 지정 시 해당 회사 게시글만 조회한다")
+        void findByCompanyWithCursor_SpecificCompany_ReturnsFiltered() {
+            Post kakaoPost1 = createPost("카카오 게시글1", techBlog1, LocalDateTime.now().minusDays(2), 100L);
+            Post kakaoPost2 = createPost("카카오 게시글2", techBlog1, LocalDateTime.now().minusDays(1), 200L);
+            Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 300L);
+            postRepository.saveAll(List.of(kakaoPost1, kakaoPost2, naverPost));
+
+            List<PostInfoDto> result = postRepository.findByCompanyWithCursor("카카오", null, PageRequest.of(0, 10));
+
+            assertThat(result).hasSize(2);
+            assertThat(result).allMatch(dto -> dto.company().equals("카카오"));
+        }
     }
 
-    // 헬퍼 메서드
+    @Nested
+    @DisplayName("회사 목록 기반 게시글 조회 V2")
+    class FindByCompanyNamesWithCursor {
+
+        @Test
+        @DisplayName("companies가 null이면 모든 회사 게시글을 조회한다")
+        void findByCompanyNames_NullCompanies_ReturnsAll() {
+            Post kakaoPost = createPost("카카오 게시글", techBlog1, LocalDateTime.now().minusDays(2), 100L);
+            Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 300L);
+            Post awsPost = createPost("AWS 게시글", techBlog3, LocalDateTime.now(), 500L);
+            postRepository.saveAll(List.of(kakaoPost, naverPost, awsPost));
+
+            List<PostInfoDto> result = postRepository.findByCompanyNamesWithCursor(null, null, null, PageRequest.of(0, 10));
+
+            assertThat(result).hasSize(3);
+            assertThat(result).extracting(PostInfoDto::company)
+                    .containsExactlyInAnyOrder("카카오", "네이버", "AWS");
+        }
+
+        @Test
+        @DisplayName("companies 지정 시 해당 회사들 게시글만 조회한다")
+        void findByCompanyNamesWithCursor_SpecificCompanies_ReturnsFiltered() {
+            Post kakaoPost1 = createPost("카카오 게시글1", techBlog1, LocalDateTime.now().minusDays(2), 100L);
+            Post kakaoPost2 = createPost("카카오 게시글2", techBlog1, LocalDateTime.now().minusDays(1), 200L);
+            Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 300L);
+            Post awsPost = createPost("AWS 게시글", techBlog3, LocalDateTime.now(), 500L);
+            postRepository.saveAll(List.of(kakaoPost1, kakaoPost2, naverPost, awsPost));
+
+            List<PostInfoDto> result = postRepository.findByCompanyNamesWithCursor(
+                    List.of("카카오", "네이버"),
+                    null,
+                    null,
+                    PageRequest.of(0, 10)
+            );
+
+            assertThat(result).hasSize(3);
+            assertThat(result).extracting(PostInfoDto::company)
+                    .containsOnly("카카오", "네이버")
+                    .doesNotContain("AWS");
+        }
+
+        @Test
+        @DisplayName("발행일 내림차순으로 정렬한다")
+        void findByCompanyNames_SortPublishedAtCheck() {
+            Post recentPost = createPost("최신 글", techBlog1, LocalDateTime.now(), 100L);
+            Post oldPost = createPost("옛날 글", techBlog1, LocalDateTime.now().minusDays(5), 200L);
+            postRepository.saveAll(List.of(recentPost, oldPost));
+
+            List<PostInfoDto> result = postRepository.findByCompanyNamesWithCursor(null, null, null, PageRequest.of(0, 10));
+
+            assertThat(result)
+                    .extracting(PostInfoDto::title)
+                    .containsExactly("최신 글", "옛날 글");
+        }
+
+        @Test
+        @DisplayName("발행일이 같으면 ID 내림차순으로 정렬한다")
+        void findByCompanyNames_SortPublihedAtEqualsCheck() {
+            LocalDateTime now = LocalDateTime.now();
+            Post kakaoPost = createPost("카카오 게시글", techBlog1, now, 100L);
+            Post naverPost = createPost("네이버 게시글", techBlog2, now, 300L);
+            Post awsPost = createPost("AWS 게시글", techBlog3, now, 500L);
+            postRepository.saveAll(List.of(kakaoPost, naverPost, awsPost));
+
+            List<PostInfoDto> result = postRepository.findByCompanyNamesWithCursor(null, null, null, PageRequest.of(0, 10));
+
+            assertThat(result)
+                    .extracting("id")
+                    .containsExactly(awsPost.getId(), naverPost.getId(), kakaoPost.getId());
+        }
+
+        @Test
+        @DisplayName("커서 기반으로 다음 페이지를 조회한다")
+        void findByCompanyNames_CursorPaging() {
+            LocalDateTime now = LocalDateTime.now();
+            List<Post> posts = new ArrayList<>();
+            for (int i = 1; i <= 5; i++) {
+                posts.add(createPost("게시글" + i, techBlog1, now.plusHours(i), 10L));
+            }
+            postRepository.saveAll(posts);
+
+            PageRequest pageRequest = PageRequest.of(0, 2);
+            List<PostInfoDto> page1 = postRepository.findByCompanyNamesWithCursor(null, null, null, pageRequest);
+            PostInfoDto lastPostOfPage1 = page1.get(1);
+            List<PostInfoDto> page2 = postRepository.findByCompanyNamesWithCursor(
+                    null,
+                    lastPostOfPage1.publishedAt(),
+                    lastPostOfPage1.id(),
+                    pageRequest
+            );
+
+            assertThat(page1).extracting("title")
+                    .containsExactly("게시글5", "게시글4");
+            assertThat(page2).extracting("title")
+                    .containsExactly("게시글3", "게시글2");
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 상세 조회")
+    class FindByIdWithTechBlog {
+
+        @Test
+        @DisplayName("JOIN하여 게시글 상세 정보 조회에 성공한다")
+        void findByIdWithTechBlog_Success_ReturnsPostDetailDto() {
+            Post post = postRepository.save(createPost("테스트 게시글", techBlog1, LocalDateTime.now(), 100L));
+
+            Optional<PostDetailDto> result = postRepository.findByIdWithTechBlog(post.getId());
+
+            assertThat(result).isPresent();
+            PostDetailDto dto = result.get();
+            assertThat(dto.id()).isEqualTo(post.getId());
+            assertThat(dto.title()).isEqualTo("테스트 게시글");
+            assertThat(dto.company()).isEqualTo("카카오");
+            assertThat(dto.viewCount()).isEqualTo(100L);
+            assertThat(dto.keywords()).isNull();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 ID 조회 시 Empty를 반환한다")
+        void findByIdWithTechBlog_NotFound_ReturnsEmpty() {
+            Optional<PostDetailDto> result = postRepository.findByIdWithTechBlog(99999L);
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("회사 목록 조회")
+    class FindDistinctCompanies {
+
+        @Test
+        @DisplayName("중복 없이 회사 목록을 조회한다")
+        void findDistinctCompanies_ReturnsUniqueCompanies() {
+            Post kakaoPost1 = createPost("카카오 게시글1", techBlog1, LocalDateTime.now(), 100L);
+            Post kakaoPost2 = createPost("카카오 게시글2", techBlog1, LocalDateTime.now(), 200L);
+            Post naverPost = createPost("네이버 게시글", techBlog2, LocalDateTime.now(), 300L);
+            postRepository.saveAll(List.of(kakaoPost1, kakaoPost2, naverPost));
+
+            List<String> result = postRepository.findDistinctCompanies();
+
+            assertThat(result).hasSize(2);
+            assertThat(result).containsExactlyInAnyOrder("카카오", "네이버");
+        }
+    }
+
+    @Nested
+    @DisplayName("회사 상세 정보 조회")
+    class FindCompaniesWithDetails {
+
+        @Test
+        @DisplayName("회사별 상세 정보 조회에 성공한다")
+        void findCompaniesWithDetails_Success() {
+            Post kakaoPost1 = createPost("카카오 게시글1", techBlog1, LocalDate.now().atStartOfDay(), 100L);
+            Post kakaoPost2 = createPost("카카오 게시글2", techBlog1, LocalDate.now().minusDays(1).atStartOfDay(), 200L);
+            Post naverPost = createPost("네이버 게시글", techBlog2, LocalDate.now().minusDays(2).atStartOfDay(), 300L);
+            postRepository.saveAll(List.of(kakaoPost1, kakaoPost2, naverPost));
+
+            List<CompanyDto> result = postRepository.findCompaniesWithDetails();
+
+            assertThat(result).hasSize(2);
+
+            CompanyDto firstCompany = result.get(0);
+            assertThat(firstCompany.company()).isEqualTo("카카오");
+            assertThat(firstCompany.hasNewPost()).isTrue();
+            assertThat(firstCompany.logoUrl()).isNotNull();
+
+            CompanyDto secondCompany = result.get(1);
+            assertThat(secondCompany.company()).isEqualTo("네이버");
+            assertThat(secondCompany.hasNewPost()).isFalse();
+        }
+
+        @Test
+        @DisplayName("오늘 발행된 게시글 여부를 정확히 판단한다")
+        void findCompaniesWithDetails_HasNewPost_AccurateDetection() {
+            Post todayPost = createPost("오늘 게시글", techBlog1, LocalDate.now().atTime(14, 30), 100L);
+            Post yesterdayPost = createPost("어제 게시글", techBlog2, LocalDate.now().minusDays(1).atStartOfDay(), 200L);
+            postRepository.saveAll(List.of(todayPost, yesterdayPost));
+
+            List<CompanyDto> result = postRepository.findCompaniesWithDetails();
+
+            CompanyDto kakaoCompany = result.stream()
+                    .filter(c -> c.company().equals("카카오"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(kakaoCompany.hasNewPost()).isTrue();
+
+            CompanyDto naverCompany = result.stream()
+                    .filter(c -> c.company().equals("네이버"))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(naverCompany.hasNewPost()).isFalse();
+        }
+
+        @Test
+        @DisplayName("최신 발행일 기준으로 정렬한다")
+        void findCompaniesWithDetails_OrderByLatestPublishedAtDesc() {
+            Post oldPost = createPost("오래된 게시글", techBlog1, LocalDate.now().minusDays(10).atStartOfDay(), 100L);
+            Post recentPost = createPost("최근 게시글", techBlog2, LocalDate.now().minusDays(1).atStartOfDay(), 200L);
+            postRepository.saveAll(List.of(oldPost, recentPost));
+
+            List<CompanyDto> result = postRepository.findCompaniesWithDetails();
+
+            assertThat(result).hasSize(2);
+            assertThat(result.get(0).company()).isEqualTo("네이버");
+            assertThat(result.get(1).company()).isEqualTo("카카오");
+        }
+
+        @Test
+        @DisplayName("게시글이 없으면 빈 리스트를 반환한다")
+        void findCompaniesWithDetails_NoPosts_ReturnsEmptyList() {
+            List<CompanyDto> result = postRepository.findCompaniesWithDetails();
+
+            assertThat(result).isEmpty();
+        }
+    }
+
     private Post createPost(String title, TechBlog techBlog, LocalDateTime publishedAt, Long viewCount) {
         Post post = Post.builder()
                 .title(title)
@@ -576,7 +547,6 @@ class PostRepositoryTest {
                 .techBlog(techBlog)
                 .build();
 
-        // viewCount 설정 (reflection 또는 여러 번 증가)
         for (int i = 0; i < viewCount; i++) {
             post.incrementViewCount();
         }

--- a/src/test/java/com/techfork/domain/post/repository/PostRepositoryTest.java
+++ b/src/test/java/com/techfork/domain/post/repository/PostRepositoryTest.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -547,9 +548,7 @@ class PostRepositoryTest {
                 .techBlog(techBlog)
                 .build();
 
-        for (int i = 0; i < viewCount; i++) {
-            post.incrementViewCount();
-        }
+        ReflectionTestUtils.setField(post, "viewCount", viewCount);
 
         return post;
     }

--- a/src/test/java/com/techfork/domain/post/service/PostCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/post/service/PostCommandServiceTest.java
@@ -1,6 +1,7 @@
 package com.techfork.domain.post.service;
 
 import com.techfork.domain.post.repository.PostRepository;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,6 +9,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -20,13 +23,32 @@ class PostCommandServiceTest {
     @InjectMocks
     private PostCommandService postCommandService;
 
-    @Test
-    @DisplayName("incrementViewCount - repository atomic update를 위임한다")
-    void incrementViewCount_DelegatesToRepositoryAtomicUpdate() {
-        Long postId = 100L;
+    @Nested
+    @DisplayName("incrementViewCount")
+    class IncrementViewCount {
 
-        postCommandService.incrementViewCount(postId);
+        @Test
+        @DisplayName("1건이 업데이트되면 true를 반환한다")
+        void incrementViewCount_ReturnsTrue_WhenSingleRowUpdated() {
+            Long postId = 100L;
+            given(postRepository.incrementViewCount(postId)).willReturn(1);
 
-        verify(postRepository, times(1)).incrementViewCount(postId);
+            boolean incremented = postCommandService.incrementViewCount(postId);
+
+            assertThat(incremented).isTrue();
+            verify(postRepository, times(1)).incrementViewCount(postId);
+        }
+
+        @Test
+        @DisplayName("업데이트 건수가 1이 아니면 false를 반환한다")
+        void incrementViewCount_ReturnsFalse_WhenUpdatedCountIsNotOne() {
+            Long postId = 100L;
+            given(postRepository.incrementViewCount(postId)).willReturn(0);
+
+            boolean incremented = postCommandService.incrementViewCount(postId);
+
+            assertThat(incremented).isFalse();
+            verify(postRepository, times(1)).incrementViewCount(postId);
+        }
     }
 }

--- a/src/test/java/com/techfork/domain/post/service/PostCommandServiceTest.java
+++ b/src/test/java/com/techfork/domain/post/service/PostCommandServiceTest.java
@@ -1,0 +1,32 @@
+package com.techfork.domain.post.service;
+
+import com.techfork.domain.post.repository.PostRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PostCommandServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private PostCommandService postCommandService;
+
+    @Test
+    @DisplayName("incrementViewCount - repository atomic update를 위임한다")
+    void incrementViewCount_DelegatesToRepositoryAtomicUpdate() {
+        Long postId = 100L;
+
+        postCommandService.incrementViewCount(postId);
+
+        verify(postRepository, times(1)).incrementViewCount(postId);
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

- `ReadPostCommandService`의 조회수 증가 경로를 `PostCommandService` / `PostRepository`의 SQL atomic update로 전환했습니다.
- `Post.incrementViewCount()`는 production 경로에서 제거하고, 조회수 증가는 atomic update를 canonical write path로 정리했습니다.
- atomic update 결과를 `boolean` 계약과 로그로 명확히 하고, 관련 테스트/문서도 함께 최신화했습니다.
- `PostRepositoryTest`는 기능별 1단 `@Nested` 구조로 정리했고, 같은 기능 안에서 V1 → V2 순서로 재배치했습니다.
- `isFirstRead` race / idempotency 문제는 이번 PR 범위에서 제외했고 후속 이슈 `#385`로 분리했습니다.

테스트
- `./gradlew test --tests 'com.techfork.activity.readpost.application.command.ReadPostCommandServiceTest' --tests 'com.techfork.domain.post.service.PostCommandServiceTest' --tests 'com.techfork.domain.post.repository.PostRepositoryTest'`
- `PostControllerV2IntegrationTest`는 로컬 검증을 위해 `MySqlRedisIntegrationTestBase`로 일시 전환해 성공 확인 후, 현재 코드에는 `IntegrationTestBase`로 원복했습니다.

> CLI 환경이라 swagger 테스트 스크린샷 대신 실행 명령과 결과를 기재했습니다.

<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #383
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] `#385`(ReadPost 최초 읽기 판별 race condition 방지)는 이번 PR 범위에서 제외했습니다.
- [ ] `PostCommandService`의 atomic update 경로를 production canonical path로 유지할지 확인 부탁드립니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?
