### PR TITLE
[refactor/#397] User 관심사 불변식을 aggregate 내부로 이동

### DIFF
--- a/src/main/java/com/techfork/useraccount/application/command/InterestCommandService.java
+++ b/src/main/java/com/techfork/useraccount/application/command/InterestCommandService.java
@@ -1,11 +1,10 @@
 package com.techfork.useraccount.application.command;
 
 import com.techfork.useraccount.domain.User;
-import com.techfork.useraccount.domain.UserInterestCategory;
-import com.techfork.useraccount.domain.UserInterestKeyword;
 import com.techfork.useraccount.domain.enums.EInterestCategory;
 import com.techfork.useraccount.domain.enums.EInterestKeyword;
 import com.techfork.useraccount.domain.exception.UserErrorCode;
+import com.techfork.useraccount.domain.vo.UserInterestSelection;
 import com.techfork.useraccount.infrastructure.UserRepository;
 import com.techfork.domain.personalization.service.PersonalizationProfileService;
 import com.techfork.global.exception.GeneralException;
@@ -33,44 +32,28 @@ public class InterestCommandService {
     }
 
     void saveUserInterests(User user, List<UserInterestCommand> interests) {
-        user.getInterestCategories().clear();
-        List<UserInterestCategory> categories = createCategoriesFromRequest(user, interests);
-        user.getInterestCategories().addAll(categories);
+        List<UserInterestSelection> interestSelections = toInterestSelections(interests);
+        user.replaceInterests(interestSelections);
 
-        log.info("Saved {} interest categories for user {}", categories.size(), user.getId());
+        log.info("Saved {} interest categories for user {}", interestSelections.size(), user.getId());
 
         personalizationProfileService.generatePersonalizationProfile(user.getId());
     }
 
-    private List<UserInterestCategory> createCategoriesFromRequest(User user, List<UserInterestCommand> interests) {
+    private List<UserInterestSelection> toInterestSelections(List<UserInterestCommand> interests) {
         return interests.stream()
-                .map(dto -> createCategoryWithKeywords(user, dto))
+                .map(this::toInterestSelection)
                 .toList();
     }
 
-    private UserInterestCategory createCategoryWithKeywords(User user, UserInterestCommand command) {
+    private UserInterestSelection toInterestSelection(UserInterestCommand command) {
         EInterestCategory category = EInterestCategory.valueOf(command.category());
-        UserInterestCategory userCategory = UserInterestCategory.create(user, category);
+        List<EInterestKeyword> keywords = command.keywords() == null
+                ? List.of()
+                : command.keywords().stream()
+                        .map(EInterestKeyword::valueOf)
+                        .toList();
 
-        if (command.keywords() != null && !command.keywords().isEmpty()) {
-            addKeywordsToCategory(userCategory, category, command.keywords());
-        }
-
-        return userCategory;
-    }
-
-    private void addKeywordsToCategory(UserInterestCategory userCategory, EInterestCategory category, List<String> keywordNames) {
-        for (String keywordName : keywordNames) {
-            EInterestKeyword keyword = EInterestKeyword.valueOf(keywordName);
-            validateKeywordCategory(keyword, category);
-            UserInterestKeyword userInterestKeyword = UserInterestKeyword.create(userCategory, keyword);
-            userCategory.addKeyword(userInterestKeyword);
-        }
-    }
-
-    private void validateKeywordCategory(EInterestKeyword keyword, EInterestCategory category) {
-        if (keyword.getCategory() != category) {
-            throw new GeneralException(UserErrorCode.INVALID_INTEREST_KEYWORD);
-        }
+        return new UserInterestSelection(category, keywords);
     }
 }

--- a/src/main/java/com/techfork/useraccount/application/command/InterestCommandService.java
+++ b/src/main/java/com/techfork/useraccount/application/command/InterestCommandService.java
@@ -1,5 +1,7 @@
 package com.techfork.useraccount.application.command;
 
+import com.techfork.useraccount.application.command.input.UpdateUserInterestsCommand;
+import com.techfork.useraccount.application.command.input.UserInterestCommand;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.EInterestCategory;
 import com.techfork.useraccount.domain.enums.EInterestKeyword;

--- a/src/main/java/com/techfork/useraccount/application/command/InterestCommandService.java
+++ b/src/main/java/com/techfork/useraccount/application/command/InterestCommandService.java
@@ -49,11 +49,11 @@ public class InterestCommandService {
     }
 
     private UserInterestSelection toInterestSelection(UserInterestCommand command) {
-        EInterestCategory category = EInterestCategory.valueOf(command.category());
+        EInterestCategory category = EInterestCategory.from(command.category());
         List<EInterestKeyword> keywords = command.keywords() == null
                 ? List.of()
                 : command.keywords().stream()
-                        .map(EInterestKeyword::valueOf)
+                        .map(EInterestKeyword::from)
                         .toList();
 
         return new UserInterestSelection(category, keywords);

--- a/src/main/java/com/techfork/useraccount/application/command/UserCommandService.java
+++ b/src/main/java/com/techfork/useraccount/application/command/UserCommandService.java
@@ -1,5 +1,8 @@
 package com.techfork.useraccount.application.command;
 
+import com.techfork.useraccount.application.command.input.CompleteOnboardingCommand;
+import com.techfork.useraccount.application.command.input.UpdateAccountProfileCommand;
+import com.techfork.useraccount.application.command.input.WithdrawUserCommand;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.exception.UserErrorCode;
 import com.techfork.useraccount.infrastructure.UserRepository;

--- a/src/main/java/com/techfork/useraccount/application/command/input/CompleteOnboardingCommand.java
+++ b/src/main/java/com/techfork/useraccount/application/command/input/CompleteOnboardingCommand.java
@@ -1,4 +1,4 @@
-package com.techfork.useraccount.application.command;
+package com.techfork.useraccount.application.command.input;
 
 import java.util.List;
 

--- a/src/main/java/com/techfork/useraccount/application/command/input/UpdateAccountProfileCommand.java
+++ b/src/main/java/com/techfork/useraccount/application/command/input/UpdateAccountProfileCommand.java
@@ -1,4 +1,4 @@
-package com.techfork.useraccount.application.command;
+package com.techfork.useraccount.application.command.input;
 
 public record UpdateAccountProfileCommand(
         Long userId,

--- a/src/main/java/com/techfork/useraccount/application/command/input/UpdateUserInterestsCommand.java
+++ b/src/main/java/com/techfork/useraccount/application/command/input/UpdateUserInterestsCommand.java
@@ -1,4 +1,4 @@
-package com.techfork.useraccount.application.command;
+package com.techfork.useraccount.application.command.input;
 
 import java.util.List;
 

--- a/src/main/java/com/techfork/useraccount/application/command/input/UserInterestCommand.java
+++ b/src/main/java/com/techfork/useraccount/application/command/input/UserInterestCommand.java
@@ -1,4 +1,4 @@
-package com.techfork.useraccount.application.command;
+package com.techfork.useraccount.application.command.input;
 
 import lombok.Builder;
 

--- a/src/main/java/com/techfork/useraccount/application/command/input/WithdrawUserCommand.java
+++ b/src/main/java/com/techfork/useraccount/application/command/input/WithdrawUserCommand.java
@@ -1,4 +1,4 @@
-package com.techfork.useraccount.application.command;
+package com.techfork.useraccount.application.command.input;
 
 public record WithdrawUserCommand(
         Long userId

--- a/src/main/java/com/techfork/useraccount/domain/User.java
+++ b/src/main/java/com/techfork/useraccount/domain/User.java
@@ -1,9 +1,14 @@
 package com.techfork.useraccount.domain;
 
+import com.techfork.global.common.BaseTimeEntity;
+import com.techfork.global.exception.GeneralException;
+import com.techfork.useraccount.domain.enums.EInterestCategory;
+import com.techfork.useraccount.domain.enums.EInterestKeyword;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.enums.UserStatus;
-import com.techfork.global.common.BaseTimeEntity;
+import com.techfork.useraccount.domain.exception.UserErrorCode;
+import com.techfork.useraccount.domain.vo.UserInterestSelection;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -84,6 +89,38 @@ public class User extends BaseTimeEntity {
         }
         if (description != null) {
             this.description = description;
+        }
+    }
+
+    public void replaceInterests(List<UserInterestSelection> interests) {
+        List<UserInterestCategory> newInterestCategories = interests.stream()
+                .map(this::createInterestCategory)
+                .toList();
+
+        this.interestCategories.clear();
+        this.interestCategories.addAll(newInterestCategories);
+    }
+
+    private UserInterestCategory createInterestCategory(UserInterestSelection interest) {
+        UserInterestCategory userInterestCategory = UserInterestCategory.create(this, interest.category());
+
+        if (interest.keywords() != null && !interest.keywords().isEmpty()) {
+            addKeywordsToCategory(userInterestCategory, interest);
+        }
+
+        return userInterestCategory;
+    }
+
+    private void addKeywordsToCategory(UserInterestCategory userInterestCategory, UserInterestSelection interest) {
+        interest.keywords().forEach(keyword -> {
+            validateKeywordCategory(keyword, interest.category());
+            userInterestCategory.addKeyword(UserInterestKeyword.create(userInterestCategory, keyword));
+        });
+    }
+
+    private void validateKeywordCategory(EInterestKeyword keyword, EInterestCategory category) {
+        if (keyword.getCategory() != category) {
+            throw new GeneralException(UserErrorCode.INVALID_INTEREST_KEYWORD);
         }
     }
 

--- a/src/main/java/com/techfork/useraccount/domain/User.java
+++ b/src/main/java/com/techfork/useraccount/domain/User.java
@@ -104,7 +104,7 @@ public class User extends BaseTimeEntity {
     private UserInterestCategory createInterestCategory(UserInterestSelection interest) {
         UserInterestCategory userInterestCategory = UserInterestCategory.create(this, interest.category());
 
-        if (interest.keywords() != null && !interest.keywords().isEmpty()) {
+        if (!interest.keywords().isEmpty()) {
             addKeywordsToCategory(userInterestCategory, interest);
         }
 

--- a/src/main/java/com/techfork/useraccount/domain/enums/EInterestCategory.java
+++ b/src/main/java/com/techfork/useraccount/domain/enums/EInterestCategory.java
@@ -1,5 +1,7 @@
 package com.techfork.useraccount.domain.enums;
 
+import com.techfork.global.exception.GeneralException;
+import com.techfork.useraccount.domain.exception.UserErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -41,4 +43,12 @@ public enum EInterestCategory {
     ARCHITECTURE("Architecture");
 
     private final String displayName;
+
+    public static EInterestCategory from(String categoryName) {
+        try {
+            return EInterestCategory.valueOf(categoryName);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new GeneralException(UserErrorCode.INVALID_INTEREST_CATEGORY);
+        }
+    }
 }

--- a/src/main/java/com/techfork/useraccount/domain/enums/EInterestKeyword.java
+++ b/src/main/java/com/techfork/useraccount/domain/enums/EInterestKeyword.java
@@ -1,5 +1,7 @@
 package com.techfork.useraccount.domain.enums;
 
+import com.techfork.global.exception.GeneralException;
+import com.techfork.useraccount.domain.exception.UserErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -143,6 +145,14 @@ public enum EInterestKeyword {
 
     private final EInterestCategory category;
     private final String displayName;
+
+    public static EInterestKeyword from(String keywordName) {
+        try {
+            return EInterestKeyword.valueOf(keywordName);
+        } catch (IllegalArgumentException | NullPointerException e) {
+            throw new GeneralException(UserErrorCode.INVALID_INTEREST_KEYWORD);
+        }
+    }
 
     public static List<EInterestKeyword> getKeywordsByCategory(EInterestCategory category) {
         return Arrays.stream(values())

--- a/src/main/java/com/techfork/useraccount/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/techfork/useraccount/domain/exception/UserErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements BaseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404_1", "사용자를 찾을 수 없습니다."),
     INVALID_INTEREST_KEYWORD(HttpStatus.BAD_REQUEST, "USER400_1", "유효하지 않은 관심사 키워드입니다."),
-    ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "USER400_2", "이미 탈퇴한 회원입니다.");
+    ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "USER400_2", "이미 탈퇴한 회원입니다."),
+    INVALID_INTEREST_CATEGORY(HttpStatus.BAD_REQUEST, "USER400_3", "유효하지 않은 관심사 카테고리입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/techfork/useraccount/domain/vo/UserInterestSelection.java
+++ b/src/main/java/com/techfork/useraccount/domain/vo/UserInterestSelection.java
@@ -1,0 +1,12 @@
+package com.techfork.useraccount.domain.vo;
+
+import com.techfork.useraccount.domain.enums.EInterestCategory;
+import com.techfork.useraccount.domain.enums.EInterestKeyword;
+
+import java.util.List;
+
+public record UserInterestSelection(
+        EInterestCategory category,
+        List<EInterestKeyword> keywords
+) {
+}

--- a/src/main/java/com/techfork/useraccount/domain/vo/UserInterestSelection.java
+++ b/src/main/java/com/techfork/useraccount/domain/vo/UserInterestSelection.java
@@ -9,4 +9,7 @@ public record UserInterestSelection(
         EInterestCategory category,
         List<EInterestKeyword> keywords
 ) {
+    public UserInterestSelection {
+        keywords = keywords == null ? List.of() : List.copyOf(keywords);
+    }
 }

--- a/src/main/java/com/techfork/useraccount/presentation/InterestConverter.java
+++ b/src/main/java/com/techfork/useraccount/presentation/InterestConverter.java
@@ -1,7 +1,7 @@
 package com.techfork.useraccount.presentation;
 
-import com.techfork.useraccount.application.command.UpdateUserInterestsCommand;
-import com.techfork.useraccount.application.command.UserInterestCommand;
+import com.techfork.useraccount.application.command.input.UpdateUserInterestsCommand;
+import com.techfork.useraccount.application.command.input.UserInterestCommand;
 import com.techfork.useraccount.application.query.result.GetInterestListResult;
 import com.techfork.useraccount.application.query.result.GetUserInterestsResult;
 import com.techfork.useraccount.presentation.request.SaveInterestRequest;

--- a/src/main/java/com/techfork/useraccount/presentation/UserController.java
+++ b/src/main/java/com/techfork/useraccount/presentation/UserController.java
@@ -2,7 +2,7 @@ package com.techfork.useraccount.presentation;
 
 import com.techfork.useraccount.application.command.InterestCommandService;
 import com.techfork.useraccount.application.command.UserCommandService;
-import com.techfork.useraccount.application.command.WithdrawUserCommand;
+import com.techfork.useraccount.application.command.input.WithdrawUserCommand;
 import com.techfork.useraccount.application.query.GetAccountProfileQuery;
 import com.techfork.useraccount.application.query.GetUserInterestsQuery;
 import com.techfork.useraccount.application.query.InterestQueryService;

--- a/src/main/java/com/techfork/useraccount/presentation/UserConverter.java
+++ b/src/main/java/com/techfork/useraccount/presentation/UserConverter.java
@@ -1,8 +1,8 @@
 package com.techfork.useraccount.presentation;
 
-import com.techfork.useraccount.application.command.CompleteOnboardingCommand;
-import com.techfork.useraccount.application.command.UpdateAccountProfileCommand;
-import com.techfork.useraccount.application.command.UserInterestCommand;
+import com.techfork.useraccount.application.command.input.CompleteOnboardingCommand;
+import com.techfork.useraccount.application.command.input.UpdateAccountProfileCommand;
+import com.techfork.useraccount.application.command.input.UserInterestCommand;
 import com.techfork.useraccount.application.query.result.GetAccountProfileResult;
 import com.techfork.useraccount.presentation.request.OnboardingRequest;
 import com.techfork.useraccount.presentation.request.UpdateAccountProfileRequest;

--- a/src/main/java/com/techfork/useraccount/presentation/request/OnboardingRequest.java
+++ b/src/main/java/com/techfork/useraccount/presentation/request/OnboardingRequest.java
@@ -1,5 +1,6 @@
 package com.techfork.useraccount.presentation.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -22,6 +23,6 @@ public record OnboardingRequest(
 
         @NotNull(message = "관심사 목록은 필수입니다.")
         @NotEmpty(message = "관심사를 최소 1개 이상 선택해주세요.")
-        List<UserInterestRequest> interests
+        List<@NotNull(message = "관심사 항목은 필수입니다.") @Valid UserInterestRequest> interests
 ) {
 }

--- a/src/main/java/com/techfork/useraccount/presentation/request/SaveInterestRequest.java
+++ b/src/main/java/com/techfork/useraccount/presentation/request/SaveInterestRequest.java
@@ -1,5 +1,6 @@
 package com.techfork.useraccount.presentation.request;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
@@ -8,6 +9,6 @@ import java.util.List;
 public record SaveInterestRequest(
         @NotNull(message = "관심사 목록은 필수입니다.")
         @NotEmpty(message = "관심사를 최소 1개 이상 선택해주세요.")
-        List<UserInterestRequest> interests
+        List<@NotNull(message = "관심사 항목은 필수입니다.") @Valid UserInterestRequest> interests
 ) {
 }

--- a/src/main/java/com/techfork/useraccount/presentation/request/UserInterestRequest.java
+++ b/src/main/java/com/techfork/useraccount/presentation/request/UserInterestRequest.java
@@ -1,12 +1,14 @@
 package com.techfork.useraccount.presentation.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 
 import java.util.List;
 
 @Builder
 public record UserInterestRequest(
+        @NotBlank(message = "관심사 카테고리는 필수입니다.")
         String category,
-        List<String> keywords
+        List<@NotBlank(message = "관심사 키워드는 필수입니다.") String> keywords
 ) {
 }

--- a/src/test/java/com/techfork/useraccount/application/command/InterestCommandServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/command/InterestCommandServiceTest.java
@@ -102,6 +102,36 @@ class InterestCommandServiceTest {
     }
 
     @Test
+    @DisplayName("관심사 저장 - 존재하지 않는 카테고리면 개인화 프로필 생성을 트리거하지 않는다")
+    void saveUserInterests_UnknownCategory_SkipsProfileGeneration() {
+        User user = createUserWithId(1L);
+        List<UserInterestCommand> interests = List.of(
+                UserInterestCommand.builder().category("UNKNOWN").keywords(List.of("JAVA")).build()
+        );
+
+        assertThatThrownBy(() -> interestCommandService.saveUserInterests(user, interests))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", UserErrorCode.INVALID_INTEREST_CATEGORY);
+
+        verify(personalizationProfileService, never()).generatePersonalizationProfile(any());
+    }
+
+    @Test
+    @DisplayName("관심사 저장 - 존재하지 않는 키워드면 개인화 프로필 생성을 트리거하지 않는다")
+    void saveUserInterests_UnknownKeyword_SkipsProfileGeneration() {
+        User user = createUserWithId(1L);
+        List<UserInterestCommand> interests = List.of(
+                UserInterestCommand.builder().category("BACKEND").keywords(List.of("UNKNOWN")).build()
+        );
+
+        assertThatThrownBy(() -> interestCommandService.saveUserInterests(user, interests))
+                .isInstanceOf(GeneralException.class)
+                .hasFieldOrPropertyWithValue("code", UserErrorCode.INVALID_INTEREST_KEYWORD);
+
+        verify(personalizationProfileService, never()).generatePersonalizationProfile(any());
+    }
+
+    @Test
     @DisplayName("관심사 업데이트 - 사용자를 조회해 관심사를 교체하고 개인화 프로필 생성을 트리거한다")
     void updateUserInterests_Success() {
         Long userId = 1L;

--- a/src/test/java/com/techfork/useraccount/application/command/InterestCommandServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/command/InterestCommandServiceTest.java
@@ -1,5 +1,7 @@
 package com.techfork.useraccount.application.command;
 
+import com.techfork.useraccount.application.command.input.UpdateUserInterestsCommand;
+import com.techfork.useraccount.application.command.input.UserInterestCommand;
 import com.techfork.domain.personalization.service.PersonalizationProfileService;
 import com.techfork.global.exception.GeneralException;
 import com.techfork.useraccount.domain.User;

--- a/src/test/java/com/techfork/useraccount/application/command/InterestCommandServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/command/InterestCommandServiceTest.java
@@ -1,12 +1,15 @@
 package com.techfork.useraccount.application.command;
 
+import com.techfork.domain.personalization.service.PersonalizationProfileService;
+import com.techfork.global.exception.GeneralException;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.UserInterestCategory;
+import com.techfork.useraccount.domain.UserInterestKeyword;
+import com.techfork.useraccount.domain.enums.EInterestCategory;
+import com.techfork.useraccount.domain.enums.EInterestKeyword;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.exception.UserErrorCode;
 import com.techfork.useraccount.infrastructure.UserRepository;
-import com.techfork.domain.personalization.service.PersonalizationProfileService;
-import com.techfork.global.exception.GeneralException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,7 +24,9 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class InterestCommandServiceTest {
@@ -36,10 +41,10 @@ class InterestCommandServiceTest {
     private InterestCommandService interestCommandService;
 
     @Test
-    @DisplayName("관심사 저장 - 정상 케이스")
-    void saveUserInterests_Success() {
-        User user = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", null);
-
+    @DisplayName("관심사 저장 - 요청을 도메인 선택값으로 변환하고 개인화 프로필 생성을 트리거한다")
+    void saveUserInterests_ConvertsCommandAndTriggersProfileGeneration() {
+        Long userId = 1L;
+        User user = createUserWithId(userId);
         List<UserInterestCommand> interests = List.of(
                 UserInterestCommand.builder()
                         .category("BACKEND")
@@ -49,16 +54,20 @@ class InterestCommandServiceTest {
 
         interestCommandService.saveUserInterests(user, interests);
 
+        UserInterestCategory category = user.getInterestCategories().get(0);
         assertThat(user.getInterestCategories()).hasSize(1);
-        assertThat(user.getInterestCategories().get(0).getKeywords()).hasSize(2);
-        verify(personalizationProfileService).generatePersonalizationProfile(user.getId());
+        assertThat(category.getCategory()).isEqualTo(EInterestCategory.BACKEND);
+        assertThat(category.getKeywords())
+                .extracting(UserInterestKeyword::getKeyword)
+                .containsExactly(EInterestKeyword.JAVA, EInterestKeyword.SPRING);
+        verify(personalizationProfileService).generatePersonalizationProfile(userId);
     }
 
     @Test
-    @DisplayName("관심사 저장 - 키워드 없이 카테고리만 저장")
-    void saveUserInterests_CategoryOnly_Success() {
-        User user = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", null);
-
+    @DisplayName("관심사 저장 - 키워드가 없는 요청도 카테고리만 저장하고 개인화 프로필 생성을 트리거한다")
+    void saveUserInterests_CategoryOnly_TriggersProfileGeneration() {
+        Long userId = 1L;
+        User user = createUserWithId(userId);
         List<UserInterestCommand> interests = List.of(
                 UserInterestCommand.builder()
                         .category("AI_ML")
@@ -68,54 +77,17 @@ class InterestCommandServiceTest {
 
         interestCommandService.saveUserInterests(user, interests);
 
+        UserInterestCategory category = user.getInterestCategories().get(0);
         assertThat(user.getInterestCategories()).hasSize(1);
-        assertThat(user.getInterestCategories().get(0).getKeywords()).isEmpty();
-        verify(personalizationProfileService).generatePersonalizationProfile(user.getId());
+        assertThat(category.getCategory()).isEqualTo(EInterestCategory.AI_ML);
+        assertThat(category.getKeywords()).isEmpty();
+        verify(personalizationProfileService).generatePersonalizationProfile(userId);
     }
 
     @Test
-    @DisplayName("관심사 저장 - 여러 카테고리와 키워드")
-    void saveUserInterests_MultipleCategories_Success() {
-        User user = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", null);
-
-        List<UserInterestCommand> interests = List.of(
-                UserInterestCommand.builder().category("BACKEND").keywords(List.of("JAVA", "SPRING", "PYTHON")).build(),
-                UserInterestCommand.builder().category("DATABASE").keywords(List.of("MYSQL", "REDIS")).build(),
-                UserInterestCommand.builder().category("DEVOPS").keywords(List.of("DOCKER", "KUBERNETES", "CI_CD")).build()
-        );
-
-        interestCommandService.saveUserInterests(user, interests);
-
-        assertThat(user.getInterestCategories()).hasSize(3);
-        assertThat(user.getInterestCategories().get(0).getKeywords()).hasSize(3);
-        assertThat(user.getInterestCategories().get(1).getKeywords()).hasSize(2);
-        assertThat(user.getInterestCategories().get(2).getKeywords()).hasSize(3);
-        verify(personalizationProfileService).generatePersonalizationProfile(user.getId());
-    }
-
-    @Test
-    @DisplayName("관심사 저장 - 기존 관심사를 clear하고 새로 저장")
-    void saveUserInterests_ClearExistingInterests_Success() {
-        User user = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", null);
-        user.getInterestCategories().add(mock(UserInterestCategory.class));
-        user.getInterestCategories().add(mock(UserInterestCategory.class));
-        assertThat(user.getInterestCategories()).hasSize(2);
-
-        List<UserInterestCommand> interests = List.of(
-                UserInterestCommand.builder().category("FRONTEND").keywords(List.of("REACT")).build()
-        );
-
-        interestCommandService.saveUserInterests(user, interests);
-
-        assertThat(user.getInterestCategories()).hasSize(1);
-        verify(personalizationProfileService).generatePersonalizationProfile(user.getId());
-    }
-
-    @Test
-    @DisplayName("관심사 저장 - 잘못된 카테고리와 키워드 조합이면 예외 발생")
-    void saveUserInterests_InvalidKeywordCategory_ThrowsException() {
-        User user = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", null);
-
+    @DisplayName("관심사 저장 - 잘못된 카테고리와 키워드 조합이면 개인화 프로필 생성을 트리거하지 않는다")
+    void saveUserInterests_InvalidKeywordCategory_SkipsProfileGeneration() {
+        User user = createUserWithId(1L);
         List<UserInterestCommand> interests = List.of(
                 UserInterestCommand.builder().category("BACKEND").keywords(List.of("REACT")).build()
         );
@@ -128,33 +100,29 @@ class InterestCommandServiceTest {
     }
 
     @Test
-    @DisplayName("관심사 업데이트 - 정상 케이스")
+    @DisplayName("관심사 업데이트 - 사용자를 조회해 관심사를 교체하고 개인화 프로필 생성을 트리거한다")
     void updateUserInterests_Success() {
         Long userId = 1L;
-        User mockUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", null);
-        ReflectionTestUtils.setField(mockUser, "id", userId);
-
+        User user = createUserWithId(userId);
         List<UserInterestCommand> interests = List.of(
                 UserInterestCommand.builder().category("AI_ML").keywords(List.of("TENSORFLOW", "PYTORCH")).build()
         );
-
-        given(userRepository.findByIdWithInterestCategories(userId)).willReturn(Optional.of(mockUser));
+        given(userRepository.findByIdWithInterestCategories(userId)).willReturn(Optional.of(user));
 
         interestCommandService.updateUserInterests(new UpdateUserInterestsCommand(userId, interests));
 
-        assertThat(mockUser.getInterestCategories()).hasSize(1);
+        assertThat(user.getInterestCategories()).hasSize(1);
         verify(userRepository).findByIdWithInterestCategories(userId);
         verify(personalizationProfileService).generatePersonalizationProfile(userId);
     }
 
     @Test
-    @DisplayName("관심사 업데이트 - 사용자가 존재하지 않으면 예외 발생")
+    @DisplayName("관심사 업데이트 - 사용자가 존재하지 않으면 예외가 발생하고 개인화 프로필 생성을 트리거하지 않는다")
     void updateUserInterests_UserNotFound_ThrowsException() {
         Long userId = 999L;
         List<UserInterestCommand> interests = List.of(
                 UserInterestCommand.builder().category("BACKEND").keywords(List.of("JAVA")).build()
         );
-
         given(userRepository.findByIdWithInterestCategories(userId)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> interestCommandService.updateUserInterests(new UpdateUserInterestsCommand(userId, interests)))
@@ -162,5 +130,11 @@ class InterestCommandServiceTest {
                 .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
 
         verify(personalizationProfileService, never()).generatePersonalizationProfile(any());
+    }
+
+    private User createUserWithId(Long userId) {
+        User user = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", null);
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
     }
 }

--- a/src/test/java/com/techfork/useraccount/application/command/UserCommandServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/command/UserCommandServiceTest.java
@@ -1,5 +1,9 @@
 package com.techfork.useraccount.application.command;
 
+import com.techfork.useraccount.application.command.input.CompleteOnboardingCommand;
+import com.techfork.useraccount.application.command.input.UpdateAccountProfileCommand;
+import com.techfork.useraccount.application.command.input.UserInterestCommand;
+import com.techfork.useraccount.application.command.input.WithdrawUserCommand;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.enums.UserStatus;

--- a/src/test/java/com/techfork/useraccount/domain/UserTest.java
+++ b/src/test/java/com/techfork/useraccount/domain/UserTest.java
@@ -1,13 +1,21 @@
 package com.techfork.useraccount.domain;
 
+import com.techfork.global.exception.GeneralException;
+import com.techfork.useraccount.domain.enums.EInterestCategory;
+import com.techfork.useraccount.domain.enums.EInterestKeyword;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.enums.UserStatus;
+import com.techfork.useraccount.domain.exception.UserErrorCode;
+import com.techfork.useraccount.domain.vo.UserInterestSelection;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UserTest {
 
@@ -34,6 +42,92 @@ class UserTest {
             assertThat(user.isActive()).isFalse();
             assertThat(user.isWithdrawn()).isFalse();
             assertThat(user.getInterestCategories()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("replaceInterests")
+    class ReplaceInterests {
+
+        @Test
+        @DisplayName("관심사 교체 시 카테고리와 키워드를 함께 조립한다")
+        void replacesInterestsWithCategoriesAndKeywords() {
+            User user = activeUser();
+
+            user.replaceInterests(List.of(
+                    new UserInterestSelection(EInterestCategory.BACKEND, List.of(EInterestKeyword.JAVA, EInterestKeyword.SPRING)),
+                    new UserInterestSelection(EInterestCategory.DATABASE, List.of(EInterestKeyword.MYSQL, EInterestKeyword.REDIS))
+            ));
+
+            assertThat(user.getInterestCategories()).hasSize(2);
+            UserInterestCategory backend = findCategory(user, EInterestCategory.BACKEND);
+            assertThat(backend.getUser()).isSameAs(user);
+            assertThat(backend.getKeywords())
+                    .extracting(UserInterestKeyword::getKeyword)
+                    .containsExactly(EInterestKeyword.JAVA, EInterestKeyword.SPRING);
+            assertThat(backend.getKeywords())
+                    .allSatisfy(keyword -> assertThat(keyword.getUserInterestCategory()).isSameAs(backend));
+
+            UserInterestCategory database = findCategory(user, EInterestCategory.DATABASE);
+            assertThat(database.getKeywords())
+                    .extracting(UserInterestKeyword::getKeyword)
+                    .containsExactly(EInterestKeyword.MYSQL, EInterestKeyword.REDIS);
+        }
+
+        @Test
+        @DisplayName("키워드가 없으면 카테고리만 교체한다")
+        void replacesInterestsWithCategoryOnly() {
+            User user = activeUser();
+
+            user.replaceInterests(List.of(
+                    new UserInterestSelection(EInterestCategory.AI_ML, null)
+            ));
+
+            assertThat(user.getInterestCategories()).hasSize(1);
+            UserInterestCategory aiMl = findCategory(user, EInterestCategory.AI_ML);
+            assertThat(aiMl.getKeywords()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("기존 관심사를 제거하고 새 관심사로 교체한다")
+        void clearsExistingInterestsBeforeReplacing() {
+            User user = activeUser();
+            user.replaceInterests(List.of(
+                    new UserInterestSelection(EInterestCategory.BACKEND, List.of(EInterestKeyword.JAVA, EInterestKeyword.SPRING))
+            ));
+
+            user.replaceInterests(List.of(
+                    new UserInterestSelection(EInterestCategory.FRONTEND, List.of(EInterestKeyword.REACT))
+            ));
+
+            assertThat(user.getInterestCategories())
+                    .extracting(UserInterestCategory::getCategory)
+                    .containsExactly(EInterestCategory.FRONTEND);
+            assertThat(findCategory(user, EInterestCategory.FRONTEND).getKeywords())
+                    .extracting(UserInterestKeyword::getKeyword)
+                    .containsExactly(EInterestKeyword.REACT);
+        }
+
+        @Test
+        @DisplayName("키워드는 선택된 카테고리에 속해야 한다")
+        void rejectsKeywordThatDoesNotBelongToCategory() {
+            User user = activeUser();
+            user.replaceInterests(List.of(
+                    new UserInterestSelection(EInterestCategory.BACKEND, List.of(EInterestKeyword.JAVA))
+            ));
+
+            assertThatThrownBy(() -> user.replaceInterests(List.of(
+                    new UserInterestSelection(EInterestCategory.BACKEND, List.of(EInterestKeyword.REACT))
+            )))
+                    .isInstanceOf(GeneralException.class)
+                    .hasFieldOrPropertyWithValue("code", UserErrorCode.INVALID_INTEREST_KEYWORD);
+
+            assertThat(user.getInterestCategories())
+                    .extracting(UserInterestCategory::getCategory)
+                    .containsExactly(EInterestCategory.BACKEND);
+            assertThat(findCategory(user, EInterestCategory.BACKEND).getKeywords())
+                    .extracting(UserInterestKeyword::getKeyword)
+                    .containsExactly(EInterestKeyword.JAVA);
         }
     }
 
@@ -137,5 +231,12 @@ class UserTest {
         );
         user.updateUser("기존닉네임", "user@example.com", "기존 자기소개");
         return user;
+    }
+
+    private UserInterestCategory findCategory(User user, EInterestCategory category) {
+        return user.getInterestCategories().stream()
+                .filter(interestCategory -> interestCategory.getCategory() == category)
+                .findFirst()
+                .orElseThrow();
     }
 }

--- a/src/test/java/com/techfork/useraccount/domain/UserTest.java
+++ b/src/test/java/com/techfork/useraccount/domain/UserTest.java
@@ -12,9 +12,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UserTest {
@@ -86,6 +88,19 @@ class UserTest {
             assertThat(user.getInterestCategories()).hasSize(1);
             UserInterestCategory aiMl = findCategory(user, EInterestCategory.AI_ML);
             assertThat(aiMl.getKeywords()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("관심사 선택값은 키워드 목록을 빈 불변 리스트로 정규화한다")
+        void interestSelectionNormalizesKeywordsToImmutableList() {
+            List<EInterestKeyword> keywords = new ArrayList<>(List.of(EInterestKeyword.JAVA));
+
+            UserInterestSelection selection = new UserInterestSelection(EInterestCategory.BACKEND, keywords);
+            keywords.add(EInterestKeyword.SPRING);
+
+            assertThat(selection.keywords()).containsExactly(EInterestKeyword.JAVA);
+            assertThatExceptionOfType(UnsupportedOperationException.class)
+                    .isThrownBy(() -> selection.keywords().add(EInterestKeyword.SPRING));
         }
 
         @Test

--- a/src/test/java/com/techfork/useraccount/infrastructure/UserRepositoryTest.java
+++ b/src/test/java/com/techfork/useraccount/infrastructure/UserRepositoryTest.java
@@ -13,7 +13,10 @@ import com.techfork.domain.source.repository.TechBlogRepository;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.UserInterestCategory;
 import com.techfork.useraccount.domain.enums.EInterestCategory;
+import com.techfork.useraccount.domain.enums.EInterestKeyword;
 import com.techfork.useraccount.domain.enums.SocialType;
+import com.techfork.useraccount.domain.vo.UserInterestSelection;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +40,12 @@ class UserRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private UserInterestCategoryRepository userInterestCategoryRepository;
+
+    @Autowired
+    private EntityManager entityManager;
 
     @Autowired
     private ReadPostRepository readPostRepository;
@@ -110,6 +119,43 @@ class UserRepositoryTest {
 
         // Then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("replaceInterests - flush 후 기존 관심사 row를 제거하고 새 관심사 graph를 저장")
+    void replaceInterests_FlushesOrphansAndPersistsNewGraph() {
+        // Given: 기존 관심사 graph 저장
+        testUser.replaceInterests(List.of(
+                new UserInterestSelection(EInterestCategory.BACKEND, List.of(EInterestKeyword.JAVA, EInterestKeyword.SPRING)),
+                new UserInterestSelection(EInterestCategory.DATABASE, List.of(EInterestKeyword.MYSQL))
+        ));
+        userRepository.saveAndFlush(testUser);
+        entityManager.clear();
+
+        List<Long> oldCategoryIds = userInterestCategoryRepository.findByUserIdWithKeywords(testUser.getId()).stream()
+                .map(UserInterestCategory::getId)
+                .toList();
+        List<Long> oldKeywordIds = findKeywordIdsByCategoryIds(oldCategoryIds);
+
+        User user = userRepository.findByIdWithInterestCategories(testUser.getId()).orElseThrow();
+
+        // When: 관심사를 새 graph로 완전히 교체하고 flush/clear
+        user.replaceInterests(List.of(
+                new UserInterestSelection(EInterestCategory.FRONTEND, List.of(EInterestKeyword.REACT))
+        ));
+        userRepository.flush();
+        entityManager.clear();
+
+        // Then: 기존 row는 orphanRemoval로 제거되고 새 graph만 남는다
+        assertThat(countCategoriesByIds(oldCategoryIds)).isZero();
+        assertThat(countKeywordsByIds(oldKeywordIds)).isZero();
+
+        List<UserInterestCategory> categories = userInterestCategoryRepository.findByUserIdWithKeywords(testUser.getId());
+        assertThat(categories).hasSize(1);
+        assertThat(categories.get(0).getCategory()).isEqualTo(EInterestCategory.FRONTEND);
+        assertThat(categories.get(0).getKeywords())
+                .extracting(keyword -> keyword.getKeyword())
+                .containsExactly(EInterestKeyword.REACT);
     }
 
     @Test
@@ -340,5 +386,35 @@ class UserRepositoryTest {
                 .crawledAt(LocalDateTime.now())
                 .techBlog(testTechBlog)
                 .build());
+    }
+
+    private List<Long> findKeywordIdsByCategoryIds(List<Long> categoryIds) {
+        return entityManager.createQuery("""
+                        SELECT keyword.id
+                        FROM UserInterestKeyword keyword
+                        WHERE keyword.userInterestCategory.id IN :categoryIds
+                        """, Long.class)
+                .setParameter("categoryIds", categoryIds)
+                .getResultList();
+    }
+
+    private Long countCategoriesByIds(List<Long> categoryIds) {
+        return entityManager.createQuery("""
+                        SELECT COUNT(category)
+                        FROM UserInterestCategory category
+                        WHERE category.id IN :categoryIds
+                        """, Long.class)
+                .setParameter("categoryIds", categoryIds)
+                .getSingleResult();
+    }
+
+    private Long countKeywordsByIds(List<Long> keywordIds) {
+        return entityManager.createQuery("""
+                        SELECT COUNT(keyword)
+                        FROM UserInterestKeyword keyword
+                        WHERE keyword.id IN :keywordIds
+                        """, Long.class)
+                .setParameter("keywordIds", keywordIds)
+                .getSingleResult();
     }
 }

--- a/src/test/java/com/techfork/useraccount/integration/UserControllerIntegrationTest.java
+++ b/src/test/java/com/techfork/useraccount/integration/UserControllerIntegrationTest.java
@@ -190,6 +190,72 @@ class UserControllerIntegrationTest extends IntegrationTestBase {
                 .andExpect(jsonPath("$.data.profileImage").value("profile.jpg")); // 변경되지 않음
     }
 
+    // ===== 관심사 수정 테스트 =====
+
+    @Test
+    @DisplayName("내 관심사 수정 실패 - 관심사 카테고리는 필수")
+    void updateMyInterests_BlankCategory_BadRequest() throws Exception {
+        String requestBody = """
+                {
+                  "interests": [
+                    {
+                      "category": "",
+                      "keywords": ["JAVA"]
+                    }
+                  ]
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/users/me/interests")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    @DisplayName("내 관심사 수정 실패 - 관심사 항목은 null일 수 없음")
+    void updateMyInterests_NullInterestItem_BadRequest() throws Exception {
+        String requestBody = """
+                {
+                  "interests": [null]
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/users/me/interests")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
+    @Test
+    @DisplayName("내 관심사 수정 실패 - 관심사 키워드는 빈 문자열일 수 없음")
+    void updateMyInterests_BlankKeyword_BadRequest() throws Exception {
+        String requestBody = """
+                {
+                  "interests": [
+                    {
+                      "category": "BACKEND",
+                      "keywords": [""]
+                    }
+                  ]
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/users/me/interests")
+                        .header("Authorization", "Bearer " + accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.isSuccess").value(false));
+    }
+
     // ===== 회원 탈퇴 테스트 =====
 
     @Test

--- a/src/test/java/com/techfork/useraccount/presentation/request/UserInterestRequestValidationTest.java
+++ b/src/test/java/com/techfork/useraccount/presentation/request/UserInterestRequestValidationTest.java
@@ -1,0 +1,102 @@
+package com.techfork.useraccount.presentation.request;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserInterestRequestValidationTest {
+
+    private static ValidatorFactory validatorFactory;
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUpValidator() {
+        validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @AfterAll
+    static void closeValidatorFactory() {
+        validatorFactory.close();
+    }
+
+    @Nested
+    @DisplayName("SaveInterestRequest")
+    class SaveInterestRequestValidation {
+
+        @Test
+        @DisplayName("null 관심사 항목을 허용하지 않는다")
+        void rejectsNullInterestItem() {
+            SaveInterestRequest request = new SaveInterestRequest(Collections.singletonList(null));
+
+            assertThat(validator.validate(request))
+                    .extracting(violation -> violation.getPropertyPath().toString())
+                    .contains("interests[0].<list element>");
+        }
+
+        @Test
+        @DisplayName("빈 카테고리를 허용하지 않는다")
+        void rejectsBlankCategory() {
+            SaveInterestRequest request = new SaveInterestRequest(List.of(
+                    UserInterestRequest.builder()
+                            .category("")
+                            .keywords(List.of("JAVA"))
+                            .build()
+            ));
+
+            assertThat(validator.validate(request))
+                    .extracting(violation -> violation.getPropertyPath().toString())
+                    .contains("interests[0].category");
+        }
+
+        @Test
+        @DisplayName("빈 키워드를 허용하지 않는다")
+        void rejectsBlankKeyword() {
+            SaveInterestRequest request = new SaveInterestRequest(List.of(
+                    UserInterestRequest.builder()
+                            .category("BACKEND")
+                            .keywords(List.of(""))
+                            .build()
+            ));
+
+            assertThat(validator.validate(request))
+                    .extracting(violation -> violation.getPropertyPath().toString())
+                    .contains("interests[0].keywords[0].<list element>");
+        }
+    }
+
+    @Nested
+    @DisplayName("OnboardingRequest")
+    class OnboardingRequestValidation {
+
+        @Test
+        @DisplayName("관심사 항목을 중첩 검증한다")
+        void validatesNestedInterestItem() {
+            OnboardingRequest request = new OnboardingRequest(
+                    "테크포크유저",
+                    "user@techfork.com",
+                    null,
+                    List.of(
+                            UserInterestRequest.builder()
+                                    .category(" ")
+                                    .keywords(List.of("JAVA"))
+                                    .build()
+                    )
+            );
+
+            assertThat(validator.validate(request))
+                    .extracting(violation -> violation.getPropertyPath().toString())
+                    .contains("interests[0].category");
+        }
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

`User` aggregate가 관심사 교체의 핵심 불변식을 소유하도록 리팩토링했습니다.

- `User.replaceInterests(...)`를 추가해 관심 카테고리/키워드 graph 조립과 keyword-category 검증을 aggregate 내부로 이동
- `InterestCommandService`는 command input 해석과 profile trigger orchestration 중심으로 축소
- command record들을 `application.command.input` 패키지로 분리
- 관심사 request nested validation과 enum 변환 실패 400 응답 매핑 보강
- `UserInterestSelection` VO의 keyword list를 불변/방어 복사로 정규화
- JPA flush/clear round-trip 테스트로 기존 관심사 row orphanRemoval 및 새 graph 저장 검증

Swagger 테스트 성공 결과 스크린샷 첨부
- 기능 변경 없는 리팩토링이라 Swagger 스크린샷 대상은 없습니다.
- 아래 CLI 테스트 결과로 검증을 대체했습니다.

```bash
./gradlew test --tests "com.techfork.useraccount.domain.UserTest" \
  --tests "com.techfork.useraccount.application.command.InterestCommandServiceTest" \
  --tests "com.techfork.useraccount.application.command.UserCommandServiceTest" \
  --tests "com.techfork.useraccount.presentation.request.UserInterestRequestValidationTest" \
  --tests "com.techfork.useraccount.infrastructure.UserRepositoryTest"

BUILD SUCCESSFUL
```

<br>

## 연결된 issue

close #397 

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] `UserInterestSelection`은 aggregate 입력 VO라 `domain.vo`에 유지했습니다.
- [ ] 중복 카테고리/키워드 정책은 기존 동작을 유지했습니다.
- [ ] Personalization profile trigger after-commit seam은 후속 이슈 #398에서 다루는 전제로 남겼습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (CLI 테스트 결과로 대체)
- [x] 이슈넘버를 적었는가?
