### PR TITLE
[test/#427] Auth / Security DDD 리팩터링 전 회귀 테스트 보강

### DIFF
--- a/src/test/java/com/techfork/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/techfork/global/security/filter/JwtAuthenticationFilterTest.java
@@ -1,5 +1,8 @@
 package com.techfork.global.security.filter;
 
+import com.techfork.domain.auth.exception.AuthErrorCode;
+import com.techfork.global.constant.Constants;
+import com.techfork.global.exception.GeneralException;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.SocialType;
@@ -216,8 +219,9 @@ class JwtAuthenticationFilterTest {
         void doFilterInternal_Fail_InvalidToken() throws Exception {
             // Given
             String invalidToken = "invalid.token";
+            RuntimeException invalidTokenException = new RuntimeException("Invalid token");
             given(request.getHeader("Authorization")).willReturn("Bearer " + invalidToken);
-            willThrow(new RuntimeException("Invalid token")).given(jwtUtil).validateToken(invalidToken);
+            willThrow(invalidTokenException).given(jwtUtil).validateToken(invalidToken);
 
             // When
             jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -228,6 +232,7 @@ class JwtAuthenticationFilterTest {
 
             verify(jwtUtil).validateToken(invalidToken);
             verify(userRepository, never()).findById(anyLong());
+            verifyJwtExceptionAttribute(invalidTokenException);
             verify(filterChain).doFilter(request, response);
         }
 
@@ -236,9 +241,10 @@ class JwtAuthenticationFilterTest {
         void doFilterInternal_Fail_RefreshTokenUsed() throws Exception {
             // Given
             String refreshToken = "refresh.token";
+            RuntimeException tokenTypeMismatchException = new RuntimeException("Token type mismatch");
             given(request.getHeader("Authorization")).willReturn("Bearer " + refreshToken);
             willDoNothing().given(jwtUtil).validateToken(refreshToken);
-            doThrow(new RuntimeException("Token type mismatch"))
+            doThrow(tokenTypeMismatchException)
                     .when(jwtUtil).validateTokenType(refreshToken, TOKEN_TYPE_ACCESS);
 
             // When
@@ -251,6 +257,7 @@ class JwtAuthenticationFilterTest {
             verify(jwtUtil).validateToken(refreshToken);
             verify(jwtUtil).validateTokenType(refreshToken, TOKEN_TYPE_ACCESS);
             verify(userRepository, never()).findById(anyLong());
+            verifyJwtExceptionAttribute(tokenTypeMismatchException);
             verify(filterChain).doFilter(request, response);
         }
 
@@ -275,6 +282,7 @@ class JwtAuthenticationFilterTest {
             verify(jwtUtil).validateToken(deletedUserToken);
             verify(jwtUtil).validateTokenType(deletedUserToken, TOKEN_TYPE_ACCESS);
             verify(userRepository).findById(999L);
+            verifyJwtExceptionAttribute(AuthErrorCode.USER_NOT_FOUND);
             verify(filterChain).doFilter(request, response);
         }
 
@@ -303,6 +311,7 @@ class JwtAuthenticationFilterTest {
 
             verify(userRepository).findById(userId);
             verify(userAuthCacheService, never()).put(anyLong(), any(), anyLong()); // 탈퇴 유저는 캐시 저장 안 함
+            verifyJwtExceptionAttribute(AuthErrorCode.WITHDRAWN_USER);
             verify(filterChain).doFilter(request, response);
         }
 
@@ -331,8 +340,19 @@ class JwtAuthenticationFilterTest {
             assertThat(authentication).isNull();
 
             verify(userRepository, never()).findById(anyLong()); // 캐시 히트이므로 DB 조회 없음
+            verifyJwtExceptionAttribute(AuthErrorCode.WITHDRAWN_USER);
             verify(filterChain).doFilter(request, response);
         }
     }
-}
 
+    private void verifyJwtExceptionAttribute(Exception expectedException) {
+        verify(request).setAttribute(Constants.JWT_EXCEPTION_ATTRIBUTE, expectedException);
+    }
+
+    private void verifyJwtExceptionAttribute(AuthErrorCode expectedErrorCode) {
+        verify(request).setAttribute(eq(Constants.JWT_EXCEPTION_ATTRIBUTE), argThat(exception ->
+                exception instanceof GeneralException generalException
+                        && generalException.getCode() == expectedErrorCode
+        ));
+    }
+}

--- a/src/test/java/com/techfork/global/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/techfork/global/security/filter/JwtAuthenticationFilterTest.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -71,224 +72,267 @@ class JwtAuthenticationFilterTest {
         ReflectionTestUtils.setField(testUser, "id", userId);
     }
 
-    // ===== 인증 성공 테스트 =====
+    @Nested
+    @DisplayName("성공")
+    class Success {
 
-    @Test
-    @DisplayName("JWT 인증 성공 - 캐시 미스: DB 조회 후 캐시 저장")
-    void doFilterInternal_Success_CacheMiss() throws Exception {
-        // Given
-        given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
-        willDoNothing().given(jwtUtil).validateToken(validAccessToken);
-        given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
-        given(userAuthCacheService.get(userId)).willReturn(null);
-        given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
-        given(jwtProperties.getAccessTokenExpiration()).willReturn(180000L);
+        @Test
+        @DisplayName("JWT 인증 성공 - 캐시 미스: DB 조회 후 캐시 저장")
+        void doFilterInternal_Success_CacheMiss() throws Exception {
+            // Given
+            given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
+            willDoNothing().given(jwtUtil).validateToken(validAccessToken);
+            given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
+            given(userAuthCacheService.get(userId)).willReturn(null);
+            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(jwtProperties.getAccessTokenExpiration()).willReturn(180000L);
 
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNotNull();
-        assertThat(authentication.getPrincipal()).isInstanceOf(UserPrincipal.class);
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNotNull();
+            assertThat(authentication.getPrincipal()).isInstanceOf(UserPrincipal.class);
 
-        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
-        assertThat(principal.getId()).isEqualTo(userId);
-        assertThat(principal.getRole()).isEqualTo(Role.USER);
-        assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
+            UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+            assertThat(principal.getId()).isEqualTo(userId);
+            assertThat(principal.getRole()).isEqualTo(Role.USER);
+            assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
 
-        verify(userRepository).findById(userId);
-        verify(userAuthCacheService).put(eq(userId), eq(testUser), eq(180000L));
-        verify(filterChain).doFilter(request, response);
+            verify(userRepository).findById(userId);
+            verify(userAuthCacheService).put(eq(userId), eq(testUser), eq(180000L));
+            verify(filterChain).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("JWT 인증 성공 - 캐시 히트: DB 조회 없이 인증")
+        void doFilterInternal_Success_CacheHit() throws Exception {
+            // Given
+            UserPrincipal cachedPrincipal = UserPrincipal.builder()
+                    .id(userId)
+                    .role(Role.USER)
+                    .status(UserStatus.ACTIVE)
+                    .email("test@example.com")
+                    .build();
+
+            given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
+            willDoNothing().given(jwtUtil).validateToken(validAccessToken);
+            given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
+            given(userAuthCacheService.get(userId)).willReturn(cachedPrincipal);
+
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNotNull();
+            assertThat(authentication.getPrincipal()).isEqualTo(cachedPrincipal);
+
+            verify(userRepository, never()).findById(anyLong());
+            verify(userAuthCacheService, never()).put(anyLong(), any(), anyLong());
+            verify(filterChain).doFilter(request, response);
+        }
+
+        @Test
+        @DisplayName("JWT 인증 성공 - 재활성화된 PENDING 사용자는 DB 조회 후 캐시에 저장한다")
+        void doFilterInternal_Success_ReactivatedPendingUser_CacheMiss() throws Exception {
+            // Given
+            User reactivatedUser = User.createSocialUser(SocialType.APPLE, "reactivatedSocialId", "old@example.com", "old.png");
+            reactivatedUser.updateUser("재활성화유저", "old@example.com", "탈퇴 전 설명");
+            reactivatedUser.withdraw();
+            reactivatedUser.reactivate("reactivated@example.com", "reactivated.png");
+            ReflectionTestUtils.setField(reactivatedUser, "id", userId);
+
+            given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
+            willDoNothing().given(jwtUtil).validateToken(validAccessToken);
+            willDoNothing().given(jwtUtil).validateTokenType(validAccessToken, TOKEN_TYPE_ACCESS);
+            given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
+            given(userAuthCacheService.get(userId)).willReturn(null);
+            given(userRepository.findById(userId)).willReturn(Optional.of(reactivatedUser));
+            given(jwtProperties.getAccessTokenExpiration()).willReturn(180000L);
+
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNotNull();
+            assertThat(authentication.getPrincipal()).isInstanceOf(UserPrincipal.class);
+
+            UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+            assertThat(principal.getId()).isEqualTo(userId);
+            assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
+            assertThat(principal.getEmail()).isEqualTo("reactivated@example.com");
+
+            verify(userRepository).findById(userId);
+            verify(userAuthCacheService).put(userId, reactivatedUser, 180000L);
+            verify(filterChain).doFilter(request, response);
+        }
     }
 
-    @Test
-    @DisplayName("JWT 인증 성공 - 캐시 히트: DB 조회 없이 인증")
-    void doFilterInternal_Success_CacheHit() throws Exception {
-        // Given
-        UserPrincipal cachedPrincipal = UserPrincipal.builder()
-                .id(userId)
-                .role(Role.USER)
-                .status(UserStatus.ACTIVE)
-                .email("test@example.com")
-                .build();
+    @Nested
+    @DisplayName("실패")
+    class Failure {
 
-        given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
-        willDoNothing().given(jwtUtil).validateToken(validAccessToken);
-        given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
-        given(userAuthCacheService.get(userId)).willReturn(cachedPrincipal);
+        @Test
+        @DisplayName("JWT 인증 실패 - Authorization 헤더 없음")
+        void doFilterInternal_Fail_NoAuthorizationHeader() throws Exception {
+            // Given
+            given(request.getHeader("Authorization")).willReturn(null);
 
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNotNull();
-        assertThat(authentication.getPrincipal()).isEqualTo(cachedPrincipal);
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNull();
 
-        verify(userRepository, never()).findById(anyLong());
-        verify(userAuthCacheService, never()).put(anyLong(), any(), anyLong());
-        verify(filterChain).doFilter(request, response);
-    }
+            verify(jwtUtil, never()).validateToken(anyString());
+            verify(userRepository, never()).findById(anyLong());
+            verify(filterChain).doFilter(request, response);
+        }
 
-    // ===== 인증 실패 테스트 =====
+        @Test
+        @DisplayName("JWT 인증 실패 - Bearer 접두사 없음")
+        void doFilterInternal_Fail_NoBearerPrefix() throws Exception {
+            // Given
+            given(request.getHeader("Authorization")).willReturn(validAccessToken);
 
-    @Test
-    @DisplayName("JWT 인증 실패 - Authorization 헤더 없음")
-    void doFilterInternal_Fail_NoAuthorizationHeader() throws Exception {
-        // Given
-        given(request.getHeader("Authorization")).willReturn(null);
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNull();
 
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNull();
+            verify(jwtUtil, never()).validateToken(anyString());
+            verify(userRepository, never()).findById(anyLong());
+            verify(filterChain).doFilter(request, response);
+        }
 
-        verify(jwtUtil, never()).validateToken(anyString());
-        verify(userRepository, never()).findById(anyLong());
-        verify(filterChain).doFilter(request, response);
-    }
+        @Test
+        @DisplayName("JWT 인증 실패 - 유효하지 않은 토큰")
+        void doFilterInternal_Fail_InvalidToken() throws Exception {
+            // Given
+            String invalidToken = "invalid.token";
+            given(request.getHeader("Authorization")).willReturn("Bearer " + invalidToken);
+            willThrow(new RuntimeException("Invalid token")).given(jwtUtil).validateToken(invalidToken);
 
-    @Test
-    @DisplayName("JWT 인증 실패 - Bearer 접두사 없음")
-    void doFilterInternal_Fail_NoBearerPrefix() throws Exception {
-        // Given
-        given(request.getHeader("Authorization")).willReturn(validAccessToken);
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNull();
 
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNull();
+            verify(jwtUtil).validateToken(invalidToken);
+            verify(userRepository, never()).findById(anyLong());
+            verify(filterChain).doFilter(request, response);
+        }
 
-        verify(jwtUtil, never()).validateToken(anyString());
-        verify(userRepository, never()).findById(anyLong());
-        verify(filterChain).doFilter(request, response);
-    }
+        @Test
+        @DisplayName("JWT 인증 실패 - 리프레시 토큰 사용 시도")
+        void doFilterInternal_Fail_RefreshTokenUsed() throws Exception {
+            // Given
+            String refreshToken = "refresh.token";
+            given(request.getHeader("Authorization")).willReturn("Bearer " + refreshToken);
+            willDoNothing().given(jwtUtil).validateToken(refreshToken);
+            doThrow(new RuntimeException("Token type mismatch"))
+                    .when(jwtUtil).validateTokenType(refreshToken, TOKEN_TYPE_ACCESS);
 
-    @Test
-    @DisplayName("JWT 인증 실패 - 유효하지 않은 토큰")
-    void doFilterInternal_Fail_InvalidToken() throws Exception {
-        // Given
-        String invalidToken = "invalid.token";
-        given(request.getHeader("Authorization")).willReturn("Bearer " + invalidToken);
-        willThrow(new RuntimeException("Invalid token")).given(jwtUtil).validateToken(invalidToken);
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNull();
 
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNull();
+            verify(jwtUtil).validateToken(refreshToken);
+            verify(jwtUtil).validateTokenType(refreshToken, TOKEN_TYPE_ACCESS);
+            verify(userRepository, never()).findById(anyLong());
+            verify(filterChain).doFilter(request, response);
+        }
 
-        verify(jwtUtil).validateToken(invalidToken);
-        verify(userRepository, never()).findById(anyLong());
-        verify(filterChain).doFilter(request, response);
-    }
+        @Test
+        @DisplayName("JWT 인증 실패 - 사용자를 찾을 수 없음 (삭제된 사용자)")
+        void doFilterInternal_Fail_UserNotFound() throws Exception {
+            // Given
+            String deletedUserToken = "deleted.user.token";
+            given(request.getHeader("Authorization")).willReturn("Bearer " + deletedUserToken);
+            willDoNothing().given(jwtUtil).validateToken(deletedUserToken);
+            willDoNothing().given(jwtUtil).validateTokenType(deletedUserToken, TOKEN_TYPE_ACCESS);
+            given(jwtUtil.getUserIdFromToken(deletedUserToken)).willReturn(999L);
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
 
-    @Test
-    @DisplayName("JWT 인증 실패 - 리프레시 토큰 사용 시도")
-    void doFilterInternal_Fail_RefreshTokenUsed() throws Exception {
-        // Given
-        String refreshToken = "refresh.token";
-        given(request.getHeader("Authorization")).willReturn("Bearer " + refreshToken);
-        willDoNothing().given(jwtUtil).validateToken(refreshToken);
-        doThrow(new RuntimeException("Token type mismatch"))
-                .when(jwtUtil).validateTokenType(refreshToken, TOKEN_TYPE_ACCESS);
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNull();
 
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNull();
+            verify(jwtUtil).validateToken(deletedUserToken);
+            verify(jwtUtil).validateTokenType(deletedUserToken, TOKEN_TYPE_ACCESS);
+            verify(userRepository).findById(999L);
+            verify(filterChain).doFilter(request, response);
+        }
 
-        verify(jwtUtil).validateToken(refreshToken);
-        verify(jwtUtil).validateTokenType(refreshToken, TOKEN_TYPE_ACCESS);
-        verify(userRepository, never()).findById(anyLong());
-        verify(filterChain).doFilter(request, response);
-    }
+        @Test
+        @DisplayName("JWT 인증 실패 - 탈퇴한 회원 (캐시 미스 후 DB 조회)")
+        void doFilterInternal_Fail_WithdrawnUser_CacheMiss() throws Exception {
+            // Given
+            User withdrawnUser = User.createSocialUser(SocialType.KAKAO, "withdrawnSocialId", "withdrawn@example.com", null);
+            withdrawnUser.updateUser("탈퇴유저", "withdrawn@example.com", "개발자였습니다.");
+            withdrawnUser.withdraw();
+            ReflectionTestUtils.setField(withdrawnUser, "id", userId);
 
-    @Test
-    @DisplayName("JWT 인증 실패 - 사용자를 찾을 수 없음 (삭제된 사용자)")
-    void doFilterInternal_Fail_UserNotFound() throws Exception {
-        // Given
-        String deletedUserToken = "deleted.user.token";
-        given(request.getHeader("Authorization")).willReturn("Bearer " + deletedUserToken);
-        willDoNothing().given(jwtUtil).validateToken(deletedUserToken);
-        willDoNothing().given(jwtUtil).validateTokenType(deletedUserToken, TOKEN_TYPE_ACCESS);
-        given(jwtUtil.getUserIdFromToken(deletedUserToken)).willReturn(999L);
-        given(userRepository.findById(999L)).willReturn(Optional.empty());
+            given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
+            willDoNothing().given(jwtUtil).validateToken(validAccessToken);
+            willDoNothing().given(jwtUtil).validateTokenType(validAccessToken, TOKEN_TYPE_ACCESS);
+            given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
+            given(userAuthCacheService.get(userId)).willReturn(null);
+            given(userRepository.findById(userId)).willReturn(Optional.of(withdrawnUser));
 
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNull();
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNull();
 
-        verify(jwtUtil).validateToken(deletedUserToken);
-        verify(jwtUtil).validateTokenType(deletedUserToken, TOKEN_TYPE_ACCESS);
-        verify(userRepository).findById(999L);
-        verify(filterChain).doFilter(request, response);
-    }
+            verify(userRepository).findById(userId);
+            verify(userAuthCacheService, never()).put(anyLong(), any(), anyLong()); // 탈퇴 유저는 캐시 저장 안 함
+            verify(filterChain).doFilter(request, response);
+        }
 
-    @Test
-    @DisplayName("JWT 인증 실패 - 탈퇴한 회원 (캐시 미스 후 DB 조회)")
-    void doFilterInternal_Fail_WithdrawnUser_CacheMiss() throws Exception {
-        // Given
-        User withdrawnUser = User.createSocialUser(SocialType.KAKAO, "withdrawnSocialId", "withdrawn@example.com", null);
-        withdrawnUser.updateUser("탈퇴유저", "withdrawn@example.com", "개발자였습니다.");
-        withdrawnUser.withdraw();
-        ReflectionTestUtils.setField(withdrawnUser, "id", userId);
+        @Test
+        @DisplayName("JWT 인증 실패 - 탈퇴한 회원 (캐시 히트)")
+        void doFilterInternal_Fail_WithdrawnUser_CacheHit() throws Exception {
+            // Given
+            UserPrincipal withdrawnPrincipal = UserPrincipal.builder()
+                    .id(userId)
+                    .role(Role.USER)
+                    .status(UserStatus.WITHDRAWN)
+                    .email(null)
+                    .build();
 
-        given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
-        willDoNothing().given(jwtUtil).validateToken(validAccessToken);
-        willDoNothing().given(jwtUtil).validateTokenType(validAccessToken, TOKEN_TYPE_ACCESS);
-        given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
-        given(userAuthCacheService.get(userId)).willReturn(null);
-        given(userRepository.findById(userId)).willReturn(Optional.of(withdrawnUser));
+            given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
+            willDoNothing().given(jwtUtil).validateToken(validAccessToken);
+            willDoNothing().given(jwtUtil).validateTokenType(validAccessToken, TOKEN_TYPE_ACCESS);
+            given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
+            given(userAuthCacheService.get(userId)).willReturn(withdrawnPrincipal);
 
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+            // When
+            jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
 
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNull();
+            // Then
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            assertThat(authentication).isNull();
 
-        verify(userRepository).findById(userId);
-        verify(userAuthCacheService, never()).put(anyLong(), any(), anyLong()); // 탈퇴 유저는 캐시 저장 안 함
-        verify(filterChain).doFilter(request, response);
-    }
-
-    @Test
-    @DisplayName("JWT 인증 실패 - 탈퇴한 회원 (캐시 히트)")
-    void doFilterInternal_Fail_WithdrawnUser_CacheHit() throws Exception {
-        // Given
-        UserPrincipal withdrawnPrincipal = UserPrincipal.builder()
-                .id(userId)
-                .role(Role.USER)
-                .status(UserStatus.WITHDRAWN)
-                .email(null)
-                .build();
-
-        given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
-        willDoNothing().given(jwtUtil).validateToken(validAccessToken);
-        willDoNothing().given(jwtUtil).validateTokenType(validAccessToken, TOKEN_TYPE_ACCESS);
-        given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
-        given(userAuthCacheService.get(userId)).willReturn(withdrawnPrincipal);
-
-        // When
-        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
-
-        // Then
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        assertThat(authentication).isNull();
-
-        verify(userRepository, never()).findById(anyLong()); // 캐시 히트이므로 DB 조회 없음
-        verify(filterChain).doFilter(request, response);
+            verify(userRepository, never()).findById(anyLong()); // 캐시 히트이므로 DB 조회 없음
+            verify(filterChain).doFilter(request, response);
+        }
     }
 }
+

--- a/src/test/java/com/techfork/global/security/handler/login/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/com/techfork/global/security/handler/login/OAuth2AuthenticationFailureHandlerTest.java
@@ -1,0 +1,40 @@
+package com.techfork.global.security.handler.login;
+
+import com.techfork.global.security.jwt.JwtProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.BadCredentialsException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OAuth2AuthenticationFailureHandlerTest {
+
+    private static final String LOGIN_FAILURE_REDIRECT_URI = "http://localhost:5173/login?error=true";
+
+    private OAuth2AuthenticationFailureHandler failureHandler;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setLoginFailureRedirectUri(LOGIN_FAILURE_REDIRECT_URI);
+        failureHandler = new OAuth2AuthenticationFailureHandler(jwtProperties);
+    }
+
+    @Test
+    @DisplayName("OAuth2 로그인 실패 - 실패 리다이렉트 URI에 에러 메시지를 query parameter로 추가한다")
+    void onAuthenticationFailure_RedirectsWithErrorQueryParameter() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        failureHandler.onAuthenticationFailure(
+                new MockHttpServletRequest(),
+                response,
+                new BadCredentialsException("oauth_failed")
+        );
+
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo(LOGIN_FAILURE_REDIRECT_URI + "&error=oauth_failed");
+    }
+}

--- a/src/test/java/com/techfork/global/security/handler/login/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/techfork/global/security/handler/login/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,142 @@
+package com.techfork.global.security.handler.login;
+
+import com.techfork.global.security.auth.service.RefreshTokenService;
+import com.techfork.global.security.jwt.JwtDTO;
+import com.techfork.global.security.jwt.JwtProperties;
+import com.techfork.global.security.jwt.JwtUtil;
+import com.techfork.global.security.oauth.UserPrincipal;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2AuthenticationSuccessHandlerTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String ACCESS_TOKEN = "access-token";
+    private static final String REFRESH_TOKEN = "refresh-token";
+    private static final long REFRESH_TOKEN_EXPIRATION_MILLIS = 900_000L;
+    private static final String REDIRECT_URI = "http://localhost:5173/auth/callback?registered=%s&token=%s&email=%s";
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private Authentication authentication;
+
+    private JwtProperties jwtProperties;
+    private OAuth2AuthenticationSuccessHandler successHandler;
+
+    @BeforeEach
+    void setUp() {
+        jwtProperties = new JwtProperties();
+        jwtProperties.setRefreshTokenExpiration(REFRESH_TOKEN_EXPIRATION_MILLIS);
+        jwtProperties.setRedirectUri(REDIRECT_URI);
+
+        successHandler = new OAuth2AuthenticationSuccessHandler(jwtUtil, jwtProperties, refreshTokenService);
+        ReflectionTestUtils.setField(successHandler, "domain", "localhost");
+    }
+
+    @Test
+    @DisplayName("OAuth2 로그인 성공 - ACTIVE 사용자는 등록 완료 상태로 토큰과 함께 리다이렉트한다")
+    void onAuthenticationSuccess_ActiveUser_RedirectsWithRegisteredTrueAndTokens() throws Exception {
+        UserPrincipal principal = principal(UserStatus.ACTIVE, "dev user@example.com");
+        given(authentication.getPrincipal()).willReturn(principal);
+        given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
+
+        verify(jwtUtil).generateTokens(USER_ID, Role.USER);
+        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
+        assertThat(response.getRedirectedUrl()).isEqualTo(String.format(
+                REDIRECT_URI,
+                true,
+                ACCESS_TOKEN,
+                UriUtils.encode("dev user@example.com", StandardCharsets.UTF_8)
+        ));
+        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
+    }
+
+    @Test
+    @DisplayName("OAuth2 로그인 성공 - PENDING 사용자는 등록 미완료 상태로 리다이렉트한다")
+    void onAuthenticationSuccess_PendingUser_RedirectsWithRegisteredFalse() throws Exception {
+        UserPrincipal principal = principal(UserStatus.PENDING, "pending@example.com");
+        given(authentication.getPrincipal()).willReturn(principal);
+        given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
+
+        assertThat(response.getRedirectedUrl()).isEqualTo(String.format(
+                REDIRECT_URI,
+                false,
+                ACCESS_TOKEN,
+                UriUtils.encode("pending@example.com", StandardCharsets.UTF_8)
+        ));
+        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
+        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
+    }
+
+    @Test
+    @DisplayName("OAuth2 로그인 성공 - 이메일이 없으면 빈 이메일 파라미터로 리다이렉트한다")
+    void onAuthenticationSuccess_NullEmail_RedirectsWithEmptyEmail() throws Exception {
+        UserPrincipal principal = principal(UserStatus.ACTIVE, null);
+        given(authentication.getPrincipal()).willReturn(principal);
+        given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
+
+        assertThat(response.getRedirectedUrl()).isEqualTo(String.format(
+                REDIRECT_URI,
+                true,
+                ACCESS_TOKEN,
+                ""
+        ));
+        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
+        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
+    }
+
+    private UserPrincipal principal(UserStatus status, String email) {
+        return UserPrincipal.builder()
+                .id(USER_ID)
+                .role(Role.USER)
+                .status(status)
+                .email(email)
+                .build();
+    }
+
+    private void assertRefreshTokenCookie(String setCookieHeader) {
+        assertThat(setCookieHeader)
+                .contains("refreshToken=" + REFRESH_TOKEN)
+                .contains("Path=/")
+                .contains("Domain=localhost")
+                .contains("Max-Age=900")
+                .contains("Secure")
+                .contains("HttpOnly")
+                .contains("SameSite=None");
+    }
+}

--- a/src/test/java/com/techfork/global/security/oauth/CustomOidcUserServiceTest.java
+++ b/src/test/java/com/techfork/global/security/oauth/CustomOidcUserServiceTest.java
@@ -88,6 +88,40 @@ class CustomOidcUserServiceTest {
         }
 
         @Test
+        @DisplayName("신규 Kakao OIDC 사용자를 생성하고 UserPrincipal을 반환한다")
+        void loadUser_NewKakaoOidcUser_CreatesKakaoUserAndReturnsPrincipal() {
+            String kakaoSocialId = "kakao-sub-456";
+            String kakaoEmail = "kakao-user@example.com";
+            String kakaoProfileImage = "https://cdn.example.com/kakao-user.png";
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, kakaoSocialId))
+                    .willReturn(Optional.empty());
+            given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+                User savedUser = invocation.getArgument(0);
+                ReflectionTestUtils.setField(savedUser, "id", 4L);
+                return savedUser;
+            });
+
+            OidcUser oidcUser = customOidcUserService.loadUser(
+                    userRequest("kakao", claims(kakaoSocialId, kakaoEmail, kakaoProfileImage))
+            );
+
+            assertThat(oidcUser).isInstanceOf(UserPrincipal.class);
+            UserPrincipal principal = (UserPrincipal) oidcUser;
+            assertThat(principal.getId()).isEqualTo(4L);
+            assertThat(principal.getRole()).isEqualTo(Role.USER);
+            assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
+            assertThat(principal.getEmail()).isEqualTo(kakaoEmail);
+
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(userCaptor.capture());
+            User savedUser = userCaptor.getValue();
+            assertThat(savedUser.getSocialType()).isEqualTo(SocialType.KAKAO);
+            assertThat(savedUser.getSocialId()).isEqualTo(kakaoSocialId);
+            assertThat(savedUser.getEmail()).isEqualTo(kakaoEmail);
+            assertThat(savedUser.getProfileImage()).isEqualTo(kakaoProfileImage);
+        }
+
+        @Test
         @DisplayName("기존 Apple 사용자를 재사용하고 새 사용자를 저장하지 않는다")
         void loadUser_ExistingAppleUser_ReusesUserWithoutSaving() {
             User existingUser = appleUser(2L, EMAIL, PROFILE_IMAGE);
@@ -166,6 +200,10 @@ class CustomOidcUserServiceTest {
     }
 
     private OidcUserRequest userRequest(Map<String, Object> claims) {
+        return userRequest("apple", claims);
+    }
+
+    private OidcUserRequest userRequest(String registrationId, Map<String, Object> claims) {
         Instant issuedAt = Instant.now();
         Instant expiresAt = issuedAt.plusSeconds(300);
         OidcIdToken idToken = new OidcIdToken("id-token", issuedAt, expiresAt, claims);
@@ -177,23 +215,23 @@ class CustomOidcUserServiceTest {
                 Set.of("openid")
         );
 
-        return new OidcUserRequest(clientRegistration(), accessToken, idToken);
+        return new OidcUserRequest(clientRegistration(registrationId), accessToken, idToken);
     }
 
-    private ClientRegistration clientRegistration() {
-        return ClientRegistration.withRegistrationId("apple")
+    private ClientRegistration clientRegistration(String registrationId) {
+        return ClientRegistration.withRegistrationId(registrationId)
                 .clientId("techfork-client")
                 .clientSecret("techfork-secret")
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .redirectUri("https://techfork.site/login/oauth2/code/apple")
+                .redirectUri("https://techfork.site/login/oauth2/code/" + registrationId)
                 .scope("openid")
-                .authorizationUri("https://appleid.apple.com/auth/authorize")
-                .tokenUri("https://appleid.apple.com/auth/token")
-                .jwkSetUri("https://appleid.apple.com/auth/keys")
-                .issuerUri("https://appleid.apple.com")
+                .authorizationUri("https://auth.example.com/oauth/authorize")
+                .tokenUri("https://auth.example.com/oauth/token")
+                .jwkSetUri("https://auth.example.com/oauth/keys")
+                .issuerUri("https://auth.example.com")
                 .userNameAttributeName("sub")
-                .clientName("Apple")
+                .clientName(registrationId)
                 .build();
     }
 

--- a/src/test/java/com/techfork/global/security/oauth/CustomOidcUserServiceTest.java
+++ b/src/test/java/com/techfork/global/security/oauth/CustomOidcUserServiceTest.java
@@ -1,0 +1,213 @@
+package com.techfork.global.security.oauth;
+
+import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.SocialType;
+import com.techfork.useraccount.domain.enums.UserStatus;
+import com.techfork.useraccount.infrastructure.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CustomOidcUserServiceTest {
+
+    private static final String SOCIAL_ID = "apple-sub-123";
+    private static final String EMAIL = "apple-user@example.com";
+    private static final String PROFILE_IMAGE = "https://cdn.example.com/apple-user.png";
+
+    @Mock
+    private UserRepository userRepository;
+
+    private CustomOidcUserService customOidcUserService;
+
+    @BeforeEach
+    void setUp() {
+        customOidcUserService = new CustomOidcUserService(userRepository);
+        customOidcUserService.setRetrieveUserInfo(request -> false);
+    }
+
+    @Nested
+    @DisplayName("성공")
+    class Success {
+
+        @Test
+        @DisplayName("신규 Apple 사용자를 생성하고 UserPrincipal을 반환한다")
+        void loadUser_NewAppleUser_CreatesUserAndReturnsPrincipal() {
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
+                    .willReturn(Optional.empty());
+            given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+                User savedUser = invocation.getArgument(0);
+                ReflectionTestUtils.setField(savedUser, "id", 1L);
+                return savedUser;
+            });
+
+            OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
+
+            assertThat(oidcUser).isInstanceOf(UserPrincipal.class);
+            UserPrincipal principal = (UserPrincipal) oidcUser;
+            assertThat(principal.getId()).isEqualTo(1L);
+            assertThat(principal.getRole()).isEqualTo(Role.USER);
+            assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
+            assertThat(principal.getEmail()).isEqualTo(EMAIL);
+
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(userCaptor.capture());
+            User savedUser = userCaptor.getValue();
+            assertThat(savedUser.getSocialType()).isEqualTo(SocialType.APPLE);
+            assertThat(savedUser.getSocialId()).isEqualTo(SOCIAL_ID);
+            assertThat(savedUser.getEmail()).isEqualTo(EMAIL);
+            assertThat(savedUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
+        }
+
+        @Test
+        @DisplayName("기존 Apple 사용자를 재사용하고 새 사용자를 저장하지 않는다")
+        void loadUser_ExistingAppleUser_ReusesUserWithoutSaving() {
+            User existingUser = appleUser(2L, EMAIL, PROFILE_IMAGE);
+            existingUser.updateUser("기존사용자", EMAIL, "온보딩 완료 사용자");
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
+                    .willReturn(Optional.of(existingUser));
+
+            OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
+
+            UserPrincipal principal = (UserPrincipal) oidcUser;
+            assertThat(principal.getId()).isEqualTo(2L);
+            assertThat(principal.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(principal.getEmail()).isEqualTo(EMAIL);
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("탈퇴 Apple 사용자를 재활성화하고 PENDING principal을 반환한다")
+        void loadUser_WithdrawnAppleUser_ReactivatesUserAndReturnsPendingPrincipal() {
+            User withdrawnUser = appleUser(3L, "old@example.com", "https://cdn.example.com/old.png");
+            withdrawnUser.updateUser("탈퇴사용자", "old@example.com", "탈퇴 전 설명");
+            withdrawnUser.withdraw();
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
+                    .willReturn(Optional.of(withdrawnUser));
+
+            OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
+
+            UserPrincipal principal = (UserPrincipal) oidcUser;
+            assertThat(principal.getId()).isEqualTo(3L);
+            assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
+            assertThat(principal.getEmail()).isEqualTo(EMAIL);
+            assertThat(withdrawnUser.getEmail()).isEqualTo(EMAIL);
+            assertThat(withdrawnUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
+            assertThat(withdrawnUser.getStatus()).isEqualTo(UserStatus.PENDING);
+            verify(userRepository, never()).save(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("실패")
+    class Failure {
+
+        @Test
+        @DisplayName("sub 클레임이 없으면 예외를 던진다")
+        void loadUser_MissingSubject_ThrowsException() {
+            Map<String, Object> claims = claims(null, EMAIL, PROFILE_IMAGE);
+
+            assertThatThrownBy(() -> customOidcUserService.loadUser(userRequest(claims)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("sub");
+
+            verify(userRepository, never()).findBySocialTypeAndSocialId(any(), any());
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("email 클레임이 없으면 예외를 던지고 사용자를 저장하지 않는다")
+        void loadUser_MissingEmail_ThrowsOAuth2AuthenticationException() {
+            Map<String, Object> claims = claims(SOCIAL_ID, null, PROFILE_IMAGE);
+
+            assertThatThrownBy(() -> customOidcUserService.loadUser(userRequest(claims)))
+                    .isInstanceOf(OAuth2AuthenticationException.class)
+                    .satisfies(exception -> assertThat(((OAuth2AuthenticationException) exception)
+                            .getError()
+                            .getErrorCode()).isEqualTo("email not found"));
+
+            verify(userRepository, never()).findBySocialTypeAndSocialId(any(), any());
+            verify(userRepository, never()).save(any(User.class));
+        }
+    }
+
+    private User appleUser(Long id, String email, String profileImage) {
+        User user = User.createSocialUser(SocialType.APPLE, SOCIAL_ID, email, profileImage);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private OidcUserRequest userRequest(Map<String, Object> claims) {
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = issuedAt.plusSeconds(300);
+        OidcIdToken idToken = new OidcIdToken("id-token", issuedAt, expiresAt, claims);
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "access-token",
+                issuedAt,
+                expiresAt,
+                Set.of("openid")
+        );
+
+        return new OidcUserRequest(clientRegistration(), accessToken, idToken);
+    }
+
+    private ClientRegistration clientRegistration() {
+        return ClientRegistration.withRegistrationId("apple")
+                .clientId("techfork-client")
+                .clientSecret("techfork-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://techfork.site/login/oauth2/code/apple")
+                .scope("openid")
+                .authorizationUri("https://appleid.apple.com/auth/authorize")
+                .tokenUri("https://appleid.apple.com/auth/token")
+                .jwkSetUri("https://appleid.apple.com/auth/keys")
+                .issuerUri("https://appleid.apple.com")
+                .userNameAttributeName("sub")
+                .clientName("Apple")
+                .build();
+    }
+
+    private Map<String, Object> claims(String subject, String email, String profileImage) {
+        Map<String, Object> claims = new HashMap<>();
+        if (subject != null) {
+            claims.put("sub", subject);
+        }
+        if (email != null) {
+            claims.put("email", email);
+        }
+        if (profileImage != null) {
+            claims.put("picture", profileImage);
+        }
+        return claims;
+    }
+}

--- a/src/test/java/com/techfork/global/security/oauth/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/src/test/java/com/techfork/global/security/oauth/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -1,0 +1,121 @@
+package com.techfork.global.security.oauth;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import java.util.Map;
+import java.util.Set;
+
+import static com.techfork.global.security.oauth.HttpCookieOAuth2AuthorizationRequestRepository.OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
+
+    private final HttpCookieOAuth2AuthorizationRequestRepository repository =
+            new HttpCookieOAuth2AuthorizationRequestRepository();
+
+    @Test
+    @DisplayName("OAuth2 authorization request 저장 시 직렬화된 httpOnly 쿠키를 생성한다")
+    void saveAuthorizationRequest_CreatesSerializedHttpOnlyCookie() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        OAuth2AuthorizationRequest authorizationRequest = authorizationRequest();
+
+        repository.saveAuthorizationRequest(
+                authorizationRequest,
+                new MockHttpServletRequest(),
+                response
+        );
+
+        Cookie cookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        assertThat(cookie).isNotNull();
+        assertThat(cookie.getValue()).isNotBlank();
+        assertThat(cookie.getPath()).isEqualTo("/");
+        assertThat(cookie.isHttpOnly()).isTrue();
+        assertThat(cookie.getMaxAge()).isEqualTo(180);
+    }
+
+    @Test
+    @DisplayName("OAuth2 authorization request 쿠키가 있으면 역직렬화해서 로드한다")
+    void loadAuthorizationRequest_WithCookie_ReturnsDeserializedAuthorizationRequest() {
+        OAuth2AuthorizationRequest original = authorizationRequest();
+        MockHttpServletResponse saveResponse = new MockHttpServletResponse();
+        repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
+
+        MockHttpServletRequest loadRequest = new MockHttpServletRequest();
+        loadRequest.setCookies(saveResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
+
+        OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(loadRequest);
+
+        assertThat(loaded).isNotNull();
+        assertThat(loaded.getAuthorizationUri()).isEqualTo(original.getAuthorizationUri());
+        assertThat(loaded.getClientId()).isEqualTo(original.getClientId());
+        assertThat(loaded.getRedirectUri()).isEqualTo(original.getRedirectUri());
+        assertThat(loaded.getScopes()).isEqualTo(original.getScopes());
+        assertThat(loaded.getState()).isEqualTo(original.getState());
+        assertThat(loaded.getAdditionalParameters()).containsEntry("nonce", "nonce-123");
+        assertThat(loaded.getAttributes()).containsEntry("registration_id", "apple");
+    }
+
+    @Test
+    @DisplayName("OAuth2 authorization request 쿠키가 없으면 null을 반환한다")
+    void loadAuthorizationRequest_WithoutCookie_ReturnsNull() {
+        OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(new MockHttpServletRequest());
+
+        assertThat(loaded).isNull();
+    }
+
+    @Test
+    @DisplayName("removeAuthorizationRequest는 기존 request를 반환하고 삭제 쿠키를 추가한다")
+    void removeAuthorizationRequest_ReturnsExistingRequestAndAddsDeleteCookie() {
+        OAuth2AuthorizationRequest original = authorizationRequest();
+        MockHttpServletResponse saveResponse = new MockHttpServletResponse();
+        repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
+
+        MockHttpServletRequest removeRequest = new MockHttpServletRequest();
+        removeRequest.setCookies(saveResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
+        MockHttpServletResponse removeResponse = new MockHttpServletResponse();
+
+        OAuth2AuthorizationRequest removed = repository.removeAuthorizationRequest(removeRequest, removeResponse);
+
+        assertThat(removed).isNotNull();
+        assertThat(removed.getState()).isEqualTo(original.getState());
+        Cookie deleteCookie = removeResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        assertThat(deleteCookie).isNotNull();
+        assertThat(deleteCookie.getValue()).isEmpty();
+        assertThat(deleteCookie.getPath()).isEqualTo("/");
+        assertThat(deleteCookie.getMaxAge()).isZero();
+    }
+
+    @Test
+    @DisplayName("saveAuthorizationRequest에 null을 넘기면 기존 authorization request 쿠키를 삭제한다")
+    void saveAuthorizationRequest_NullRequest_AddsDeleteCookieWhenCookieExists() {
+        Cookie existingCookie = new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, "serialized-request");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(existingCookie);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        repository.saveAuthorizationRequest(null, request, response);
+
+        Cookie deleteCookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        assertThat(deleteCookie).isNotNull();
+        assertThat(deleteCookie.getValue()).isEmpty();
+        assertThat(deleteCookie.getPath()).isEqualTo("/");
+        assertThat(deleteCookie.getMaxAge()).isZero();
+    }
+
+    private OAuth2AuthorizationRequest authorizationRequest() {
+        return OAuth2AuthorizationRequest.authorizationCode()
+                .authorizationUri("https://appleid.apple.com/auth/authorize")
+                .clientId("techfork-client")
+                .redirectUri("https://techfork.site/login/oauth2/code/apple")
+                .scopes(Set.of("openid", "email"))
+                .state("state-123")
+                .additionalParameters(Map.of("nonce", "nonce-123"))
+                .attributes(Map.of("registration_id", "apple"))
+                .build();
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

Auth / Security DDD 리팩터링 전 회귀 테스트를 보강했습니다.

- OAuth2 로그인 성공/실패 핸들러 단위 테스트 추가
- OAuth2 authorization request cookie repository save/load/remove 테스트 추가
- `CustomOidcUserService` Apple/Kakao OIDC 신규/기존/탈퇴 재가입/실패 케이스 테스트 추가
- `JwtAuthenticationFilterTest`를 성공/실패 Nested 구조로 정리
- JWT 인증 실패 시 `JWT_EXCEPTION_ATTRIBUTE`로 예외가 entry point까지 전달되는지 검증 추가

> OAuth2 실패 redirect error encoding 및 authorization request cookie `Secure`/`SameSite` 정책은 프론트/브라우저 동작 영향이 있어 #433으로 분리했습니다.

<br>

## 연결된 issue

close #427

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] `global/security` 테스트가 DDD 리팩터링 전 회귀 안전망으로 충분한지 확인해주세요.
- [ ] OAuth2/OIDC 브라우저 보안 속성 변경은 이번 PR에서 제외하고 #433으로 분리한 결정이 적절한지 확인해주세요.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과를 넣었는가?
- [x] 이슈넘버를 적었는가?

## 🧪 테스트 결과

```bash
./gradlew test \
  --tests '*OAuth2AuthenticationSuccessHandlerTest' \
  --tests '*OAuth2AuthenticationFailureHandlerTest' \
  --tests '*HttpCookieOAuth2AuthorizationRequestRepositoryTest' \
  --tests '*CustomOidcUserServiceTest' \
  --tests '*JwtAuthenticationFilterTest' \
  --tests '*UserAuthCacheEventListenerTest'
```

- Result: `BUILD SUCCESSFUL`

추가 확인:

```bash
./gradlew test --tests '*JwtAuthenticationFilterTest'
./gradlew test --tests '*OAuth2AuthenticationFailureHandlerTest'
```

- Result: `BUILD SUCCESSFUL`
