### PR TITLE
[refactor/#410] 프로필 생성 후 추천 트리거 이벤트 분리

### DIFF
--- a/src/main/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListener.java
+++ b/src/main/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListener.java
@@ -1,0 +1,35 @@
+package com.techfork.domain.recommendation.listener;
+
+import com.techfork.domain.recommendation.service.RecommendationService;
+import com.techfork.personalization.application.event.PersonalizedProfileGeneratedEvent;
+import com.techfork.useraccount.application.query.lookup.UserLookupService;
+import com.techfork.useraccount.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PersonalizedProfileGeneratedEventListener {
+
+    private final UserLookupService userLookupService;
+    private final RecommendationService recommendationService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(PersonalizedProfileGeneratedEvent event) {
+        Long userId = event.userId();
+
+        try {
+            User user = userLookupService.getUserOrThrow(userId);
+            int recommendationCount = recommendationService.generateRecommendationsForUser(user);
+
+            log.info("Recommendations generated after personalization profile creation for userId: {} - {} recommendations created",
+                    userId, recommendationCount);
+        } catch (Exception e) {
+            log.error("Failed to generate recommendations after personalization profile creation for userId: {}", userId, e);
+        }
+    }
+}

--- a/src/main/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListener.java
+++ b/src/main/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListener.java
@@ -24,7 +24,11 @@ public class PersonalizedProfileGeneratedEventListener {
 
         try {
             User user = userLookupService.getUserOrThrow(userId);
-            int recommendationCount = recommendationService.generateRecommendationsForUser(user);
+            int recommendationCount = recommendationService.generateRecommendationsForUser(
+                    user,
+                    event.profileVector(),
+                    event.keyKeywords()
+            );
 
             log.info("Recommendations generated after personalization profile creation for userId: {} - {} recommendations created",
                     userId, recommendationCount);

--- a/src/main/java/com/techfork/domain/recommendation/service/LlmRecommendationService.java
+++ b/src/main/java/com/techfork/domain/recommendation/service/LlmRecommendationService.java
@@ -67,8 +67,6 @@ public class LlmRecommendationService implements RecommendationService {
 
     @Override
     public int generateRecommendationsForUser(User user) {
-        log.info("사용자 {} 추천 생성 시작", user.getId());
-
         Optional<PersonalizationProfileDocument> personalizationProfileOpt =
                 personalizationProfileDocumentRepository.findByUserId(user.getId());
         if (personalizationProfileOpt.isEmpty() || personalizationProfileOpt.get().getProfileVector() == null) {
@@ -77,11 +75,27 @@ public class LlmRecommendationService implements RecommendationService {
         }
 
         PersonalizationProfileDocument personalizationProfile = personalizationProfileOpt.get();
-        float[] personalizationProfileVector = personalizationProfile.getProfileVector();
+        return generateRecommendationsForUser(
+                user,
+                personalizationProfile.getProfileVector(),
+                personalizationProfile.getKeyKeywords()
+        );
+    }
+
+    @Override
+    public int generateRecommendationsForUser(User user, float[] personalizationProfileVector, List<String> keyKeywords) {
+        log.info("사용자 {} 추천 생성 시작", user.getId());
+
+        if (personalizationProfileVector == null) {
+            log.warn("사용자 {}의 개인화 프로필 벡터를 찾을 수 없음. 추천 생성 스킵.", user.getId());
+            return 0;
+        }
+
+        List<String> safeKeyKeywords = keyKeywords == null ? List.of() : keyKeywords;
 
         try {
             // 2. k-NN 검색으로 초기 후보군 가져오기
-            List<MmrCandidate> candidates = searchCandidates(personalizationProfileVector, user);
+            List<MmrCandidate> candidates = searchCandidates(personalizationProfileVector, safeKeyKeywords, user);
 
             if (candidates.isEmpty()) {
                 log.info("사용자 {}의 추천 후보군을 찾을 수 없음", user.getId());
@@ -119,17 +133,15 @@ public class LlmRecommendationService implements RecommendationService {
         }
     }
 
-    private List<MmrCandidate> searchCandidates(float[] personalizationProfileVector, User user) throws IOException {
+    private List<MmrCandidate> searchCandidates(
+            float[] personalizationProfileVector,
+            List<String> keyKeywords,
+            User user
+    ) throws IOException {
         Set<Long> readPostIds = readPostRepository.findRecentReadPostsByUserIdWithMinDuration(user.getId(), PageRequest.of(0, 1000))
                 .stream()
                 .map(readPost -> readPost.getPost().getId())
                 .collect(Collectors.toSet());
-
-        Optional<PersonalizationProfileDocument> personalizationProfileOpt =
-                personalizationProfileDocumentRepository.findByUserId(user.getId());
-        List<String> keyKeywords = personalizationProfileOpt
-                .map(PersonalizationProfileDocument::getKeyKeywords)
-                .orElse(List.of());
 
         RecommendationProperties.EmbeddingWeights weights = properties.getEmbeddingWeights();
         Query filterQuery = vectorQueryBuilder.createExcludeFilter(readPostIds);

--- a/src/main/java/com/techfork/domain/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/techfork/domain/recommendation/service/RecommendationService.java
@@ -1,6 +1,7 @@
 package com.techfork.domain.recommendation.service;
 
 import com.techfork.useraccount.domain.User;
+import java.util.List;
 
 /**
  * 추천 전략 인터페이스
@@ -15,4 +16,17 @@ public interface RecommendationService {
      * @return 생성된 추천 개수
      */
     int generateRecommendationsForUser(User user);
+
+    /**
+     * 사용자별 개인화 추천 게시글 생성
+     *
+     * <p>이미 생성된 개인화 프로필 스냅샷을 기반으로 추천을 생성합니다.
+     * 프로필 저장 직후 이벤트 소비자가 Elasticsearch refresh 이전 검색 가시성에 의존하지 않도록 사용합니다.</p>
+     *
+     * @param user 추천 대상 사용자
+     * @param personalizationProfileVector 개인화 프로필 벡터
+     * @param keyKeywords 개인화 프로필 핵심 키워드
+     * @return 생성된 추천 개수
+     */
+    int generateRecommendationsForUser(User user, float[] personalizationProfileVector, List<String> keyKeywords);
 }

--- a/src/main/java/com/techfork/personalization/application/PersonalizationProfileService.java
+++ b/src/main/java/com/techfork/personalization/application/PersonalizationProfileService.java
@@ -2,6 +2,7 @@ package com.techfork.personalization.application;
 
 import com.techfork.personalization.application.event.PersonalizedProfileGeneratedEvent;
 import com.techfork.personalization.application.generation.PersonalizedProfileGenerator;
+import com.techfork.personalization.infrastructure.PersonalizationProfileDocument;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,8 +31,12 @@ public class PersonalizationProfileService {
     @Transactional
     public void generatePersonalizationProfileSync(Long userId) {
         try {
-            personalizedProfileGenerator.generate(userId);
-            eventPublisher.publishEvent(new PersonalizedProfileGeneratedEvent(userId));
+            PersonalizationProfileDocument profileDocument = personalizedProfileGenerator.generate(userId);
+            eventPublisher.publishEvent(new PersonalizedProfileGeneratedEvent(
+                    userId,
+                    profileDocument.getProfileVector(),
+                    profileDocument.getKeyKeywords()
+            ));
 
             log.info("Personalization profile generated successfully for userId: {}", userId);
 

--- a/src/main/java/com/techfork/personalization/application/PersonalizationProfileService.java
+++ b/src/main/java/com/techfork/personalization/application/PersonalizationProfileService.java
@@ -1,11 +1,10 @@
 package com.techfork.personalization.application;
 
-import com.techfork.domain.recommendation.service.RecommendationService;
-import com.techfork.useraccount.domain.User;
+import com.techfork.personalization.application.event.PersonalizedProfileGeneratedEvent;
 import com.techfork.personalization.application.generation.PersonalizedProfileGenerator;
-import com.techfork.useraccount.application.query.lookup.UserLookupService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,8 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PersonalizationProfileService {
 
     private final PersonalizedProfileGenerator personalizedProfileGenerator;
-    private final UserLookupService userLookupService;
-    private final RecommendationService recommendationService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Async
     @Transactional
@@ -33,32 +31,13 @@ public class PersonalizationProfileService {
     public void generatePersonalizationProfileSync(Long userId) {
         try {
             personalizedProfileGenerator.generate(userId);
+            eventPublisher.publishEvent(new PersonalizedProfileGeneratedEvent(userId));
 
             log.info("Personalization profile generated successfully for userId: {}", userId);
-
-            generateRecommendationsAfterProfile(userId);
 
         } catch (Exception e) {
             log.error("Failed to generate personalization profile for userId: {}", userId, e);
             throw e;
-        }
-    }
-
-    /**
-     * 개인화 프로필 생성 완료 후 추천 생성
-     * 온보딩 또는 관심사 변경 시 새 개인화 프로필 기반으로 추천을 갱신합니다.
-     */
-    private void generateRecommendationsAfterProfile(Long userId) {
-        try {
-            User user = userLookupService.getUserOrThrow(userId);
-
-            int recommendationCount = recommendationService.generateRecommendationsForUser(user);
-
-            log.info("Recommendations generated after personalization profile creation for userId: {} - {} recommendations created",
-                    userId, recommendationCount);
-
-        } catch (Exception e) {
-            log.error("Failed to generate recommendations after personalization profile creation for userId: {}", userId, e);
         }
     }
 }

--- a/src/main/java/com/techfork/personalization/application/event/PersonalizedProfileGeneratedEvent.java
+++ b/src/main/java/com/techfork/personalization/application/event/PersonalizedProfileGeneratedEvent.java
@@ -1,0 +1,6 @@
+package com.techfork.personalization.application.event;
+
+public record PersonalizedProfileGeneratedEvent(
+        Long userId
+) {
+}

--- a/src/main/java/com/techfork/personalization/application/event/PersonalizedProfileGeneratedEvent.java
+++ b/src/main/java/com/techfork/personalization/application/event/PersonalizedProfileGeneratedEvent.java
@@ -1,6 +1,19 @@
 package com.techfork.personalization.application.event;
 
+import java.util.List;
+
 public record PersonalizedProfileGeneratedEvent(
-        Long userId
+        Long userId,
+        float[] profileVector,
+        List<String> keyKeywords
 ) {
+    public PersonalizedProfileGeneratedEvent {
+        profileVector = profileVector == null ? null : profileVector.clone();
+        keyKeywords = keyKeywords == null ? List.of() : List.copyOf(keyKeywords);
+    }
+
+    @Override
+    public float[] profileVector() {
+        return profileVector == null ? null : profileVector.clone();
+    }
 }

--- a/src/test/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListenerTest.java
+++ b/src/test/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListenerTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class PersonalizedProfileGeneratedEventListenerTest {
@@ -59,6 +60,20 @@ class PersonalizedProfileGeneratedEventListenerTest {
 
         verify(userLookupService).getUserOrThrow(userId);
         verify(recommendationService).generateRecommendationsForUser(user);
+    }
+
+    @Test
+    @DisplayName("사용자 조회가 실패해도 예외를 전파하지 않고 추천을 시도하지 않는다")
+    void handle_UserLookupFailureDoesNotPropagateExceptionAndSkipsRecommendation() {
+        Long userId = 3L;
+        given(userLookupService.getUserOrThrow(userId))
+                .willThrow(new RuntimeException("user lookup failure"));
+
+        assertThatCode(() -> listener.handle(new PersonalizedProfileGeneratedEvent(userId)))
+                .doesNotThrowAnyException();
+
+        verify(userLookupService).getUserOrThrow(userId);
+        verifyNoInteractions(recommendationService);
     }
 
     @Test

--- a/src/test/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListenerTest.java
+++ b/src/test/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListenerTest.java
@@ -1,0 +1,74 @@
+package com.techfork.domain.recommendation.listener;
+
+import com.techfork.domain.recommendation.service.RecommendationService;
+import com.techfork.personalization.application.event.PersonalizedProfileGeneratedEvent;
+import com.techfork.useraccount.application.query.lookup.UserLookupService;
+import com.techfork.useraccount.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PersonalizedProfileGeneratedEventListenerTest {
+
+    @Mock
+    private UserLookupService userLookupService;
+
+    @Mock
+    private RecommendationService recommendationService;
+
+    @InjectMocks
+    private PersonalizedProfileGeneratedEventListener listener;
+
+    @Test
+    @DisplayName("프로필 생성 이벤트를 받으면 추천을 생성한다")
+    void handle_GeneratesRecommendationsWhenProfileGeneratedEventIsReceived() {
+        Long userId = 1L;
+        User user = mock(User.class);
+        given(userLookupService.getUserOrThrow(userId)).willReturn(user);
+        given(recommendationService.generateRecommendationsForUser(user)).willReturn(5);
+
+        listener.handle(new PersonalizedProfileGeneratedEvent(userId));
+
+        verify(userLookupService).getUserOrThrow(userId);
+        verify(recommendationService).generateRecommendationsForUser(user);
+    }
+
+    @Test
+    @DisplayName("추천 생성이 실패해도 예외를 전파하지 않는다")
+    void handle_RecommendationFailureDoesNotPropagateException() {
+        Long userId = 2L;
+        User user = mock(User.class);
+        given(userLookupService.getUserOrThrow(userId)).willReturn(user);
+        given(recommendationService.generateRecommendationsForUser(user))
+                .willThrow(new RuntimeException("recommendation failure"));
+
+        assertThatCode(() -> listener.handle(new PersonalizedProfileGeneratedEvent(userId)))
+                .doesNotThrowAnyException();
+
+        verify(userLookupService).getUserOrThrow(userId);
+        verify(recommendationService).generateRecommendationsForUser(user);
+    }
+
+    @Test
+    @DisplayName("프로필 생성 이벤트 리스너는 AFTER_COMMIT 단계에서 실행된다")
+    void listenerMethod_RunsAfterCommit() throws NoSuchMethodException {
+        TransactionalEventListener annotation = PersonalizedProfileGeneratedEventListener.class
+                .getDeclaredMethod("handle", PersonalizedProfileGeneratedEvent.class)
+                .getAnnotation(TransactionalEventListener.class);
+
+        assertThat(annotation).isNotNull();
+        assertThat(annotation.phase()).isEqualTo(TransactionPhase.AFTER_COMMIT);
+    }
+}

--- a/src/test/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListenerTest.java
+++ b/src/test/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListenerTest.java
@@ -13,8 +13,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -37,13 +43,23 @@ class PersonalizedProfileGeneratedEventListenerTest {
     void handle_GeneratesRecommendationsWhenProfileGeneratedEventIsReceived() {
         Long userId = 1L;
         User user = mock(User.class);
+        float[] profileVector = new float[]{0.1f, 0.2f};
+        List<String> keyKeywords = List.of("Spring", "JPA");
         given(userLookupService.getUserOrThrow(userId)).willReturn(user);
-        given(recommendationService.generateRecommendationsForUser(user)).willReturn(5);
+        given(recommendationService.generateRecommendationsForUser(
+                eq(user),
+                any(float[].class),
+                eq(keyKeywords)
+        )).willReturn(5);
 
-        listener.handle(new PersonalizedProfileGeneratedEvent(userId));
+        listener.handle(new PersonalizedProfileGeneratedEvent(userId, profileVector, keyKeywords));
 
         verify(userLookupService).getUserOrThrow(userId);
-        verify(recommendationService).generateRecommendationsForUser(user);
+        verify(recommendationService).generateRecommendationsForUser(
+                eq(user),
+                argThat(vector -> Arrays.equals(vector, profileVector)),
+                eq(keyKeywords)
+        );
     }
 
     @Test
@@ -51,15 +67,25 @@ class PersonalizedProfileGeneratedEventListenerTest {
     void handle_RecommendationFailureDoesNotPropagateException() {
         Long userId = 2L;
         User user = mock(User.class);
+        float[] profileVector = new float[]{0.1f, 0.2f};
+        List<String> keyKeywords = List.of("Spring", "JPA");
         given(userLookupService.getUserOrThrow(userId)).willReturn(user);
-        given(recommendationService.generateRecommendationsForUser(user))
+        given(recommendationService.generateRecommendationsForUser(
+                eq(user),
+                any(float[].class),
+                eq(keyKeywords)
+        ))
                 .willThrow(new RuntimeException("recommendation failure"));
 
-        assertThatCode(() -> listener.handle(new PersonalizedProfileGeneratedEvent(userId)))
+        assertThatCode(() -> listener.handle(new PersonalizedProfileGeneratedEvent(userId, profileVector, keyKeywords)))
                 .doesNotThrowAnyException();
 
         verify(userLookupService).getUserOrThrow(userId);
-        verify(recommendationService).generateRecommendationsForUser(user);
+        verify(recommendationService).generateRecommendationsForUser(
+                eq(user),
+                argThat(vector -> Arrays.equals(vector, profileVector)),
+                eq(keyKeywords)
+        );
     }
 
     @Test
@@ -69,7 +95,7 @@ class PersonalizedProfileGeneratedEventListenerTest {
         given(userLookupService.getUserOrThrow(userId))
                 .willThrow(new RuntimeException("user lookup failure"));
 
-        assertThatCode(() -> listener.handle(new PersonalizedProfileGeneratedEvent(userId)))
+        assertThatCode(() -> listener.handle(new PersonalizedProfileGeneratedEvent(userId, new float[]{0.1f}, List.of("Spring"))))
                 .doesNotThrowAnyException();
 
         verify(userLookupService).getUserOrThrow(userId);

--- a/src/test/java/com/techfork/domain/recommendation/service/LlmRecommendationServiceTest.java
+++ b/src/test/java/com/techfork/domain/recommendation/service/LlmRecommendationServiceTest.java
@@ -43,6 +43,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -172,7 +173,7 @@ class LlmRecommendationServiceTest {
         assertThat(candidatesCaptor.getValue())
                 .extracting(MmrService.MmrCandidate::getPostId)
                 .containsExactly(501L, 502L);
-        verify(personalizationProfileDocumentRepository, times(2)).findByUserId(userId);
+        verify(personalizationProfileDocumentRepository, times(1)).findByUserId(userId);
         verify(vectorQueryBuilder).createKnnSearches(
                 eq("titleEmbedding"),
                 eq("summaryEmbedding"),
@@ -186,6 +187,43 @@ class LlmRecommendationServiceTest {
                 same(filterQuery)
         );
         verify(vectorQueryBuilder).createBm25Query(List.of("Spring", "JPA"), 0.6f, 0.2f, 0.2f);
+    }
+
+    @Test
+    @DisplayName("프로필 스냅샷 기반 추천 생성은 PersonalizationProfileDocument를 다시 조회하지 않는다")
+    void generateRecommendationsForUser_WithProfileSnapshot_DoesNotReadPersonalizationProfileProjection() throws IOException {
+        Long userId = 10L;
+        User user = createUser(userId);
+        float[] profileVector = new float[]{0.1f, 0.2f};
+        List<String> keyKeywords = List.of("Spring", "JPA");
+        Query filterQuery = Query.of(query -> query.matchAll(matchAll -> matchAll));
+        Query bm25Query = Query.of(query -> query.matchAll(matchAll -> matchAll));
+
+        given(readPostRepository.findRecentReadPostsByUserIdWithMinDuration(userId, PageRequest.of(0, 1000)))
+                .willReturn(List.of());
+        given(vectorQueryBuilder.createExcludeFilter(Set.of())).willReturn(filterQuery);
+        given(vectorQueryBuilder.createKnnSearches(
+                eq("titleEmbedding"),
+                eq("summaryEmbedding"),
+                eq("contentChunks.embedding"),
+                same(profileVector),
+                eq(0.6f),
+                eq(0.2f),
+                eq(0.2f),
+                eq(50),
+                eq(150),
+                same(filterQuery)
+        )).willReturn(List.of());
+        given(vectorQueryBuilder.createBm25Query(keyKeywords, 0.6f, 0.2f, 0.2f))
+                .willReturn(bm25Query);
+        given(elasticsearchClient.search(searchRequestBuilder(), eq(PostDocument.class)))
+                .willReturn(emptySearchResponse(), emptySearchResponse());
+
+        int createdCount = llmRecommendationService.generateRecommendationsForUser(user, profileVector, keyKeywords);
+
+        assertThat(createdCount).isZero();
+        verify(personalizationProfileDocumentRepository, never()).findByUserId(any());
+        verify(vectorQueryBuilder).createBm25Query(keyKeywords, 0.6f, 0.2f, 0.2f);
     }
 
     @Test
@@ -282,6 +320,19 @@ class LlmRecommendationServiceTest {
                         .failed(0)
                 )
                 .hits(hits -> hits.hits(hit))
+        );
+    }
+
+    private SearchResponse<PostDocument> emptySearchResponse() {
+        return SearchResponse.of(response -> response
+                .took(1)
+                .timedOut(false)
+                .shards(shards -> shards
+                        .total(1)
+                        .successful(1)
+                        .failed(0)
+                )
+                .hits(hits -> hits.hits(List.of()))
         );
     }
 

--- a/src/test/java/com/techfork/personalization/application/PersonalizationProfileServiceTest.java
+++ b/src/test/java/com/techfork/personalization/application/PersonalizationProfileServiceTest.java
@@ -2,6 +2,8 @@ package com.techfork.personalization.application;
 
 import com.techfork.personalization.application.event.PersonalizedProfileGeneratedEvent;
 import com.techfork.personalization.application.generation.PersonalizedProfileGenerator;
+import com.techfork.personalization.infrastructure.PersonalizationProfileDocument;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,13 +35,25 @@ class PersonalizationProfileServiceTest {
     @DisplayName("개인화 프로필 생성 성공 후 프로필 생성 이벤트를 발행한다")
     void generatePersonalizationProfileSync_PublishesProfileGeneratedEventAfterProfileGeneration() {
         Long userId = 1L;
+        float[] profileVector = new float[]{0.1f, 0.2f};
+        PersonalizationProfileDocument profileDocument = PersonalizationProfileDocument.create(
+                userId,
+                "Spring과 JPA 기반 백엔드 관심 프로필",
+                profileVector,
+                List.of("Backend"),
+                List.of("Spring", "JPA")
+        );
+        given(personalizedProfileGenerator.generate(userId)).willReturn(profileDocument);
 
         personalizationProfileService.generatePersonalizationProfileSync(userId);
 
         ArgumentCaptor<PersonalizedProfileGeneratedEvent> eventCaptor = ArgumentCaptor.forClass(PersonalizedProfileGeneratedEvent.class);
         verify(personalizedProfileGenerator).generate(userId);
         verify(eventPublisher).publishEvent(eventCaptor.capture());
-        assertThat(eventCaptor.getValue().userId()).isEqualTo(userId);
+        PersonalizedProfileGeneratedEvent event = eventCaptor.getValue();
+        assertThat(event.userId()).isEqualTo(userId);
+        assertThat(event.profileVector()).containsExactly(0.1f, 0.2f);
+        assertThat(event.keyKeywords()).containsExactly("Spring", "JPA");
     }
 
     @Test

--- a/src/test/java/com/techfork/personalization/application/PersonalizationProfileServiceTest.java
+++ b/src/test/java/com/techfork/personalization/application/PersonalizationProfileServiceTest.java
@@ -1,19 +1,17 @@
 package com.techfork.personalization.application;
 
-import com.techfork.domain.recommendation.service.RecommendationService;
-import com.techfork.useraccount.domain.User;
-import com.techfork.useraccount.domain.enums.SocialType;
+import com.techfork.personalization.application.event.PersonalizedProfileGeneratedEvent;
 import com.techfork.personalization.application.generation.PersonalizedProfileGenerator;
-import com.techfork.useraccount.application.query.lookup.UserLookupService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.context.ApplicationEventPublisher;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -26,32 +24,27 @@ class PersonalizationProfileServiceTest {
     private PersonalizedProfileGenerator personalizedProfileGenerator;
 
     @Mock
-    private UserLookupService userLookupService;
-
-    @Mock
-    private RecommendationService recommendationService;
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private PersonalizationProfileService personalizationProfileService;
 
     @Test
-    @DisplayName("개인화 프로필 생성을 요청한 뒤 추천을 생성한다")
-    void generatePersonalizationProfileSync_GeneratesProfileAndRecommendations() {
+    @DisplayName("개인화 프로필 생성 성공 후 프로필 생성 이벤트를 발행한다")
+    void generatePersonalizationProfileSync_PublishesProfileGeneratedEventAfterProfileGeneration() {
         Long userId = 1L;
-        User user = createUser(userId);
-        given(userLookupService.getUserOrThrow(userId)).willReturn(user);
-        given(recommendationService.generateRecommendationsForUser(user)).willReturn(5);
 
         personalizationProfileService.generatePersonalizationProfileSync(userId);
 
+        ArgumentCaptor<PersonalizedProfileGeneratedEvent> eventCaptor = ArgumentCaptor.forClass(PersonalizedProfileGeneratedEvent.class);
         verify(personalizedProfileGenerator).generate(userId);
-        verify(userLookupService).getUserOrThrow(userId);
-        verify(recommendationService).generateRecommendationsForUser(user);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        assertThat(eventCaptor.getValue().userId()).isEqualTo(userId);
     }
 
     @Test
-    @DisplayName("개인화 프로필 생성이 실패하면 예외를 전파하고 추천을 시도하지 않는다")
-    void generatePersonalizationProfileSync_ProfileGenerationFailurePropagatesException() {
+    @DisplayName("개인화 프로필 생성이 실패하면 예외를 전파하고 이벤트를 발행하지 않는다")
+    void generatePersonalizationProfileSync_ProfileGenerationFailurePropagatesExceptionAndDoesNotPublishEvent() {
         Long userId = 2L;
         RuntimeException failure = new RuntimeException("profile generation failure");
         given(personalizedProfileGenerator.generate(userId)).willThrow(failure);
@@ -60,28 +53,6 @@ class PersonalizationProfileServiceTest {
                 .isSameAs(failure);
 
         verify(personalizedProfileGenerator).generate(userId);
-        verifyNoInteractions(userLookupService, recommendationService);
-    }
-
-    @Test
-    @DisplayName("추천 생성이 실패해도 개인화 프로필 저장은 유지된다")
-    void generatePersonalizationProfileSync_RecommendationFailureDoesNotBreakProfileSave() {
-        Long userId = 3L;
-        User user = createUser(userId);
-        given(userLookupService.getUserOrThrow(userId)).willReturn(user);
-        given(recommendationService.generateRecommendationsForUser(user))
-                .willThrow(new RuntimeException("recommendation failure"));
-
-        assertThatCode(() -> personalizationProfileService.generatePersonalizationProfileSync(userId))
-                .doesNotThrowAnyException();
-
-        verify(personalizedProfileGenerator).generate(userId);
-        verify(recommendationService).generateRecommendationsForUser(user);
-    }
-
-    private User createUser(Long userId) {
-        User user = User.createSocialUser(SocialType.KAKAO, "social-" + userId, "user" + userId + "@example.com", null);
-        ReflectionTestUtils.setField(user, "id", userId);
-        return user;
+        verifyNoInteractions(eventPublisher);
     }
 }


### PR DESCRIPTION
## ❤️ 기능 설명

Personalization Profile 생성 완료 후 추천 생성을 직접 호출하지 않고 이벤트로 분리했습니다.

- `PersonalizedProfileGeneratedEvent` 도입
- 프로필 생성 성공 후 이벤트 발행
- `PersonalizationProfileService`의 `RecommendationService` 직접 의존 제거
- Recommendation 컨텍스트 listener에서 이벤트 수신 후 추천 생성
- ES 저장 직후 검색 가시성 문제를 피하기 위해 이벤트에 추천용 profile snapshot(`profileVector`, `keyKeywords`) 포함
- 추천 생성/사용자 조회 실패는 listener 내부에서 격리해 프로필 저장 결과에 영향 없도록 유지

Swagger 테스트 스크린샷: API 변경 없는 리팩토링이라 해당 없음
<br>

## 연결된 issue

close #410
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 이벤트 payload에 추천 생성에 필요한 `profileVector`, `keyKeywords`를 포함해 Recommendation listener가 저장 직후 ES profile 재검색에 의존하지 않도록 했습니다.
- [ ] Recommendation 모델/알고리즘 자체는 변경하지 않았습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (API 변경 없는 리팩토링이라 명령 결과로 대체)
- [x] 이슈넘버를 적었는가?

## 테스트

```bash
./gradlew test --tests '*PersonalizationProfileServiceTest' --tests '*PersonalizedProfileGeneratedEventListenerTest' --tests '*LlmRecommendationServiceTest'
./gradlew test --tests '*PersonalizationProfileEventListenerTest' --tests '*PersonalizedProfileGeneratorTest' --tests '*PersonalizationProfileAnalyzerTest' --tests '*UserActivityCollectorTest'
./gradlew compileTestJava
git diff --check
```
