### PR TITLE
[test/#407] Personalization Profile 리팩터링 안전망 보강

### DIFF
--- a/src/test/java/com/techfork/domain/personalization/service/PersonalizationProfileServiceTest.java
+++ b/src/test/java/com/techfork/domain/personalization/service/PersonalizationProfileServiceTest.java
@@ -28,6 +28,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -159,6 +160,10 @@ class PersonalizationProfileServiceTest {
 
         verify(userRepository).findById(userId);
         verify(recommendationService).generateRecommendationsForUser(user);
+        verify(userInterestCategoryRepository).findByUserIdWithKeywords(userId);
+        verify(readPostRepository).findRecentReadPostsByUserIdWithMinDuration(userId, PageRequest.of(0, 20));
+        verify(bookmarkRepository).findRecentBookmarksByUserId(userId, PageRequest.of(0, 20));
+        verify(searchHistoryRepository).findRecentSearchHistoriesByUserId(userId, PageRequest.of(0, 30));
     }
 
     @Test
@@ -187,6 +192,38 @@ class PersonalizationProfileServiceTest {
         assertThat(savedDocument.getProfileText()).isEqualTo(llmResponse);
         assertThat(savedDocument.getKeyKeywords()).isEmpty();
         assertThat(savedDocument.getProfileVector()).containsExactly(1.0f, 2.0f);
+    }
+
+    @Test
+    @DisplayName("LLM 응답의 핵심 키워드는 최대 5개까지만 저장한다")
+    void generatePersonalizationProfileSync_LimitsKeyKeywordsToFive() {
+        Long userId = 4L;
+        User user = createUser(userId);
+
+        given(userInterestCategoryRepository.findByUserIdWithKeywords(userId)).willReturn(List.of());
+        given(readPostRepository.findRecentReadPostsByUserIdWithMinDuration(anyLong(), any())).willReturn(List.of());
+        given(bookmarkRepository.findRecentBookmarksByUserId(anyLong(), any())).willReturn(List.of());
+        given(searchHistoryRepository.findRecentSearchHistoriesByUserId(anyLong(), any())).willReturn(List.of());
+        given(llmClient.call(anyString(), anyString()))
+                .willReturn("""
+                        ### PROFILE
+                        Java와 Spring 기반 백엔드 성능 최적화에 집중하는 사용자
+
+                        ### KEYWORDS
+                        Java, Spring, JPA, Redis, Kafka, Kubernetes, Elasticsearch
+                        """);
+        given(embeddingClient.embed(anyString())).willReturn(List.of(0.4f, 0.5f));
+        given(personalizationProfileDocumentRepository.save(any(PersonalizationProfileDocument.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        personalizationProfileService.generatePersonalizationProfileSync(userId);
+
+        ArgumentCaptor<PersonalizationProfileDocument> documentCaptor = ArgumentCaptor.forClass(PersonalizationProfileDocument.class);
+        verify(personalizationProfileDocumentRepository).save(documentCaptor.capture());
+
+        assertThat(documentCaptor.getValue().getKeyKeywords())
+                .containsExactly("Java", "Spring", "JPA", "Redis", "Kafka");
     }
 
     @Test

--- a/src/test/java/com/techfork/domain/recommendation/service/LlmRecommendationServiceTest.java
+++ b/src/test/java/com/techfork/domain/recommendation/service/LlmRecommendationServiceTest.java
@@ -1,28 +1,48 @@
 package com.techfork.domain.recommendation.service;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.util.ObjectBuilder;
 import com.techfork.activity.readpost.infrastructure.ReadPostRepository;
+import com.techfork.domain.personalization.document.PersonalizationProfileDocument;
+import com.techfork.domain.personalization.repository.PersonalizationProfileDocumentRepository;
 import com.techfork.global.elasticsearch.query.VectorQueryBuilder;
 import com.techfork.post.domain.projection.PostDocument;
 import com.techfork.domain.recommendation.config.RecommendationProperties;
 import com.techfork.domain.recommendation.repository.RecommendedPostRepository;
 import com.techfork.domain.recommendation.repository.RecommendationHistoryRepository;
-import com.techfork.domain.personalization.repository.PersonalizationProfileDocumentRepository;
+import com.techfork.post.domain.Post;
 import com.techfork.post.infrastructure.PostRepository;
 import com.techfork.global.util.TimeDecayStrategy;
+import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.domain.enums.SocialType;
+import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -76,6 +96,96 @@ class LlmRecommendationServiceTest {
                 vectorQueryBuilder,
                 Runnable::run
         );
+    }
+
+    @Test
+    @DisplayName("추천 생성은 PersonalizationProfileDocument projection의 벡터와 핵심 키워드로 후보를 검색한다")
+    void generateRecommendationsForUser_UsesPersonalizationProfileProjectionVectorAndKeywords() throws IOException {
+        Long userId = 9L;
+        User user = createUser(userId);
+        float[] profileVector = new float[]{0.1f, 0.2f};
+        PersonalizationProfileDocument personalizationProfile = PersonalizationProfileDocument.create(
+                userId,
+                "Spring과 JPA 기반 백엔드 성능 개선에 관심이 높은 사용자",
+                profileVector,
+                List.of("Backend"),
+                List.of("Spring", "JPA")
+        );
+        Query filterQuery = Query.of(query -> query.matchAll(matchAll -> matchAll));
+        Query bm25Query = Query.of(query -> query.matchAll(matchAll -> matchAll));
+        PostDocument vectorDocument = postDocument(
+                501L,
+                List.of(0.1f, 0.2f),
+                List.of(0.3f, 0.4f),
+                LocalDateTime.of(2026, 5, 4, 9, 0)
+        );
+        PostDocument keywordDocument = postDocument(
+                502L,
+                List.of(0.5f, 0.6f),
+                List.of(0.7f, 0.8f),
+                LocalDateTime.of(2026, 5, 5, 9, 0)
+        );
+        Post recommendedPost = mock(Post.class);
+
+        given(personalizationProfileDocumentRepository.findByUserId(userId))
+                .willReturn(Optional.of(personalizationProfile));
+        given(readPostRepository.findRecentReadPostsByUserIdWithMinDuration(userId, PageRequest.of(0, 1000)))
+                .willReturn(List.of());
+        given(vectorQueryBuilder.createExcludeFilter(Set.of())).willReturn(filterQuery);
+        given(vectorQueryBuilder.createKnnSearches(
+                eq("titleEmbedding"),
+                eq("summaryEmbedding"),
+                eq("contentChunks.embedding"),
+                same(profileVector),
+                eq(0.6f),
+                eq(0.2f),
+                eq(0.2f),
+                eq(50),
+                eq(150),
+                same(filterQuery)
+        )).willReturn(List.of());
+        given(vectorQueryBuilder.createBm25Query(List.of("Spring", "JPA"), 0.6f, 0.2f, 0.2f))
+                .willReturn(bm25Query);
+        given(elasticsearchClient.search(searchRequestBuilder(), eq(PostDocument.class)))
+                .willReturn(
+                        searchResponse(hit("501", 9.0, vectorDocument)),
+                        searchResponse(hit("502", 7.0, keywordDocument))
+                );
+        given(timeDecayStrategy.calculateWeight(any())).willReturn(1.0);
+        given(mmrService.applyMmr(anyList()))
+                .willReturn(List.of(MmrService.MmrResult.builder()
+                        .postId(501L)
+                        .similarityScore(0.9)
+                        .mmrScore(0.8)
+                        .rank(1)
+                        .build()));
+        given(recommendedPostRepository.findByUserOrderByRankAsc(user)).willReturn(List.of());
+        given(postRepository.getReferenceById(501L)).willReturn(recommendedPost);
+        given(recommendedPostRepository.saveAll(anyList())).willAnswer(invocation -> invocation.getArgument(0));
+
+        int createdCount = llmRecommendationService.generateRecommendationsForUser(user);
+
+        assertThat(createdCount).isEqualTo(1);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<MmrService.MmrCandidate>> candidatesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(mmrService).applyMmr(candidatesCaptor.capture());
+        assertThat(candidatesCaptor.getValue())
+                .extracting(MmrService.MmrCandidate::getPostId)
+                .containsExactly(501L, 502L);
+        verify(personalizationProfileDocumentRepository, times(2)).findByUserId(userId);
+        verify(vectorQueryBuilder).createKnnSearches(
+                eq("titleEmbedding"),
+                eq("summaryEmbedding"),
+                eq("contentChunks.embedding"),
+                same(profileVector),
+                eq(0.6f),
+                eq(0.2f),
+                eq(0.2f),
+                eq(50),
+                eq(150),
+                same(filterQuery)
+        );
+        verify(vectorQueryBuilder).createBm25Query(List.of("Spring", "JPA"), 0.6f, 0.2f, 0.2f);
     }
 
     @Test
@@ -157,6 +267,24 @@ class LlmRecommendationServiceTest {
         verify(timeDecayStrategy).calculateWeight(document.getPublishedAt());
     }
 
+    @SuppressWarnings("unchecked")
+    private Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>> searchRequestBuilder() {
+        return (Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>>) any();
+    }
+
+    private SearchResponse<PostDocument> searchResponse(Hit<PostDocument> hit) {
+        return SearchResponse.of(response -> response
+                .took(1)
+                .timedOut(false)
+                .shards(shards -> shards
+                        .total(1)
+                        .successful(1)
+                        .failed(0)
+                )
+                .hits(hits -> hits.hits(hit))
+        );
+    }
+
     private Hit<PostDocument> hit(String id, double score, PostDocument document) {
         return Hit.of(hit -> hit
                 .id(id)
@@ -187,5 +315,11 @@ class LlmRecommendationServiceTest {
                 .summaryEmbedding(summaryEmbedding)
                 .contentChunks(List.of())
                 .build();
+    }
+
+    private User createUser(Long userId) {
+        User user = User.createSocialUser(SocialType.KAKAO, "social-" + userId, "user" + userId + "@example.com", null);
+        ReflectionTestUtils.setField(user, "id", userId);
+        return user;
     }
 }

--- a/src/test/java/com/techfork/domain/search/service/SearchServiceImplTest.java
+++ b/src/test/java/com/techfork/domain/search/service/SearchServiceImplTest.java
@@ -6,10 +6,11 @@ import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.util.ObjectBuilder;
 import com.techfork.activity.bookmark.infrastructure.BookmarkRepository;
+import com.techfork.domain.personalization.document.PersonalizationProfileDocument;
+import com.techfork.domain.personalization.repository.PersonalizationProfileDocumentRepository;
 import com.techfork.post.domain.Post;
 import com.techfork.post.domain.projection.PostDocument;
 import com.techfork.post.infrastructure.PostRepository;
-import com.techfork.domain.personalization.repository.PersonalizationProfileDocumentRepository;
 import com.techfork.domain.search.config.GeneralSearchProperties;
 import com.techfork.domain.search.dto.SearchResult;
 import com.techfork.global.llm.EmbeddingClient;
@@ -17,6 +18,7 @@ import com.techfork.global.util.CloudflareThirdPartyThumbnailOptimizer;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -82,8 +84,8 @@ class SearchServiceImplTest {
         given(metadataPost.getId()).willReturn(10L);
         given(metadataPost.getViewCount()).willReturn(321L);
         given(postRepository.findAllById(List.of(10L))).willReturn(List.of(metadataPost));
-        given(thumbnailOptimizer.optimize("https://cdn.example.com/thumb.png"))
-                .willReturn("https://cdn.example.com/thumb.optimized.png");
+        given(thumbnailOptimizer.optimize("https://cdn.example.com/thumb-10.png"))
+                .willReturn("https://cdn.example.com/thumb-10.optimized.png");
 
         List<SearchResult> results = searchService.searchGeneral("spring batch");
 
@@ -94,7 +96,7 @@ class SearchServiceImplTest {
         assertThat(result.getSummary()).isEqualTo("배치 처리 요약");
         assertThat(result.getShortSummary()).isEqualTo("짧은 요약");
         assertThat(result.getCompanyName()).isEqualTo("TechFork");
-        assertThat(result.getThumbnailUrl()).isEqualTo("https://cdn.example.com/thumb.optimized.png");
+        assertThat(result.getThumbnailUrl()).isEqualTo("https://cdn.example.com/thumb-10.optimized.png");
         assertThat(result.getViewCount()).isEqualTo(321L);
         assertThat(result.getIsBookmarked()).isFalse();
         assertThat(result.getTitleVector()).isNull();
@@ -104,12 +106,87 @@ class SearchServiceImplTest {
         verify(bookmarkRepository, never()).findBookmarkedPostIds(any(), any());
     }
 
+    @Test
+    @DisplayName("개인화 검색은 PersonalizationProfileDocument projection 벡터로 검색 결과를 재정렬한다")
+    void searchPersonalized_ReranksWithPersonalizationProfileProjection() throws IOException {
+        Long userId = 7L;
+        GeneralSearchProperties properties = new GeneralSearchProperties();
+        properties.setSearchSize(2);
+        properties.setRRF_WINDOW_SIZE(2);
+        properties.setHybridScoreWeight(0.0);
+        properties.setPersonalScoreWeight(1.0);
+        properties.setRerankDocumentTitleWeight(1.0);
+        properties.setRerankDocumentSummaryWeight(0.0);
+        SearchServiceImpl searchService = new SearchServiceImpl(
+                elasticsearchClient,
+                embeddingClient,
+                properties,
+                personalizationProfileDocumentRepository,
+                postRepository,
+                bookmarkRepository,
+                Runnable::run,
+                thumbnailOptimizer
+        );
+
+        PersonalizationProfileDocument personalizationProfile = PersonalizationProfileDocument.create(
+                userId,
+                "Kubernetes 운영 자동화에 관심이 높은 사용자",
+                new float[]{0.0f, 1.0f},
+                List.of("DevOps"),
+                List.of("Kubernetes", "운영 자동화")
+        );
+        PostDocument lessRelevantDocument = postDocument(10L, "Java 튜닝", List.of(1.0f, 0.0f), List.of(1.0f, 0.0f));
+        PostDocument moreRelevantDocument = postDocument(20L, "Kubernetes 운영", List.of(0.0f, 1.0f), List.of(0.0f, 1.0f));
+        SearchResponse<PostDocument> lexicalResponse = searchResponse(
+                hit("10", 9.0, lessRelevantDocument),
+                hit("20", 8.0, moreRelevantDocument)
+        );
+        SearchResponse<PostDocument> semanticResponse = searchResponse(
+                hit("10", 7.0, lessRelevantDocument),
+                hit("20", 6.0, moreRelevantDocument)
+        );
+        Post lessRelevantPost = metadataPost(10L, 10L);
+        Post moreRelevantPost = metadataPost(20L, 20L);
+
+        given(personalizationProfileDocumentRepository.findByUserId(userId))
+                .willReturn(Optional.of(personalizationProfile));
+        given(elasticsearchClient.search(searchRequestBuilder(), eq(PostDocument.class)))
+                .willReturn(lexicalResponse, semanticResponse);
+        given(embeddingClient.embed("kubernetes")).willReturn(List.of(0.0f, 1.0f));
+        given(postRepository.findAllById(List.of(20L, 10L)))
+                .willReturn(List.of(moreRelevantPost, lessRelevantPost));
+        given(bookmarkRepository.findBookmarkedPostIds(userId, List.of(20L, 10L)))
+                .willReturn(List.of(20L));
+        given(thumbnailOptimizer.optimize("https://cdn.example.com/thumb-10.png"))
+                .willReturn("https://cdn.example.com/thumb-10.optimized.png");
+        given(thumbnailOptimizer.optimize("https://cdn.example.com/thumb-20.png"))
+                .willReturn("https://cdn.example.com/thumb-20.optimized.png");
+
+        List<SearchResult> results = searchService.searchPersonalized("kubernetes", userId);
+
+        assertThat(results)
+                .extracting(SearchResult::getPostId)
+                .containsExactly(20L, 10L);
+        assertThat(results.get(0).getPersonalScore()).isGreaterThan(results.get(1).getPersonalScore());
+        assertThat(results.get(0).getIsBookmarked()).isTrue();
+        assertThat(results.get(1).getIsBookmarked()).isFalse();
+        assertThat(results)
+                .allSatisfy(result -> {
+                    assertThat(result.getTitleVector()).isNull();
+                    assertThat(result.getSummaryVector()).isNull();
+                });
+
+        verify(personalizationProfileDocumentRepository).findByUserId(userId);
+        verify(bookmarkRepository).findBookmarkedPostIds(userId, List.of(20L, 10L));
+    }
+
     @SuppressWarnings("unchecked")
     private Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>> searchRequestBuilder() {
         return (Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>>) any();
     }
 
-    private SearchResponse<PostDocument> searchResponse(Hit<PostDocument> hit) {
+    @SafeVarargs
+    private final SearchResponse<PostDocument> searchResponse(Hit<PostDocument>... hits) {
         return SearchResponse.of(response -> response
                 .took(1)
                 .timedOut(false)
@@ -118,7 +195,7 @@ class SearchServiceImplTest {
                         .successful(1)
                         .failed(0)
                 )
-                .hits(hits -> hits.hits(hit))
+                .hits(searchHits -> searchHits.hits(List.of(hits)))
         );
     }
 
@@ -132,20 +209,41 @@ class SearchServiceImplTest {
     }
 
     private PostDocument postDocument(Long postId) {
+        return postDocument(
+                postId,
+                "Spring Batch 정리",
+                List.of(0.11f, 0.22f),
+                List.of(0.33f, 0.44f)
+        );
+    }
+
+    private PostDocument postDocument(
+            Long postId,
+            String title,
+            List<Float> titleEmbedding,
+            List<Float> summaryEmbedding
+    ) {
         return PostDocument.builder()
                 .id(String.valueOf(postId))
                 .postId(postId)
-                .title("Spring Batch 정리")
+                .title(title)
                 .summary("배치 처리 요약")
                 .shortSummary("짧은 요약")
                 .company("TechFork")
                 .url("https://posts.example.com/" + postId)
                 .logoUrl("https://cdn.example.com/logo.png")
-                .thumbnailUrl("https://cdn.example.com/thumb.png")
+                .thumbnailUrl("https://cdn.example.com/thumb-" + postId + ".png")
                 .publishedAtString(LocalDateTime.of(2026, 5, 1, 10, 0).toString())
-                .titleEmbedding(List.of(0.11f, 0.22f))
-                .summaryEmbedding(List.of(0.33f, 0.44f))
+                .titleEmbedding(titleEmbedding)
+                .summaryEmbedding(summaryEmbedding)
                 .contentChunks(List.of())
                 .build();
+    }
+
+    private Post metadataPost(Long postId, Long viewCount) {
+        Post post = mock(Post.class);
+        given(post.getId()).willReturn(postId);
+        given(post.getViewCount()).willReturn(viewCount);
+        return post;
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명

Personalization Profile 컨텍스트를 최상위 도메인으로 승격하기 전에, 기존 동작과 Search/Recommendation 의존 경로를 테스트로 고정했습니다.

- `PersonalizationProfileServiceTest` 기준 안전망 보강
  - 활동 데이터 조회 범위 검증
  - LLM 핵심 키워드 최대 5개 저장 정책 검증
- `SearchServiceImplTest` 보강
  - 개인화 검색이 `PersonalizationProfileDocument.profileVector`로 rerank하는 경로 검증
- `LlmRecommendationServiceTest` 보강
  - 추천 생성이 `PersonalizationProfileDocument.profileVector/keyKeywords`를 후보 검색 입력으로 사용하는 경로 검증

테스트 결과:
```bash
./gradlew test --tests '*PersonalizationProfileServiceTest' --tests '*PersonalizationProfileEventListenerTest' --tests '*SearchServiceImplTest' --tests '*LlmRecommendationServiceTest'
# BUILD SUCCESSFUL

git diff --check
# 통과
```

<br>

## 연결된 issue

close #407

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] #408 패키지 승격 전에 Search/Recommendation 쪽 `PersonalizationProfileDocument` 의존 경로가 충분히 고정되었는지 확인해주세요.
- [ ] 테스트만 변경한 PR이며 운영 코드 동작 변경은 없습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? *(CLI 테스트 결과를 본문에 첨부)*
- [x] 이슈넘버를 적었는가?
