### PR TITLE
[test/#411] Personalization/Recommendation 이벤트 경계 테스트 보강

### DIFF
--- a/src/test/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListenerTest.java
+++ b/src/test/java/com/techfork/domain/recommendation/listener/PersonalizedProfileGeneratedEventListenerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -39,8 +40,8 @@ class PersonalizedProfileGeneratedEventListenerTest {
     private PersonalizedProfileGeneratedEventListener listener;
 
     @Test
-    @DisplayName("프로필 생성 이벤트를 받으면 추천을 생성한다")
-    void handle_GeneratesRecommendationsWhenProfileGeneratedEventIsReceived() {
+    @DisplayName("프로필 생성 이벤트를 받으면 이벤트 스냅샷으로 추천을 생성한다")
+    void handle_GeneratesRecommendationsWithEventSnapshotWhenProfileGeneratedEventIsReceived() {
         Long userId = 1L;
         User user = mock(User.class);
         float[] profileVector = new float[]{0.1f, 0.2f};
@@ -60,6 +61,7 @@ class PersonalizedProfileGeneratedEventListenerTest {
                 argThat(vector -> Arrays.equals(vector, profileVector)),
                 eq(keyKeywords)
         );
+        verify(recommendationService, never()).generateRecommendationsForUser(user);
     }
 
     @Test
@@ -86,6 +88,7 @@ class PersonalizedProfileGeneratedEventListenerTest {
                 argThat(vector -> Arrays.equals(vector, profileVector)),
                 eq(keyKeywords)
         );
+        verify(recommendationService, never()).generateRecommendationsForUser(user);
     }
 
     @Test

--- a/src/test/java/com/techfork/personalization/application/event/PersonalizedProfileGeneratedEventTest.java
+++ b/src/test/java/com/techfork/personalization/application/event/PersonalizedProfileGeneratedEventTest.java
@@ -1,0 +1,84 @@
+package com.techfork.personalization.application.event;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PersonalizedProfileGeneratedEventTest {
+
+    @Test
+    @DisplayName("프로필 벡터는 생성 시점 값으로 복사된다")
+    void constructor_CopiesProfileVector() {
+        float[] profileVector = new float[]{0.1f, 0.2f};
+
+        PersonalizedProfileGeneratedEvent event = new PersonalizedProfileGeneratedEvent(
+                1L,
+                profileVector,
+                List.of("Spring")
+        );
+        profileVector[0] = 9.9f;
+
+        assertThat(event.profileVector()).containsExactly(0.1f, 0.2f);
+    }
+
+    @Test
+    @DisplayName("프로필 벡터 조회 결과를 변경해도 이벤트 내부 상태는 변경되지 않는다")
+    void profileVector_ReturnsCopy() {
+        PersonalizedProfileGeneratedEvent event = new PersonalizedProfileGeneratedEvent(
+                1L,
+                new float[]{0.1f, 0.2f},
+                List.of("Spring")
+        );
+
+        float[] returnedVector = event.profileVector();
+        returnedVector[0] = 9.9f;
+
+        assertThat(event.profileVector()).containsExactly(0.1f, 0.2f);
+    }
+
+    @Test
+    @DisplayName("핵심 키워드는 생성 시점 값으로 복사되고 불변 목록으로 유지된다")
+    void constructor_CopiesKeyKeywordsAsImmutableList() {
+        List<String> keyKeywords = new ArrayList<>(List.of("Spring", "JPA"));
+
+        PersonalizedProfileGeneratedEvent event = new PersonalizedProfileGeneratedEvent(
+                1L,
+                new float[]{0.1f},
+                keyKeywords
+        );
+        keyKeywords.add("Kafka");
+
+        assertThat(event.keyKeywords()).containsExactly("Spring", "JPA");
+        assertThatThrownBy(() -> event.keyKeywords().add("Kafka"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("핵심 키워드가 null이면 빈 목록으로 정규화한다")
+    void constructor_NullKeyKeywordsDefaultsToEmptyList() {
+        PersonalizedProfileGeneratedEvent event = new PersonalizedProfileGeneratedEvent(
+                1L,
+                new float[]{0.1f},
+                null
+        );
+
+        assertThat(event.keyKeywords()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("프로필 벡터가 null이면 null로 유지한다")
+    void constructor_NullProfileVectorRemainsNull() {
+        PersonalizedProfileGeneratedEvent event = new PersonalizedProfileGeneratedEvent(
+                1L,
+                null,
+                List.of("Spring")
+        );
+
+        assertThat(event.profileVector()).isNull();
+    }
+}

--- a/src/test/java/com/techfork/personalization/integration/PersonalizedProfileGeneratedAfterCommitIntegrationTest.java
+++ b/src/test/java/com/techfork/personalization/integration/PersonalizedProfileGeneratedAfterCommitIntegrationTest.java
@@ -1,29 +1,43 @@
 package com.techfork.personalization.integration;
 
+import com.techfork.domain.recommendation.listener.PersonalizedProfileGeneratedEventListener;
 import com.techfork.domain.recommendation.service.RecommendationService;
-import com.techfork.global.common.IntegrationTestBase;
 import com.techfork.personalization.application.event.PersonalizedProfileGeneratedEvent;
 import com.techfork.useraccount.application.query.lookup.UserLookupService;
 import com.techfork.useraccount.domain.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.Arrays;
 import java.util.List;
+
+import javax.sql.DataSource;
 
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
-class PersonalizedProfileGeneratedAfterCommitIntegrationTest extends IntegrationTestBase {
+@Tag("integration")
+@SpringJUnitConfig(PersonalizedProfileGeneratedAfterCommitIntegrationTest.TestConfig.class)
+class PersonalizedProfileGeneratedAfterCommitIntegrationTest {
 
     @Autowired
     private ApplicationEventPublisher eventPublisher;
@@ -31,11 +45,16 @@ class PersonalizedProfileGeneratedAfterCommitIntegrationTest extends Integration
     @Autowired
     private TransactionTemplate transactionTemplate;
 
-    @MockitoBean
+    @Autowired
     private UserLookupService userLookupService;
 
-    @MockitoBean
+    @Autowired
     private RecommendationService recommendationService;
+
+    @BeforeEach
+    void setUp() {
+        reset(userLookupService, recommendationService);
+    }
 
     @Test
     @DisplayName("프로필 생성 이벤트는 실제 트랜잭션 커밋 이후 추천 생성을 실행한다")
@@ -79,5 +98,46 @@ class PersonalizedProfileGeneratedAfterCommitIntegrationTest extends Integration
         });
 
         verifyNoInteractions(userLookupService, recommendationService);
+    }
+
+    @Configuration
+    @EnableTransactionManagement
+    static class TestConfig {
+
+        @Bean
+        PersonalizedProfileGeneratedEventListener personalizedProfileGeneratedEventListener(
+                UserLookupService userLookupService,
+                RecommendationService recommendationService
+        ) {
+            return new PersonalizedProfileGeneratedEventListener(userLookupService, recommendationService);
+        }
+
+        @Bean
+        UserLookupService userLookupService() {
+            return mock(UserLookupService.class);
+        }
+
+        @Bean
+        RecommendationService recommendationService() {
+            return mock(RecommendationService.class);
+        }
+
+        @Bean
+        DataSource dataSource() {
+            return new EmbeddedDatabaseBuilder()
+                    .generateUniqueName(true)
+                    .setType(EmbeddedDatabaseType.H2)
+                    .build();
+        }
+
+        @Bean
+        PlatformTransactionManager transactionManager(DataSource dataSource) {
+            return new DataSourceTransactionManager(dataSource);
+        }
+
+        @Bean
+        TransactionTemplate transactionTemplate(PlatformTransactionManager transactionManager) {
+            return new TransactionTemplate(transactionManager);
+        }
     }
 }

--- a/src/test/java/com/techfork/personalization/integration/PersonalizedProfileGeneratedAfterCommitIntegrationTest.java
+++ b/src/test/java/com/techfork/personalization/integration/PersonalizedProfileGeneratedAfterCommitIntegrationTest.java
@@ -1,0 +1,83 @@
+package com.techfork.personalization.integration;
+
+import com.techfork.domain.recommendation.service.RecommendationService;
+import com.techfork.global.common.IntegrationTestBase;
+import com.techfork.personalization.application.event.PersonalizedProfileGeneratedEvent;
+import com.techfork.useraccount.application.query.lookup.UserLookupService;
+import com.techfork.useraccount.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class PersonalizedProfileGeneratedAfterCommitIntegrationTest extends IntegrationTestBase {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @MockitoBean
+    private UserLookupService userLookupService;
+
+    @MockitoBean
+    private RecommendationService recommendationService;
+
+    @Test
+    @DisplayName("프로필 생성 이벤트는 실제 트랜잭션 커밋 이후 추천 생성을 실행한다")
+    void profileGeneratedEvent_CommittedTransaction_GeneratesRecommendationAfterCommit() {
+        Long userId = 1L;
+        User user = mock(User.class);
+        float[] profileVector = new float[]{0.1f, 0.2f};
+        List<String> keyKeywords = List.of("Spring", "JPA");
+        given(userLookupService.getUserOrThrow(userId)).willReturn(user);
+        given(recommendationService.generateRecommendationsForUser(
+                eq(user),
+                argThat(vector -> Arrays.equals(vector, profileVector)),
+                eq(keyKeywords)
+        )).willReturn(5);
+
+        transactionTemplate.executeWithoutResult(status -> {
+            eventPublisher.publishEvent(new PersonalizedProfileGeneratedEvent(userId, profileVector, keyKeywords));
+
+            verifyNoInteractions(userLookupService, recommendationService);
+        });
+
+        verify(userLookupService).getUserOrThrow(userId);
+        verify(recommendationService).generateRecommendationsForUser(
+                eq(user),
+                argThat(vector -> Arrays.equals(vector, profileVector)),
+                eq(keyKeywords)
+        );
+        verify(recommendationService, never()).generateRecommendationsForUser(user);
+    }
+
+    @Test
+    @DisplayName("트랜잭션이 롤백되면 프로필 생성 이벤트의 추천 후처리는 실행되지 않는다")
+    void profileGeneratedEvent_RolledBackTransaction_DoesNotGenerateRecommendation() {
+        transactionTemplate.executeWithoutResult(status -> {
+            eventPublisher.publishEvent(new PersonalizedProfileGeneratedEvent(
+                    1L,
+                    new float[]{0.1f},
+                    List.of("Spring")
+            ));
+            status.setRollbackOnly();
+        });
+
+        verifyNoInteractions(userLookupService, recommendationService);
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

Personalization Profile 생성 후 Recommendation으로 이어지는 이벤트 경계를 테스트로 보강했습니다.

- `PersonalizedProfileGeneratedEvent` 페이로드 방어적 복사/불변 계약 검증
- Recommendation 리스너가 이벤트 스냅샷 기반 추천 생성 경로를 사용하는지 검증
- 추천 생성 예외가 Personalization Profile 생성 결과로 전파되지 않는지 검증
- 실제 Spring transaction event wiring에서 commit 후 실행 / rollback 시 미실행 검증
- 통합 이벤트 경계 테스트는 H2 + 최소 Spring 컨텍스트로 구성해 Testcontainers 의존을 제거했습니다.

swagger 테스트 성공 결과 스크린샷 첨부

- 테스트 전용 변경이라 Swagger 스크린샷은 해당 없습니다.
- 아래 CLI 테스트 결과로 대체합니다.

<br>

## 연결된 issue

close #411

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 이벤트 경계 통합 테스트를 `IntegrationTestBase` 없이 최소 Spring 컨텍스트로 둔 방향이 적절한지 확인해주세요.
- [ ] `PersonalizedProfileGeneratedEvent`의 null 처리 정책을 테스트 계약으로 고정하는 것이 적절한지 확인해주세요.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (테스트 전용 PR이라 CLI 결과로 대체)
- [x] 이슈넘버를 적었는가?

## 테스트

- [x] `./gradlew integrationTest --tests '*PersonalizedProfileGeneratedAfterCommitIntegrationTest'`
- [x] `./gradlew test --tests '*PersonalizationProfileServiceTest' --tests '*PersonalizedProfileGeneratedEventListenerTest' --tests '*PersonalizedProfileGeneratedEventTest'`
- [x] `./gradlew compileTestJava`
- [x] `git diff --check`
