### PR TITLE
[refactor/#396] User aggregate 도메인 규칙 안전망 정리

### DIFF
--- a/src/test/java/com/techfork/domain/useraccount/entity/UserTest.java
+++ b/src/test/java/com/techfork/domain/useraccount/entity/UserTest.java
@@ -1,0 +1,141 @@
+package com.techfork.domain.useraccount.entity;
+
+import com.techfork.domain.useraccount.enums.Role;
+import com.techfork.domain.useraccount.enums.SocialType;
+import com.techfork.domain.useraccount.enums.UserStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Nested
+    @DisplayName("createSocialUser")
+    class CreateSocialUser {
+
+        @Test
+        @DisplayName("소셜 사용자 생성 시 기본 상태는 PENDING이고 ROLE_USER를 가진다")
+        void createsPendingSocialUserWithUserRole() {
+            User user = User.createSocialUser(
+                    SocialType.KAKAO,
+                    "social-id-123",
+                    "user@example.com",
+                    "https://cdn.example.com/profile.png"
+            );
+
+            assertThat(user.getSocialType()).isEqualTo(SocialType.KAKAO);
+            assertThat(user.getSocialId()).isEqualTo("social-id-123");
+            assertThat(user.getEmail()).isEqualTo("user@example.com");
+            assertThat(user.getProfileImage()).isEqualTo("https://cdn.example.com/profile.png");
+            assertThat(user.getRole()).isEqualTo(Role.USER);
+            assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING);
+            assertThat(user.isActive()).isFalse();
+            assertThat(user.isWithdrawn()).isFalse();
+            assertThat(user.getInterestCategories()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateUser")
+    class UpdateUser {
+
+        @Test
+        @DisplayName("온보딩 완료 시 계정 정보를 갱신하고 ACTIVE 상태가 된다")
+        void activatesUserWhenOnboardingCompletes() {
+            User user = User.createSocialUser(SocialType.KAKAO, "social-id-123", "before@example.com", null);
+
+            user.updateUser("테크포크유저", "after@example.com", "백엔드 개발자입니다.");
+
+            assertThat(user.getNickName()).isEqualTo("테크포크유저");
+            assertThat(user.getEmail()).isEqualTo("after@example.com");
+            assertThat(user.getDescription()).isEqualTo("백엔드 개발자입니다.");
+            assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(user.isActive()).isTrue();
+            assertThat(user.isWithdrawn()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateProfile")
+    class UpdateProfile {
+
+        @Test
+        @DisplayName("계정 프로필 수정 시 전달된 필드만 변경한다")
+        void updatesOnlyProvidedProfileFields() {
+            User user = activeUser();
+
+            user.updateProfile("새닉네임", null);
+
+            assertThat(user.getNickName()).isEqualTo("새닉네임");
+            assertThat(user.getDescription()).isEqualTo("기존 자기소개");
+
+            user.updateProfile(null, "새 자기소개");
+
+            assertThat(user.getNickName()).isEqualTo("새닉네임");
+            assertThat(user.getDescription()).isEqualTo("새 자기소개");
+            assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("withdraw")
+    class Withdraw {
+
+        @Test
+        @DisplayName("탈퇴 시 개인정보를 null 처리하고 WITHDRAWN 상태가 된다")
+        void anonymizesPersonalDataAndMarksWithdrawn() {
+            User user = activeUser();
+            String originalSocialId = user.getSocialId();
+            SocialType originalSocialType = user.getSocialType();
+            Role originalRole = user.getRole();
+
+            user.withdraw();
+
+            assertThat(user.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
+            assertThat(user.isWithdrawn()).isTrue();
+            assertThat(user.isActive()).isFalse();
+            assertThat(user.getNickName()).isNull();
+            assertThat(user.getEmail()).isNull();
+            assertThat(user.getProfileImage()).isNull();
+            assertThat(user.getDescription()).isNull();
+            assertThat(user.getSocialId()).isEqualTo(originalSocialId);
+            assertThat(user.getSocialType()).isEqualTo(originalSocialType);
+            assertThat(user.getRole()).isEqualTo(originalRole);
+        }
+    }
+
+    @Nested
+    @DisplayName("reactivate")
+    class Reactivate {
+
+        @Test
+        @DisplayName("재활성화 시 이메일과 프로필 이미지를 복구하고 PENDING 상태가 된다")
+        void reactivatesUserAsPendingWithRecoveredIdentityData() {
+            User user = activeUser();
+            user.withdraw();
+
+            user.reactivate("reactivated@example.com", "https://cdn.example.com/reactivated.png");
+
+            assertThat(user.getEmail()).isEqualTo("reactivated@example.com");
+            assertThat(user.getProfileImage()).isEqualTo("https://cdn.example.com/reactivated.png");
+            assertThat(user.getStatus()).isEqualTo(UserStatus.PENDING);
+            assertThat(user.isActive()).isFalse();
+            assertThat(user.isWithdrawn()).isFalse();
+            assertThat(user.getNickName()).isNull();
+            assertThat(user.getDescription()).isNull();
+        }
+    }
+
+    private User activeUser() {
+        User user = User.createSocialUser(
+                SocialType.KAKAO,
+                "social-id-123",
+                "user@example.com",
+                "https://cdn.example.com/profile.png"
+        );
+        user.updateUser("기존닉네임", "user@example.com", "기존 자기소개");
+        return user;
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

- `User` aggregate의 핵심 상태 전이 규칙을 전용 도메인 테스트 `UserTest`로 고정했습니다.
- 이번 PR은 서비스 테스트에 간접적으로 흩어져 있던 규칙을 aggregate 단위로 직접 검증하는 안전망 추가가 목적입니다.
- 검증한 규칙
  - `createSocialUser()` 기본 상태 `PENDING`, 기본 역할 `ROLE_USER`
  - `updateUser()` 이후 `ACTIVE`
  - `updateProfile()`는 전달된 필드만 수정
  - `withdraw()` 시 개인정보 null 처리 + `WITHDRAWN`
  - `reactivate()` 시 `PENDING` 복귀 + 이메일/프로필 이미지 복구
- 테스트 결과
  - `./gradlew test --tests 'com.techfork.domain.useraccount.entity.UserTest' --tests 'com.techfork.domain.useraccount.service.UserCommandServiceTest' --tests 'com.techfork.domain.useraccount.service.UserQueryServiceTest' -PexcludeIntegration` ✅
  - `./gradlew test -PexcludeIntegration` ✅

> 참고: 테스트 안전망 추가 PR이라 Swagger 스크린샷 대신 테스트 실행 결과를 텍스트로 남깁니다.
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #396 
<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [ ] 테스트 결과 사진을 넣었는가? (이번 PR은 텍스트 결과로 대체)
- [x] 이슈넘버를 적었는가?
