### PR TITLE
[refactor/#378] Post aggregate 도메인 규칙 안전망 정리

### DIFF
--- a/src/main/java/com/techfork/domain/post/entity/Post.java
+++ b/src/main/java/com/techfork/domain/post/entity/Post.java
@@ -106,9 +106,6 @@ public class Post extends BaseEntity {
                 .build();
     }
 
-    public void updateSummary(String summary) {
-        this.summary = summary;
-    }
 
     public void updateSummaries(String summary, String shortSummary) {
         this.summary = summary;

--- a/src/test/java/com/techfork/domain/post/entity/PostTest.java
+++ b/src/test/java/com/techfork/domain/post/entity/PostTest.java
@@ -1,0 +1,129 @@
+package com.techfork.domain.post.entity;
+
+import com.techfork.domain.source.dto.RssFeedItem;
+import com.techfork.domain.source.entity.TechBlog;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PostTest {
+
+    @Nested
+    @DisplayName("create")
+    class Create {
+
+        @Test
+        @DisplayName("RssFeedItem과 TechBlog로 게시글 aggregate를 생성한다")
+        void createsPostAggregateFromRssFeedItem() {
+            TechBlog techBlog = createTechBlog();
+            LocalDateTime publishedAt = LocalDateTime.of(2026, 5, 7, 10, 30);
+            RssFeedItem rssFeedItem = RssFeedItem.builder()
+                    .title("Post aggregate 설계")
+                    .url("https://posts.example.com/post-aggregate")
+                    .logoUrl("https://cdn.example.com/logo.png")
+                    .thumbnailUrl("https://cdn.example.com/thumb.png")
+                    .content("원문 본문")
+                    .plainContent("평문 본문")
+                    .publishedAt(publishedAt)
+                    .company("TechFork")
+                    .techBlogId(1L)
+                    .build();
+            LocalDateTime beforeCreate = LocalDateTime.now();
+
+            Post post = Post.create(rssFeedItem, techBlog);
+
+            LocalDateTime afterCreate = LocalDateTime.now();
+            assertThat(post.getTitle()).isEqualTo("Post aggregate 설계");
+            assertThat(post.getFullContent()).isEqualTo("원문 본문");
+            assertThat(post.getPlainContent()).isEqualTo("평문 본문");
+            assertThat(post.getCompany()).isEqualTo("TechFork");
+            assertThat(post.getLogoUrl()).isEqualTo("https://cdn.example.com/logo.png");
+            assertThat(post.getThumbnailUrl()).isEqualTo("https://cdn.example.com/thumb.png");
+            assertThat(post.getUrl()).isEqualTo("https://posts.example.com/post-aggregate");
+            assertThat(post.getPublishedAt()).isEqualTo(publishedAt);
+            assertThat(post.getCrawledAt()).isBetween(beforeCreate, afterCreate);
+            assertThat(post.getTechBlog()).isSameAs(techBlog);
+            assertThat(post.getViewCount()).isZero();
+            assertThat(post.getKeywords()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateSummaries")
+    class UpdateSummaries {
+
+        @Test
+        @DisplayName("summary와 shortSummary를 함께 갱신한다")
+        void updatesSummaryAndShortSummaryTogether() {
+            Post post = createPost();
+
+            post.updateSummaries("새 요약", "새 짧은 요약");
+
+            assertThat(post.getSummary()).isEqualTo("새 요약");
+            assertThat(post.getShortSummary()).isEqualTo("새 짧은 요약");
+        }
+    }
+
+    @Nested
+    @DisplayName("addKeyword")
+    class AddKeyword {
+
+        @Test
+        @DisplayName("keyword를 추가하고 동일한 post 연관관계를 유지한다")
+        void addsKeywordWithSamePostReference() {
+            Post post = createPost();
+            PostKeyword keyword = PostKeyword.create("AI", post);
+
+            post.addKeyword(keyword);
+
+            assertThat(post.getKeywords()).containsExactly(keyword);
+            assertThat(keyword.getPost()).isSameAs(post);
+        }
+    }
+
+    @Nested
+    @DisplayName("clearKeywords")
+    class ClearKeywords {
+
+        @Test
+        @DisplayName("기존 keyword를 모두 제거한다")
+        void clearsExistingKeywords() {
+            Post post = createPost();
+            post.addKeyword(PostKeyword.create("AI", post));
+            post.addKeyword(PostKeyword.create("Batch", post));
+
+            post.clearKeywords();
+
+            assertThat(post.getKeywords()).isEmpty();
+        }
+    }
+
+    private Post createPost() {
+        return Post.create(
+                RssFeedItem.builder()
+                        .title("Post aggregate 설계")
+                        .url("https://posts.example.com/post-aggregate")
+                        .logoUrl("https://cdn.example.com/logo.png")
+                        .thumbnailUrl("https://cdn.example.com/thumb.png")
+                        .content("원문 본문")
+                        .plainContent("평문 본문")
+                        .publishedAt(LocalDateTime.of(2026, 5, 7, 10, 30))
+                        .company("TechFork")
+                        .techBlogId(1L)
+                        .build(),
+                createTechBlog()
+        );
+    }
+
+    private TechBlog createTechBlog() {
+        return TechBlog.create(
+                "TechFork",
+                "https://techfork.example.com",
+                "https://techfork.example.com/rss",
+                "https://cdn.example.com/logo.png"
+        );
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

Post aggregate 리팩토링 전에 직접 노출된 핵심 규칙을 `PostTest`로 고정했습니다.
- `RssFeedItem -> Post.create(...)` 생성 규칙 검증
- `updateSummaries(...)` 검증
- `addKeyword(...)`, `clearKeywords()` 검증
- `viewCount`는 기존 repository atomic update 경계를 유지

<br>

## 연결된 issue

close #378
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 이번 PR은 aggregate 안전망 추가에만 집중했고, summary pipeline / embedding projection 책임 정리는 포함하지 않았습니다.
- [ ] `updateSummary(...)` 제거가 후속 이슈 영향 없이 안전한지 한 번 더 봐주세요.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가?
- [x] 이슈넘버를 적었는가?

### 테스트
- `./gradlew test --tests 'com.techfork.domain.post.entity.PostTest'`
