### PR TITLE
[refactor/#429] Auth 서비스의 UserRepository 직접 의존 경계 정리

### DIFF
--- a/src/main/java/com/techfork/auth/application/command/AuthCommandService.java
+++ b/src/main/java/com/techfork/auth/application/command/AuthCommandService.java
@@ -12,9 +12,9 @@ import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.service.RefreshTokenService;
 import com.techfork.auth.security.service.UserAuthCacheService;
 import com.techfork.global.exception.GeneralException;
-import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.enums.Role;
-import com.techfork.useraccount.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,7 +30,7 @@ public class AuthCommandService {
 
     private final JwtUtil jwtUtil;
     private final RefreshTokenService refreshTokenService;
-    private final UserRepository userRepository;
+    private final UserAuthAccountService userAuthAccountService;
     private final JwtProperties jwtProperties;
     private final UserAuthCacheService userAuthCacheService;
 
@@ -41,14 +41,14 @@ public class AuthCommandService {
         Long userId = jwtUtil.getUserIdFromToken(refreshToken);
         validateRefreshTokenInRedis(userId, refreshToken);
 
-        User user = userRepository.findById(userId)
+        UserAuthProfile userAuthProfile = userAuthAccountService.findAuthProfileById(userId)
                 .orElseThrow(() -> new GeneralException(AuthErrorCode.USER_NOT_FOUND));
 
-        JwtDTO newTokens = jwtUtil.generateTokens(userId, user.getRole());
+        JwtDTO newTokens = jwtUtil.generateTokens(userId, userAuthProfile.role());
         long expiration = jwtProperties.getRefreshTokenExpiration();
         saveRefreshToken(userId, newTokens.refreshToken(), expiration);
 
-        userAuthCacheService.put(userId, user, jwtProperties.getAccessTokenExpiration());
+        userAuthCacheService.put(userId, userAuthProfile, jwtProperties.getAccessTokenExpiration());
 
         log.info("Token refreshed");
 
@@ -71,14 +71,14 @@ public class AuthCommandService {
 
     public DeveloperTokenResult generateDeveloperToken(GenerateDeveloperTokenCommand command) {
         Long userId = command.userId();
-        User user = userRepository.findById(userId)
+        UserAuthProfile userAuthProfile = userAuthAccountService.findAuthProfileById(userId)
                 .orElseThrow(() -> new GeneralException(AuthErrorCode.USER_NOT_FOUND));
 
-        if (user.getRole() != Role.ADMIN) {
+        if (userAuthProfile.role() != Role.ADMIN) {
             throw new GeneralException(AuthErrorCode.FORBIDDEN_INSUFFICIENT_PERMISSIONS);
         }
 
-        String longLivedAccessToken = jwtUtil.generateLongLivedAccessToken(userId, user.getRole());
+        String longLivedAccessToken = jwtUtil.generateLongLivedAccessToken(userId, userAuthProfile.role());
 
         log.info("Developer token (long-lived access token) generated for admin userId: {}", userId);
 

--- a/src/main/java/com/techfork/auth/application/command/KakaoLoginCommandService.java
+++ b/src/main/java/com/techfork/auth/application/command/KakaoLoginCommandService.java
@@ -8,9 +8,9 @@ import com.techfork.auth.security.jwt.JwtDTO;
 import com.techfork.auth.security.jwt.JwtProperties;
 import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.service.RefreshTokenService;
-import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.enums.SocialType;
-import com.techfork.useraccount.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class KakaoLoginCommandService {
 
     private final KakaoOAuthService kakaoOAuthService;
-    private final UserRepository userRepository;
+    private final UserAuthAccountService userAuthAccountService;
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;
     private final RefreshTokenService refreshTokenService;
@@ -35,24 +35,26 @@ public class KakaoLoginCommandService {
         String email = kakaoUserInfo.kakaoAccount().email();
         String profileImageUrl = kakaoUserInfo.kakaoAccount().profile().profileImageUrl();
 
-        User user = userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, socialId)
-                .orElseGet(() -> {
-                    User newUser = User.createSocialUser(SocialType.KAKAO, socialId, email, profileImageUrl);
-                    return userRepository.save(newUser);
-                });
+        UserAuthProfile userAuthProfile = userAuthAccountService.getOrCreateSocialAuthProfile(
+                SocialType.KAKAO,
+                socialId,
+                email,
+                profileImageUrl
+        );
 
-        JwtDTO tokens = jwtUtil.generateTokens(user.getId(), user.getRole());
+        JwtDTO tokens = jwtUtil.generateTokens(userAuthProfile.id(), userAuthProfile.role());
         long expiration = jwtProperties.getRefreshTokenExpiration();
-        refreshTokenService.saveRefreshToken(user.getId(), tokens.refreshToken(), expiration);
+        refreshTokenService.saveRefreshToken(userAuthProfile.id(), tokens.refreshToken(), expiration);
 
-        log.info("Direct Kakao login successful - userId: {}, isRegistered: {}", user.getId(), user.isActive());
+        log.info("Direct Kakao login successful - userId: {}, isRegistered: {}",
+                userAuthProfile.id(), userAuthProfile.active());
 
         return KakaoLoginResult.builder()
                 .accessToken(tokens.accessToken())
                 .refreshToken(tokens.refreshToken())
                 .refreshTokenExpiration(expiration)
-                .userId(user.getId())
-                .isRegistered(user.isActive())
+                .userId(userAuthProfile.id())
+                .isRegistered(userAuthProfile.active())
                 .build();
     }
 }

--- a/src/main/java/com/techfork/auth/application/command/KakaoLoginCommandService.java
+++ b/src/main/java/com/techfork/auth/application/command/KakaoLoginCommandService.java
@@ -3,6 +3,7 @@ package com.techfork.auth.application.command;
 import com.techfork.auth.application.command.input.KakaoLoginCommand;
 import com.techfork.auth.application.command.result.KakaoLoginResult;
 import com.techfork.auth.infrastructure.kakao.KakaoOAuthService;
+import com.techfork.auth.infrastructure.kakao.KakaoSocialId;
 import com.techfork.auth.infrastructure.kakao.response.KakaoUserInfoResponse;
 import com.techfork.auth.security.jwt.JwtDTO;
 import com.techfork.auth.security.jwt.JwtProperties;
@@ -31,7 +32,7 @@ public class KakaoLoginCommandService {
     public KakaoLoginResult login(KakaoLoginCommand command) {
         KakaoUserInfoResponse kakaoUserInfo = kakaoOAuthService.getUserInfo(command.accessToken());
 
-        String socialId = kakaoUserInfo.id().toString();
+        String socialId = KakaoSocialId.fromRestUserId(kakaoUserInfo.id());
         String email = kakaoUserInfo.kakaoAccount().email();
         String profileImageUrl = kakaoUserInfo.kakaoAccount().profile().profileImageUrl();
 

--- a/src/main/java/com/techfork/auth/infrastructure/kakao/KakaoSocialId.java
+++ b/src/main/java/com/techfork/auth/infrastructure/kakao/KakaoSocialId.java
@@ -1,0 +1,32 @@
+package com.techfork.auth.infrastructure.kakao;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Kakao 계정 식별자를 TechFork 소셜 로그인 식별자로 정규화한다.
+ *
+ * <p>Kakao 문서상 REST 사용자 정보 조회 API의 {@code id}와 OIDC ID token의
+ * {@code sub}는 같은 Kakao 앱 안에서 사용자를 식별하는 service user ID 계약이다.</p>
+ *
+ * @see <a href="https://developers.kakao.com/docs/en/kakaologin/rest-api#req-user-info-response-body">Kakao REST user info</a>
+ * @see <a href="https://developers.kakao.com/docs/en/kakaologin/utilize#oidc-id-token-payload">Kakao OIDC ID token payload</a>
+ */
+public final class KakaoSocialId {
+
+    private KakaoSocialId() {
+    }
+
+    public static String fromRestUserId(Long id) {
+        if (id == null) {
+            throw new IllegalArgumentException("Kakao REST user id must not be null");
+        }
+        return id.toString();
+    }
+
+    public static String fromOidcSubject(String subject) {
+        if (!StringUtils.hasText(subject)) {
+            throw new IllegalArgumentException("Kakao OIDC subject(sub) must not be blank");
+        }
+        return subject;
+    }
+}

--- a/src/main/java/com/techfork/auth/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/techfork/auth/security/filter/JwtAuthenticationFilter.java
@@ -1,21 +1,22 @@
 package com.techfork.auth.security.filter;
 
 import com.techfork.auth.domain.exception.AuthErrorCode;
-import com.techfork.useraccount.domain.User;
-import com.techfork.useraccount.domain.enums.UserStatus;
-import com.techfork.useraccount.infrastructure.UserRepository;
 import com.techfork.auth.security.AuthSecurityConstants;
-import com.techfork.global.constant.MdcKey;
-import com.techfork.global.exception.GeneralException;
-import com.techfork.auth.security.service.UserAuthCacheService;
 import com.techfork.auth.security.jwt.JwtProperties;
 import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.oauth.UserPrincipal;
+import com.techfork.auth.security.service.UserAuthCacheService;
 import com.techfork.auth.security.util.HeaderUtil;
+import com.techfork.global.constant.MdcKey;
+import com.techfork.global.exception.GeneralException;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
+import com.techfork.useraccount.domain.enums.UserStatus;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
@@ -25,8 +26,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
 
 import static com.techfork.auth.security.jwt.JwtConstants.TOKEN_TYPE_ACCESS;
 
@@ -42,7 +41,7 @@ import static com.techfork.auth.security.jwt.JwtConstants.TOKEN_TYPE_ACCESS;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
+    private final UserAuthAccountService userAuthAccountService;
     private final UserAuthCacheService userAuthCacheService;
     private final JwtProperties jwtProperties;
 
@@ -62,16 +61,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 UserPrincipal userPrincipal = userAuthCacheService.get(userId);
 
                 if (userPrincipal == null) {
-                    User user = userRepository.findById(userId)
+                    UserAuthProfile userAuthProfile = userAuthAccountService.findAuthProfileById(userId)
                             .orElseThrow(() -> new GeneralException(AuthErrorCode.USER_NOT_FOUND));
 
-                    userPrincipal = UserPrincipal.buildUserPrincipal(user);
+                    userPrincipal = UserPrincipal.from(userAuthProfile);
 
                     if (userPrincipal.getStatus() == UserStatus.WITHDRAWN) {
                         throw new GeneralException(AuthErrorCode.WITHDRAWN_USER);
                     }
 
-                    userAuthCacheService.put(userId, user, jwtProperties.getAccessTokenExpiration());
+                    userAuthCacheService.put(userId, userAuthProfile, jwtProperties.getAccessTokenExpiration());
                 } else if (userPrincipal.getStatus() == UserStatus.WITHDRAWN) {
                     throw new GeneralException(AuthErrorCode.WITHDRAWN_USER);
                 }

--- a/src/main/java/com/techfork/auth/security/listener/UserAuthCacheEventListener.java
+++ b/src/main/java/com/techfork/auth/security/listener/UserAuthCacheEventListener.java
@@ -2,6 +2,7 @@ package com.techfork.auth.security.listener;
 
 import com.techfork.auth.security.service.UserAuthCacheService;
 import com.techfork.useraccount.application.event.OnboardingCompletedEvent;
+import com.techfork.useraccount.application.event.UserReactivatedEvent;
 import com.techfork.useraccount.application.event.UserWithdrawnEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,11 @@ public class UserAuthCacheEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(OnboardingCompletedEvent event) {
         evictUserAuthCache(event.userId(), "onboarding-completed");
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(UserReactivatedEvent event) {
+        evictUserAuthCache(event.userId(), "user-reactivated");
     }
 
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)

--- a/src/main/java/com/techfork/auth/security/oauth/CustomOidcUserService.java
+++ b/src/main/java/com/techfork/auth/security/oauth/CustomOidcUserService.java
@@ -1,8 +1,8 @@
 package com.techfork.auth.security.oauth;
 
-import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.enums.SocialType;
-import com.techfork.useraccount.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomOidcUserService extends OidcUserService {
 
-    private final UserRepository userRepository;
+    private final UserAuthAccountService userAuthAccountService;
 
     @Override
     @Transactional
@@ -37,30 +37,16 @@ public class CustomOidcUserService extends OidcUserService {
         }
         String profileImage = oidcUser.getAttribute("picture");
 
-        User user = getOrCreateUser(socialType, socialId, email, profileImage);
+        UserAuthProfile userAuthProfile = userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+                socialType,
+                socialId,
+                email,
+                profileImage
+        );
 
         log.info("CustomOAuth2UserService - loaded user: id={}, email={}, socialType={}",
-                user.getId(), email, socialType);
+                userAuthProfile.id(), email, socialType);
 
-        return UserPrincipal.buildUserPrincipal(user);
-    }
-
-    private User getOrCreateUser(SocialType socialType, String socialId, String email, String profileImage) {
-        return userRepository.findBySocialTypeAndSocialId(socialType, socialId)
-                .map(user -> {
-                    if (user.isWithdrawn()) {
-                        log.info("Withdrawn user re-registering - userId: {}, email: {}", user.getId(), email);
-                        user.reactivate(email, profileImage);
-                        return user;
-                    }
-                    return user;
-                })
-                .orElseGet(() -> {
-                    User newUser = User.createSocialUser(socialType, socialId, email, profileImage);
-                    User savedUser = userRepository.save(newUser);
-                    log.info("New user created - id: {}, socialType: {}, socialId: {}, email: {}, profileImage: {}",
-                            savedUser.getId(), socialType, socialId, email, profileImage);
-                    return savedUser;
-                });
+        return UserPrincipal.from(userAuthProfile);
     }
 }

--- a/src/main/java/com/techfork/auth/security/oauth/CustomOidcUserService.java
+++ b/src/main/java/com/techfork/auth/security/oauth/CustomOidcUserService.java
@@ -1,5 +1,6 @@
 package com.techfork.auth.security.oauth;
 
+import com.techfork.auth.infrastructure.kakao.KakaoSocialId;
 import com.techfork.useraccount.application.auth.UserAuthAccountService;
 import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.enums.SocialType;
@@ -27,10 +28,7 @@ public class CustomOidcUserService extends OidcUserService {
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
         SocialType socialType = SocialType.fromRegistrationId(registrationId);
 
-        String socialId = oidcUser.getAttribute("sub");
-        if (socialId == null) {
-            throw new OAuth2AuthenticationException("socialId(sub) not found");
-        }
+        String socialId = resolveSocialId(socialType, oidcUser);
         String email = oidcUser.getAttribute("email");
         if (email == null) {
             throw new OAuth2AuthenticationException("email not found");
@@ -48,5 +46,16 @@ public class CustomOidcUserService extends OidcUserService {
                 userAuthProfile.id(), email, socialType);
 
         return UserPrincipal.from(userAuthProfile);
+    }
+
+    private String resolveSocialId(SocialType socialType, OidcUser oidcUser) {
+        String subject = oidcUser.getAttribute("sub");
+        if (subject == null) {
+            throw new OAuth2AuthenticationException("socialId(sub) not found");
+        }
+        if (socialType == SocialType.KAKAO) {
+            return KakaoSocialId.fromOidcSubject(subject);
+        }
+        return subject;
     }
 }

--- a/src/main/java/com/techfork/auth/security/oauth/CustomOidcUserService.java
+++ b/src/main/java/com/techfork/auth/security/oauth/CustomOidcUserService.java
@@ -37,7 +37,7 @@ public class CustomOidcUserService extends OidcUserService {
         }
         String profileImage = oidcUser.getAttribute("picture");
 
-        UserAuthProfile userAuthProfile = userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+        UserAuthProfile userAuthProfile = userAuthAccountService.getOrCreateSocialAuthProfile(
                 socialType,
                 socialId,
                 email,

--- a/src/main/java/com/techfork/auth/security/oauth/UserPrincipal.java
+++ b/src/main/java/com/techfork/auth/security/oauth/UserPrincipal.java
@@ -1,8 +1,11 @@
 package com.techfork.auth.security.oauth;
 
-import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.UserStatus;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
@@ -11,10 +14,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 
 /**
  * Spring Security 인증 주체 (Principal)
@@ -27,7 +26,6 @@ import java.util.Map;
  * - role: 권한 (ADMIN, USER)
  * - status: 계정 상태 (PENDING, ACTIVE)
  * - email: 사용자 이메일
- * - profileImage: 프로필 이미지 URL
  * - attributes: OAuth2 로그인용 속성 (일반 JWT에서는 null)
  */
 @Getter
@@ -107,12 +105,12 @@ public class UserPrincipal implements UserDetails, OidcUser {
         return null;
     }
 
-    public static UserPrincipal buildUserPrincipal(User user) {
+    public static UserPrincipal from(UserAuthProfile userAuthProfile) {
         return UserPrincipal.builder()
-                .id(user.getId())
-                .role(user.getRole())
-                .status(user.getStatus())
-                .email(user.getEmail())
+                .id(userAuthProfile.id())
+                .role(userAuthProfile.role())
+                .status(userAuthProfile.status())
+                .email(userAuthProfile.email())
                 .build();
     }
 }

--- a/src/main/java/com/techfork/auth/security/service/UserAuthCacheService.java
+++ b/src/main/java/com/techfork/auth/security/service/UserAuthCacheService.java
@@ -27,7 +27,11 @@ public class UserAuthCacheService {
         if (cached == null) {
             return null;
         }
-        return deserialize(cached);
+        UserAuthProfile userAuthProfile = deserializeAuthProfile(cached);
+        if (userAuthProfile == null) {
+            return null;
+        }
+        return UserPrincipal.from(userAuthProfile);
     }
 
     public void put(Long userId, UserAuthProfile userAuthProfile, long ttlMillis) {
@@ -54,17 +58,19 @@ public class UserAuthCacheService {
                 + DELIMITER + (userAuthProfile.email() != null ? userAuthProfile.email() : "");
     }
 
-    private UserPrincipal deserialize(String value) {
+    private UserAuthProfile deserializeAuthProfile(String value) {
         String[] parts = value.split("\\" + DELIMITER, FIELD_COUNT);
         if (parts.length != FIELD_COUNT) {
             log.warn("Invalid user auth cache format: {}", value);
             return null;
         }
-        return UserPrincipal.builder()
-                .id(Long.parseLong(parts[0]))
-                .role(Role.valueOf(parts[1]))
-                .status(UserStatus.valueOf(parts[2]))
-                .email(parts[3].isEmpty() ? null : parts[3])
-                .build();
+        UserStatus status = UserStatus.valueOf(parts[2]);
+        return new UserAuthProfile(
+                Long.parseLong(parts[0]),
+                Role.valueOf(parts[1]),
+                status,
+                parts[3].isEmpty() ? null : parts[3],
+                status == UserStatus.ACTIVE
+        );
     }
 }

--- a/src/main/java/com/techfork/auth/security/service/UserAuthCacheService.java
+++ b/src/main/java/com/techfork/auth/security/service/UserAuthCacheService.java
@@ -1,17 +1,15 @@
 package com.techfork.auth.security.service;
 
+import com.techfork.auth.security.oauth.UserPrincipal;
+import com.techfork.global.constant.RedisKey;
 import com.techfork.useraccount.application.auth.UserAuthProfile;
-import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.UserStatus;
-import com.techfork.global.constant.RedisKey;
-import com.techfork.auth.security.oauth.UserPrincipal;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -30,10 +28,6 @@ public class UserAuthCacheService {
             return null;
         }
         return deserialize(cached);
-    }
-
-    public void put(Long userId, User user, long ttlMillis) {
-        put(userId, UserAuthProfile.from(user), ttlMillis);
     }
 
     public void put(Long userId, UserAuthProfile userAuthProfile, long ttlMillis) {

--- a/src/main/java/com/techfork/auth/security/service/UserAuthCacheService.java
+++ b/src/main/java/com/techfork/auth/security/service/UserAuthCacheService.java
@@ -1,5 +1,6 @@
 package com.techfork.auth.security.service;
 
+import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.UserStatus;
@@ -32,8 +33,12 @@ public class UserAuthCacheService {
     }
 
     public void put(Long userId, User user, long ttlMillis) {
+        put(userId, UserAuthProfile.from(user), ttlMillis);
+    }
+
+    public void put(Long userId, UserAuthProfile userAuthProfile, long ttlMillis) {
         String key = buildKey(userId);
-        String value = serialize(user);
+        String value = serialize(userAuthProfile);
         redisTemplate.opsForValue().set(key, value, ttlMillis, TimeUnit.MILLISECONDS);
         log.debug("User auth cached for userId: {}", userId);
     }
@@ -48,11 +53,11 @@ public class UserAuthCacheService {
         return RedisKey.USER_AUTH_PREFIX + userId;
     }
 
-    private String serialize(User user) {
-        return user.getId()
-                + DELIMITER + user.getRole().name()
-                + DELIMITER + user.getStatus().name()
-                + DELIMITER + (user.getEmail() != null ? user.getEmail() : "");
+    private String serialize(UserAuthProfile userAuthProfile) {
+        return userAuthProfile.id()
+                + DELIMITER + userAuthProfile.role().name()
+                + DELIMITER + userAuthProfile.status().name()
+                + DELIMITER + (userAuthProfile.email() != null ? userAuthProfile.email() : "");
     }
 
     private UserPrincipal deserialize(String value) {

--- a/src/main/java/com/techfork/useraccount/application/auth/UserAuthAccountService.java
+++ b/src/main/java/com/techfork/useraccount/application/auth/UserAuthAccountService.java
@@ -1,0 +1,61 @@
+package com.techfork.useraccount.application.auth;
+
+import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.domain.enums.SocialType;
+import com.techfork.useraccount.infrastructure.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserAuthAccountService {
+
+    private final UserRepository userRepository;
+
+    public Optional<UserAuthProfile> findAuthProfileById(Long userId) {
+        return userRepository.findById(userId)
+                .map(UserAuthProfile::from);
+    }
+
+    @Transactional
+    public UserAuthProfile getOrCreateSocialAuthProfile(
+            SocialType socialType,
+            String socialId,
+            String email,
+            String profileImage
+    ) {
+        User user = userRepository.findBySocialTypeAndSocialId(socialType, socialId)
+                .orElseGet(() -> createSocialUser(socialType, socialId, email, profileImage));
+
+        return UserAuthProfile.from(user);
+    }
+
+    @Transactional
+    public UserAuthProfile getOrCreateReactivatedSocialAuthProfile(
+            SocialType socialType,
+            String socialId,
+            String email,
+            String profileImage
+    ) {
+        User user = userRepository.findBySocialTypeAndSocialId(socialType, socialId)
+                .map(existingUser -> reactivateIfWithdrawn(existingUser, email, profileImage))
+                .orElseGet(() -> createSocialUser(socialType, socialId, email, profileImage));
+
+        return UserAuthProfile.from(user);
+    }
+
+    private User createSocialUser(SocialType socialType, String socialId, String email, String profileImage) {
+        User newUser = User.createSocialUser(socialType, socialId, email, profileImage);
+        return userRepository.save(newUser);
+    }
+
+    private User reactivateIfWithdrawn(User user, String email, String profileImage) {
+        if (user.isWithdrawn()) {
+            user.reactivate(email, profileImage);
+        }
+        return user;
+    }
+}

--- a/src/main/java/com/techfork/useraccount/application/auth/UserAuthAccountService.java
+++ b/src/main/java/com/techfork/useraccount/application/auth/UserAuthAccountService.java
@@ -1,10 +1,12 @@
 package com.techfork.useraccount.application.auth;
 
+import com.techfork.useraccount.application.event.UserReactivatedEvent;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.infrastructure.UserRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserAuthAccountService {
 
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public Optional<UserAuthProfile> findAuthProfileById(Long userId) {
         return userRepository.findById(userId)
@@ -42,6 +45,7 @@ public class UserAuthAccountService {
     private User reactivateIfWithdrawn(User user, String email, String profileImage) {
         if (user.isWithdrawn()) {
             user.reactivate(email, profileImage);
+            eventPublisher.publishEvent(new UserReactivatedEvent(user.getId()));
         }
         return user;
     }

--- a/src/main/java/com/techfork/useraccount/application/auth/UserAuthAccountService.java
+++ b/src/main/java/com/techfork/useraccount/application/auth/UserAuthAccountService.java
@@ -28,19 +28,6 @@ public class UserAuthAccountService {
             String profileImage
     ) {
         User user = userRepository.findBySocialTypeAndSocialId(socialType, socialId)
-                .orElseGet(() -> createSocialUser(socialType, socialId, email, profileImage));
-
-        return UserAuthProfile.from(user);
-    }
-
-    @Transactional
-    public UserAuthProfile getOrCreateReactivatedSocialAuthProfile(
-            SocialType socialType,
-            String socialId,
-            String email,
-            String profileImage
-    ) {
-        User user = userRepository.findBySocialTypeAndSocialId(socialType, socialId)
                 .map(existingUser -> reactivateIfWithdrawn(existingUser, email, profileImage))
                 .orElseGet(() -> createSocialUser(socialType, socialId, email, profileImage));
 

--- a/src/main/java/com/techfork/useraccount/application/auth/UserAuthProfile.java
+++ b/src/main/java/com/techfork/useraccount/application/auth/UserAuthProfile.java
@@ -1,0 +1,24 @@
+package com.techfork.useraccount.application.auth;
+
+import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.UserStatus;
+
+public record UserAuthProfile(
+        Long id,
+        Role role,
+        UserStatus status,
+        String email,
+        boolean active
+) {
+
+    public static UserAuthProfile from(User user) {
+        return new UserAuthProfile(
+                user.getId(),
+                user.getRole(),
+                user.getStatus(),
+                user.getEmail(),
+                user.isActive()
+        );
+    }
+}

--- a/src/main/java/com/techfork/useraccount/application/command/InterestCommandService.java
+++ b/src/main/java/com/techfork/useraccount/application/command/InterestCommandService.java
@@ -3,7 +3,7 @@ package com.techfork.useraccount.application.command;
 import com.techfork.useraccount.application.command.input.UpdateUserInterestsCommand;
 import com.techfork.useraccount.application.command.input.UserInterestCommand;
 import com.techfork.useraccount.application.event.UserInterestsChangedEvent;
-import com.techfork.useraccount.application.reader.UserReader;
+import com.techfork.useraccount.application.reader.UserAggregateReader;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.EInterestCategory;
 import com.techfork.useraccount.domain.enums.EInterestKeyword;
@@ -22,11 +22,11 @@ import java.util.List;
 @Transactional
 public class InterestCommandService {
 
-    private final UserReader userReader;
+    private final UserAggregateReader userAggregateReader;
     private final ApplicationEventPublisher eventPublisher;
 
     public void updateUserInterests(UpdateUserInterestsCommand command) {
-        User user = userReader.getByIdWithInterestCategories(command.userId());
+        User user = userAggregateReader.getByIdWithInterestCategories(command.userId());
         saveUserInterests(user, command.interests());
 
         eventPublisher.publishEvent(new UserInterestsChangedEvent(command.userId()));

--- a/src/main/java/com/techfork/useraccount/application/command/UserCommandService.java
+++ b/src/main/java/com/techfork/useraccount/application/command/UserCommandService.java
@@ -5,7 +5,7 @@ import com.techfork.useraccount.application.command.input.UpdateAccountProfileCo
 import com.techfork.useraccount.application.command.input.WithdrawUserCommand;
 import com.techfork.useraccount.application.event.OnboardingCompletedEvent;
 import com.techfork.useraccount.application.event.UserWithdrawnEvent;
-import com.techfork.useraccount.application.reader.UserReader;
+import com.techfork.useraccount.application.reader.UserAggregateReader;
 import com.techfork.useraccount.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,11 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserCommandService {
 
     private final InterestCommandService interestCommandService;
-    private final UserReader userReader;
+    private final UserAggregateReader userAggregateReader;
     private final ApplicationEventPublisher eventPublisher;
 
     public void completeOnboarding(CompleteOnboardingCommand command) {
-        User user = userReader.getByIdWithInterestCategories(command.userId());
+        User user = userAggregateReader.getByIdWithInterestCategories(command.userId());
 
         user.updateUser(command.nickname(), command.email(), command.description());
         interestCommandService.saveUserInterests(user, command.interests());
@@ -33,7 +33,7 @@ public class UserCommandService {
     }
 
     public void updateAccountProfile(UpdateAccountProfileCommand command) {
-        User user = userReader.getById(command.userId());
+        User user = userAggregateReader.getById(command.userId());
 
         user.updateProfile(command.nickName(), command.description());
 
@@ -44,7 +44,7 @@ public class UserCommandService {
     }
 
     public void withdrawUser(WithdrawUserCommand command) {
-        User user = userReader.getById(command.userId());
+        User user = userAggregateReader.getById(command.userId());
 
         user.withdraw();
         eventPublisher.publishEvent(new UserWithdrawnEvent(command.userId()));

--- a/src/main/java/com/techfork/useraccount/application/event/UserReactivatedEvent.java
+++ b/src/main/java/com/techfork/useraccount/application/event/UserReactivatedEvent.java
@@ -1,0 +1,6 @@
+package com.techfork.useraccount.application.event;
+
+public record UserReactivatedEvent(
+        Long userId
+) {
+}

--- a/src/main/java/com/techfork/useraccount/application/query/InterestQueryService.java
+++ b/src/main/java/com/techfork/useraccount/application/query/InterestQueryService.java
@@ -3,7 +3,7 @@ package com.techfork.useraccount.application.query;
 import com.techfork.useraccount.application.query.result.GetInterestListResult;
 import com.techfork.useraccount.application.query.result.GetUserInterestsResult;
 import com.techfork.useraccount.application.query.result.UserInterestResult;
-import com.techfork.useraccount.application.reader.UserReader;
+import com.techfork.useraccount.application.reader.UserAggregateReader;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.UserInterestCategory;
 import com.techfork.useraccount.domain.enums.EInterestCategory;
@@ -21,7 +21,7 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class InterestQueryService {
 
-    private final UserReader userReader;
+    private final UserAggregateReader userAggregateReader;
     private final UserInterestCategoryRepository userInterestCategoryRepository;
 
     public GetInterestListResult getAllInterests() {
@@ -33,7 +33,7 @@ public class InterestQueryService {
     }
 
     public GetUserInterestsResult getUserInterests(GetUserInterestsQuery query) {
-        User user = userReader.getById(query.userId());
+        User user = userAggregateReader.getById(query.userId());
 
         List<UserInterestCategory> categories = userInterestCategoryRepository.findByUserIdWithKeywords(user.getId());
         List<UserInterestResult> interests = categories.stream()

--- a/src/main/java/com/techfork/useraccount/application/query/UserQueryService.java
+++ b/src/main/java/com/techfork/useraccount/application/query/UserQueryService.java
@@ -1,7 +1,7 @@
 package com.techfork.useraccount.application.query;
 
 import com.techfork.useraccount.application.query.result.GetAccountProfileResult;
-import com.techfork.useraccount.application.reader.UserReader;
+import com.techfork.useraccount.application.reader.UserAggregateReader;
 import com.techfork.useraccount.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,10 +14,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserQueryService {
 
-    private final UserReader userReader;
+    private final UserAggregateReader userAggregateReader;
 
     public GetAccountProfileResult getAccountProfile(GetAccountProfileQuery query) {
-        User user = userReader.getById(query.userId());
+        User user = userAggregateReader.getById(query.userId());
 
         log.info("Account profile retrieved for userId: {}", query.userId());
 

--- a/src/main/java/com/techfork/useraccount/application/reader/UserAggregateReader.java
+++ b/src/main/java/com/techfork/useraccount/application/reader/UserAggregateReader.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class UserReader {
+public class UserAggregateReader {
 
     private final UserRepository userRepository;
 

--- a/src/test/java/com/techfork/auth/application/command/AuthCommandServiceTest.java
+++ b/src/test/java/com/techfork/auth/application/command/AuthCommandServiceTest.java
@@ -1,21 +1,22 @@
 package com.techfork.auth.application.command;
 
+import com.techfork.auth.application.command.input.GenerateDeveloperTokenCommand;
 import com.techfork.auth.application.command.input.LogoutCommand;
 import com.techfork.auth.application.command.input.RefreshTokenCommand;
-import com.techfork.auth.application.command.input.GenerateDeveloperTokenCommand;
-import com.techfork.auth.application.command.result.TokenRefreshResult;
 import com.techfork.auth.application.command.result.DeveloperTokenResult;
+import com.techfork.auth.application.command.result.TokenRefreshResult;
 import com.techfork.auth.domain.exception.AuthErrorCode;
-import com.techfork.useraccount.domain.User;
-import com.techfork.useraccount.domain.enums.Role;
-import com.techfork.useraccount.domain.enums.SocialType;
-import com.techfork.useraccount.infrastructure.UserRepository;
-import com.techfork.global.exception.GeneralException;
-import com.techfork.auth.security.service.RefreshTokenService;
-import com.techfork.auth.security.service.UserAuthCacheService;
 import com.techfork.auth.security.jwt.JwtDTO;
 import com.techfork.auth.security.jwt.JwtProperties;
 import com.techfork.auth.security.jwt.JwtUtil;
+import com.techfork.auth.security.service.RefreshTokenService;
+import com.techfork.auth.security.service.UserAuthCacheService;
+import com.techfork.global.exception.GeneralException;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.UserStatus;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,16 +24,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.Optional;
 
 import static com.techfork.auth.security.jwt.JwtConstants.TOKEN_TYPE_REFRESH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class AuthCommandServiceTest {
@@ -44,12 +45,10 @@ class AuthCommandServiceTest {
     private RefreshTokenService refreshTokenService;
 
     @Mock
-    private UserRepository userRepository;
+    private UserAuthAccountService userAuthAccountService;
 
     @Mock
     private JwtProperties jwtProperties;
-
-
 
     @Mock
     private UserAuthCacheService userAuthCacheService;
@@ -60,7 +59,7 @@ class AuthCommandServiceTest {
     private String validRefreshToken;
     private String newAccessToken;
     private String newRefreshToken;
-    private User user;
+    private UserAuthProfile userAuthProfile;
     private Long userId;
 
     @BeforeEach
@@ -69,9 +68,7 @@ class AuthCommandServiceTest {
         newAccessToken = "new.access.token";
         newRefreshToken = "new.refresh.token";
         userId = 1L;
-
-        user = User.createSocialUser(SocialType.KAKAO, "socialId123", "test@example.com", null);
-        ReflectionTestUtils.setField(user, "id", userId);
+        userAuthProfile = new UserAuthProfile(userId, Role.USER, UserStatus.PENDING, "test@example.com", false);
     }
 
     // ===== 토큰 갱신 테스트 =====
@@ -85,7 +82,7 @@ class AuthCommandServiceTest {
         given(jwtUtil.isValidToken(validRefreshToken)).willReturn(true);
         given(jwtUtil.getUserIdFromToken(validRefreshToken)).willReturn(userId);
         given(refreshTokenService.validateRefreshToken(userId, validRefreshToken)).willReturn(true);
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userAuthAccountService.findAuthProfileById(userId)).willReturn(Optional.of(userAuthProfile));
         given(jwtUtil.generateTokens(userId, Role.USER)).willReturn(newTokens);
         given(jwtProperties.getRefreshTokenExpiration()).willReturn(900000L);
         given(jwtProperties.getAccessTokenExpiration()).willReturn(180000L);
@@ -100,7 +97,7 @@ class AuthCommandServiceTest {
         verify(jwtUtil).isValidToken(validRefreshToken);
         verify(jwtUtil).validateTokenType(validRefreshToken, TOKEN_TYPE_REFRESH);
         verify(refreshTokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyLong());
-        verify(userAuthCacheService).put(eq(userId), eq(user), eq(180000L));
+        verify(userAuthCacheService).put(eq(userId), eq(userAuthProfile), eq(180000L));
     }
 
     @Test
@@ -161,7 +158,7 @@ class AuthCommandServiceTest {
         given(jwtUtil.isValidToken(validRefreshToken)).willReturn(true);
         given(jwtUtil.getUserIdFromToken(validRefreshToken)).willReturn(userId);
         given(refreshTokenService.validateRefreshToken(userId, validRefreshToken)).willReturn(true);
-        given(userRepository.findById(userId)).willReturn(Optional.empty());
+        given(userAuthAccountService.findAuthProfileById(userId)).willReturn(Optional.empty());
 
         // When & Then
         assertThatThrownBy(() -> authCommandService.refreshToken(new RefreshTokenCommand(validRefreshToken)))
@@ -227,17 +224,16 @@ class AuthCommandServiceTest {
     @DisplayName("개발자 토큰 발급 성공 - ADMIN 권한으로 30일 만료 토큰 발급")
     void generateDeveloperToken_Success() {
         // Given
-        User adminUser = User.builder()
-                .socialType(SocialType.KAKAO)
-                .socialId("adminSocialId")
-                .email("admin@example.com")
-                .role(Role.ADMIN)
-                .build();
-        ReflectionTestUtils.setField(adminUser, "id", userId);
-
+        UserAuthProfile adminAuthProfile = new UserAuthProfile(
+                userId,
+                Role.ADMIN,
+                UserStatus.ACTIVE,
+                "admin@example.com",
+                true
+        );
         String developerToken = "long.lived.access.token";
 
-        given(userRepository.findById(userId)).willReturn(Optional.of(adminUser));
+        given(userAuthAccountService.findAuthProfileById(userId)).willReturn(Optional.of(adminAuthProfile));
         given(jwtUtil.generateLongLivedAccessToken(userId, Role.ADMIN)).willReturn(developerToken);
 
         // When
@@ -245,7 +241,7 @@ class AuthCommandServiceTest {
 
         // Then
         assertThat(result.developerToken()).isEqualTo(developerToken);
-        verify(userRepository).findById(userId);
+        verify(userAuthAccountService).findAuthProfileById(userId);
         verify(jwtUtil).generateLongLivedAccessToken(userId, Role.ADMIN);
     }
 
@@ -253,7 +249,7 @@ class AuthCommandServiceTest {
     @DisplayName("개발자 토큰 발급 실패 - 사용자를 찾을 수 없음")
     void generateDeveloperToken_Fail_UserNotFound() {
         // Given
-        given(userRepository.findById(userId)).willReturn(Optional.empty());
+        given(userAuthAccountService.findAuthProfileById(userId)).willReturn(Optional.empty());
 
         // When & Then
         assertThatThrownBy(() -> authCommandService.generateDeveloperToken(new GenerateDeveloperTokenCommand(userId)))
@@ -261,18 +257,15 @@ class AuthCommandServiceTest {
                 .extracting(ex -> ((GeneralException) ex).getCode())
                 .isEqualTo(AuthErrorCode.USER_NOT_FOUND);
 
-        verify(userRepository).findById(userId);
+        verify(userAuthAccountService).findAuthProfileById(userId);
         verify(jwtUtil, never()).generateLongLivedAccessToken(anyLong(), any(Role.class));
     }
 
     @Test
     @DisplayName("개발자 토큰 발급 실패 - ADMIN 권한이 아닌 사용자")
     void generateDeveloperToken_Fail_InsufficientPermissions() {
-        // Given - 일반 사용자
-        User normalUser = User.createSocialUser(SocialType.KAKAO, "userSocialId", "user@example.com", null);
-        ReflectionTestUtils.setField(normalUser, "id", userId);
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(normalUser));
+        // Given
+        given(userAuthAccountService.findAuthProfileById(userId)).willReturn(Optional.of(userAuthProfile));
 
         // When & Then
         assertThatThrownBy(() -> authCommandService.generateDeveloperToken(new GenerateDeveloperTokenCommand(userId)))
@@ -280,8 +273,7 @@ class AuthCommandServiceTest {
                 .extracting(ex -> ((GeneralException) ex).getCode())
                 .isEqualTo(AuthErrorCode.FORBIDDEN_INSUFFICIENT_PERMISSIONS);
 
-        verify(userRepository).findById(userId);
+        verify(userAuthAccountService).findAuthProfileById(userId);
         verify(jwtUtil, never()).generateLongLivedAccessToken(anyLong(), any(Role.class));
     }
-
 }

--- a/src/test/java/com/techfork/auth/application/command/KakaoLoginCommandServiceTest.java
+++ b/src/test/java/com/techfork/auth/application/command/KakaoLoginCommandServiceTest.java
@@ -8,11 +8,11 @@ import com.techfork.auth.security.jwt.JwtDTO;
 import com.techfork.auth.security.jwt.JwtProperties;
 import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.service.RefreshTokenService;
-import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.enums.UserStatus;
-import com.techfork.useraccount.infrastructure.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,16 +20,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,7 +34,7 @@ class KakaoLoginCommandServiceTest {
     private KakaoOAuthService kakaoOAuthService;
 
     @Mock
-    private UserRepository userRepository;
+    private UserAuthAccountService userAuthAccountService;
 
     @Mock
     private JwtUtil jwtUtil;
@@ -71,21 +66,20 @@ class KakaoLoginCommandServiceTest {
         String kakaoAccessToken = "kakao.access.token";
         String socialId = "12345";
         String email = "newuser@kakao.com";
-        String profileImageUrl = "test.png";
+        String profileImageUrl = "https://example.com/profile.jpg";
         long refreshTokenExpiration = 900000L;
 
-        KakaoUserInfoResponse.Profile profile = new KakaoUserInfoResponse.Profile("https://example.com/profile.jpg");
-        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount(email, profile);
-        KakaoUserInfoResponse kakaoUserInfo = new KakaoUserInfoResponse(12345L, kakaoAccount);
-
-        User newUser = User.createSocialUser(SocialType.KAKAO, socialId, email, profileImageUrl);
-        ReflectionTestUtils.setField(newUser, "id", userId);
-
+        KakaoUserInfoResponse kakaoUserInfo = kakaoUserInfo(email, profileImageUrl);
+        UserAuthProfile newUserProfile = new UserAuthProfile(userId, Role.USER, UserStatus.PENDING, email, false);
         JwtDTO tokens = JwtDTO.of(newAccessToken, newRefreshToken);
 
         given(kakaoOAuthService.getUserInfo(kakaoAccessToken)).willReturn(kakaoUserInfo);
-        given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, socialId)).willReturn(Optional.empty());
-        given(userRepository.save(any(User.class))).willReturn(newUser);
+        given(userAuthAccountService.getOrCreateSocialAuthProfile(
+                SocialType.KAKAO,
+                socialId,
+                email,
+                profileImageUrl
+        )).willReturn(newUserProfile);
         given(jwtUtil.generateTokens(userId, Role.USER)).willReturn(tokens);
         given(jwtProperties.getRefreshTokenExpiration()).willReturn(refreshTokenExpiration);
 
@@ -100,8 +94,7 @@ class KakaoLoginCommandServiceTest {
         assertThat(result.isRegistered()).isFalse();
 
         verify(kakaoOAuthService).getUserInfo(kakaoAccessToken);
-        verify(userRepository).findBySocialTypeAndSocialId(SocialType.KAKAO, socialId);
-        verify(userRepository).save(any(User.class));
+        verify(userAuthAccountService).getOrCreateSocialAuthProfile(SocialType.KAKAO, socialId, email, profileImageUrl);
         verify(jwtUtil).generateTokens(userId, Role.USER);
         verify(refreshTokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyLong());
     }
@@ -113,21 +106,20 @@ class KakaoLoginCommandServiceTest {
         String kakaoAccessToken = "kakao.access.token";
         String socialId = "12345";
         String email = "existinguser@kakao.com";
-        String profileImageUrl = "test.png";
+        String profileImageUrl = "https://example.com/profile.jpg";
         long refreshTokenExpiration = 900000L;
 
-        KakaoUserInfoResponse.Profile profile = new KakaoUserInfoResponse.Profile("https://example.com/profile.jpg");
-        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount(email, profile);
-        KakaoUserInfoResponse kakaoUserInfo = new KakaoUserInfoResponse(12345L, kakaoAccount);
-
-        User existingUser = User.createSocialUser(SocialType.KAKAO, socialId, email, profileImageUrl);
-        ReflectionTestUtils.setField(existingUser, "id", userId);
-        ReflectionTestUtils.setField(existingUser, "status", UserStatus.ACTIVE);
-
+        KakaoUserInfoResponse kakaoUserInfo = kakaoUserInfo(email, profileImageUrl);
+        UserAuthProfile existingUserProfile = new UserAuthProfile(userId, Role.USER, UserStatus.ACTIVE, email, true);
         JwtDTO tokens = JwtDTO.of(newAccessToken, newRefreshToken);
 
         given(kakaoOAuthService.getUserInfo(kakaoAccessToken)).willReturn(kakaoUserInfo);
-        given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, socialId)).willReturn(Optional.of(existingUser));
+        given(userAuthAccountService.getOrCreateSocialAuthProfile(
+                SocialType.KAKAO,
+                socialId,
+                email,
+                profileImageUrl
+        )).willReturn(existingUserProfile);
         given(jwtUtil.generateTokens(userId, Role.USER)).willReturn(tokens);
         given(jwtProperties.getRefreshTokenExpiration()).willReturn(refreshTokenExpiration);
 
@@ -142,9 +134,14 @@ class KakaoLoginCommandServiceTest {
         assertThat(result.isRegistered()).isTrue();
 
         verify(kakaoOAuthService).getUserInfo(kakaoAccessToken);
-        verify(userRepository).findBySocialTypeAndSocialId(SocialType.KAKAO, socialId);
-        verify(userRepository, never()).save(any(User.class));
+        verify(userAuthAccountService).getOrCreateSocialAuthProfile(SocialType.KAKAO, socialId, email, profileImageUrl);
         verify(jwtUtil).generateTokens(userId, Role.USER);
         verify(refreshTokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyLong());
+    }
+
+    private KakaoUserInfoResponse kakaoUserInfo(String email, String profileImageUrl) {
+        KakaoUserInfoResponse.Profile profile = new KakaoUserInfoResponse.Profile(profileImageUrl);
+        KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount(email, profile);
+        return new KakaoUserInfoResponse(12345L, kakaoAccount);
     }
 }

--- a/src/test/java/com/techfork/auth/application/command/KakaoLoginCommandServiceTest.java
+++ b/src/test/java/com/techfork/auth/application/command/KakaoLoginCommandServiceTest.java
@@ -60,23 +60,24 @@ class KakaoLoginCommandServiceTest {
     }
 
     @Test
-    @DisplayName("iOS 카카오 로그인 성공 - 신규 회원 가입")
+    @DisplayName("iOS 카카오 로그인 성공 - REST id를 Kakao service user ID socialId로 사용해 신규 회원 가입")
     void login_Success_NewUser() {
         // Given
         String kakaoAccessToken = "kakao.access.token";
-        String socialId = "12345";
+        Long kakaoRestUserId = 12345L;
+        String kakaoServiceUserId = "12345";
         String email = "newuser@kakao.com";
         String profileImageUrl = "https://example.com/profile.jpg";
         long refreshTokenExpiration = 900000L;
 
-        KakaoUserInfoResponse kakaoUserInfo = kakaoUserInfo(email, profileImageUrl);
+        KakaoUserInfoResponse kakaoUserInfo = kakaoUserInfo(kakaoRestUserId, email, profileImageUrl);
         UserAuthProfile newUserProfile = new UserAuthProfile(userId, Role.USER, UserStatus.PENDING, email, false);
         JwtDTO tokens = JwtDTO.of(newAccessToken, newRefreshToken);
 
         given(kakaoOAuthService.getUserInfo(kakaoAccessToken)).willReturn(kakaoUserInfo);
         given(userAuthAccountService.getOrCreateSocialAuthProfile(
                 SocialType.KAKAO,
-                socialId,
+                kakaoServiceUserId,
                 email,
                 profileImageUrl
         )).willReturn(newUserProfile);
@@ -94,7 +95,12 @@ class KakaoLoginCommandServiceTest {
         assertThat(result.isRegistered()).isFalse();
 
         verify(kakaoOAuthService).getUserInfo(kakaoAccessToken);
-        verify(userAuthAccountService).getOrCreateSocialAuthProfile(SocialType.KAKAO, socialId, email, profileImageUrl);
+        verify(userAuthAccountService).getOrCreateSocialAuthProfile(
+                SocialType.KAKAO,
+                kakaoServiceUserId,
+                email,
+                profileImageUrl
+        );
         verify(jwtUtil).generateTokens(userId, Role.USER);
         verify(refreshTokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyLong());
     }
@@ -104,19 +110,20 @@ class KakaoLoginCommandServiceTest {
     void login_Success_ExistingUser() {
         // Given
         String kakaoAccessToken = "kakao.access.token";
-        String socialId = "12345";
+        Long kakaoRestUserId = 12345L;
+        String kakaoServiceUserId = "12345";
         String email = "existinguser@kakao.com";
         String profileImageUrl = "https://example.com/profile.jpg";
         long refreshTokenExpiration = 900000L;
 
-        KakaoUserInfoResponse kakaoUserInfo = kakaoUserInfo(email, profileImageUrl);
+        KakaoUserInfoResponse kakaoUserInfo = kakaoUserInfo(kakaoRestUserId, email, profileImageUrl);
         UserAuthProfile existingUserProfile = new UserAuthProfile(userId, Role.USER, UserStatus.ACTIVE, email, true);
         JwtDTO tokens = JwtDTO.of(newAccessToken, newRefreshToken);
 
         given(kakaoOAuthService.getUserInfo(kakaoAccessToken)).willReturn(kakaoUserInfo);
         given(userAuthAccountService.getOrCreateSocialAuthProfile(
                 SocialType.KAKAO,
-                socialId,
+                kakaoServiceUserId,
                 email,
                 profileImageUrl
         )).willReturn(existingUserProfile);
@@ -134,14 +141,19 @@ class KakaoLoginCommandServiceTest {
         assertThat(result.isRegistered()).isTrue();
 
         verify(kakaoOAuthService).getUserInfo(kakaoAccessToken);
-        verify(userAuthAccountService).getOrCreateSocialAuthProfile(SocialType.KAKAO, socialId, email, profileImageUrl);
+        verify(userAuthAccountService).getOrCreateSocialAuthProfile(
+                SocialType.KAKAO,
+                kakaoServiceUserId,
+                email,
+                profileImageUrl
+        );
         verify(jwtUtil).generateTokens(userId, Role.USER);
         verify(refreshTokenService).saveRefreshToken(eq(userId), eq(newRefreshToken), anyLong());
     }
 
-    private KakaoUserInfoResponse kakaoUserInfo(String email, String profileImageUrl) {
+    private KakaoUserInfoResponse kakaoUserInfo(Long kakaoRestUserId, String email, String profileImageUrl) {
         KakaoUserInfoResponse.Profile profile = new KakaoUserInfoResponse.Profile(profileImageUrl);
         KakaoUserInfoResponse.KakaoAccount kakaoAccount = new KakaoUserInfoResponse.KakaoAccount(email, profile);
-        return new KakaoUserInfoResponse(12345L, kakaoAccount);
+        return new KakaoUserInfoResponse(kakaoRestUserId, kakaoAccount);
     }
 }

--- a/src/test/java/com/techfork/auth/infrastructure/kakao/KakaoSocialIdTest.java
+++ b/src/test/java/com/techfork/auth/infrastructure/kakao/KakaoSocialIdTest.java
@@ -1,0 +1,36 @@
+package com.techfork.auth.infrastructure.kakao;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KakaoSocialIdTest {
+
+    @Test
+    @DisplayName("REST id와 OIDC sub를 같은 Kakao service user ID 문자열로 정규화한다")
+    void normalizesRestIdAndOidcSubjectToSameServiceUserId() {
+        Long restUserId = 12345L;
+        String oidcSubject = "12345";
+
+        assertThat(KakaoSocialId.fromRestUserId(restUserId)).isEqualTo("12345");
+        assertThat(KakaoSocialId.fromOidcSubject(oidcSubject)).isEqualTo("12345");
+    }
+
+    @Test
+    @DisplayName("REST id가 없으면 socialId로 사용할 수 없다")
+    void fromRestUserId_NullId_ThrowsException() {
+        assertThatThrownBy(() -> KakaoSocialId.fromRestUserId(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("REST user id");
+    }
+
+    @Test
+    @DisplayName("OIDC sub가 없으면 socialId로 사용할 수 없다")
+    void fromOidcSubject_BlankSubject_ThrowsException() {
+        assertThatThrownBy(() -> KakaoSocialId.fromOidcSubject(" "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("subject");
+    }
+}

--- a/src/test/java/com/techfork/auth/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/techfork/auth/security/filter/JwtAuthenticationFilterTest.java
@@ -2,19 +2,19 @@ package com.techfork.auth.security.filter;
 
 import com.techfork.auth.domain.exception.AuthErrorCode;
 import com.techfork.auth.security.AuthSecurityConstants;
-import com.techfork.global.exception.GeneralException;
-import com.techfork.useraccount.domain.User;
-import com.techfork.useraccount.domain.enums.Role;
-import com.techfork.useraccount.domain.enums.SocialType;
-import com.techfork.useraccount.domain.enums.UserStatus;
-import com.techfork.useraccount.infrastructure.UserRepository;
-import com.techfork.auth.security.service.UserAuthCacheService;
 import com.techfork.auth.security.jwt.JwtProperties;
 import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.oauth.UserPrincipal;
+import com.techfork.auth.security.service.UserAuthCacheService;
+import com.techfork.global.exception.GeneralException;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.UserStatus;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -26,13 +26,20 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.Optional;
 
 import static com.techfork.auth.security.jwt.JwtConstants.TOKEN_TYPE_ACCESS;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.argThat;
+import static org.mockito.BDDMockito.doThrow;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.never;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
 
 @ExtendWith(MockitoExtension.class)
 class JwtAuthenticationFilterTest {
@@ -41,7 +48,7 @@ class JwtAuthenticationFilterTest {
     private JwtUtil jwtUtil;
 
     @Mock
-    private UserRepository userRepository;
+    private UserAuthAccountService userAuthAccountService;
 
     @Mock
     private UserAuthCacheService userAuthCacheService;
@@ -61,7 +68,7 @@ class JwtAuthenticationFilterTest {
     @InjectMocks
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    private User testUser;
+    private UserAuthProfile testUserProfile;
     private Long userId;
     private String validAccessToken;
 
@@ -71,9 +78,7 @@ class JwtAuthenticationFilterTest {
 
         userId = 1L;
         validAccessToken = "valid.access.token";
-
-        testUser = User.createSocialUser(SocialType.KAKAO, "testSocialId", "test@example.com", null);
-        ReflectionTestUtils.setField(testUser, "id", userId);
+        testUserProfile = new UserAuthProfile(userId, Role.USER, UserStatus.PENDING, "test@example.com", false);
     }
 
     @Nested
@@ -81,14 +86,14 @@ class JwtAuthenticationFilterTest {
     class Success {
 
         @Test
-        @DisplayName("JWT 인증 성공 - 캐시 미스: DB 조회 후 캐시 저장")
+        @DisplayName("JWT 인증 성공 - 캐시 미스: 인증 프로필 조회 후 캐시 저장")
         void doFilterInternal_Success_CacheMiss() throws Exception {
             // Given
             given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
             willDoNothing().given(jwtUtil).validateToken(validAccessToken);
             given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
             given(userAuthCacheService.get(userId)).willReturn(null);
-            given(userRepository.findById(userId)).willReturn(Optional.of(testUser));
+            given(userAuthAccountService.findAuthProfileById(userId)).willReturn(Optional.of(testUserProfile));
             given(jwtProperties.getAccessTokenExpiration()).willReturn(180000L);
 
             // When
@@ -103,14 +108,15 @@ class JwtAuthenticationFilterTest {
             assertThat(principal.getId()).isEqualTo(userId);
             assertThat(principal.getRole()).isEqualTo(Role.USER);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
+            assertThat(principal.getEmail()).isEqualTo("test@example.com");
 
-            verify(userRepository).findById(userId);
-            verify(userAuthCacheService).put(eq(userId), eq(testUser), eq(180000L));
+            verify(userAuthAccountService).findAuthProfileById(userId);
+            verify(userAuthCacheService).put(eq(userId), eq(testUserProfile), eq(180000L));
             verify(filterChain).doFilter(request, response);
         }
 
         @Test
-        @DisplayName("JWT 인증 성공 - 캐시 히트: DB 조회 없이 인증")
+        @DisplayName("JWT 인증 성공 - 캐시 히트: 인증 프로필 조회 없이 인증")
         void doFilterInternal_Success_CacheHit() throws Exception {
             // Given
             UserPrincipal cachedPrincipal = UserPrincipal.builder()
@@ -133,27 +139,29 @@ class JwtAuthenticationFilterTest {
             assertThat(authentication).isNotNull();
             assertThat(authentication.getPrincipal()).isEqualTo(cachedPrincipal);
 
-            verify(userRepository, never()).findById(anyLong());
-            verify(userAuthCacheService, never()).put(anyLong(), any(User.class), anyLong());
+            verify(userAuthAccountService, never()).findAuthProfileById(anyLong());
+            verify(userAuthCacheService, never()).put(anyLong(), any(UserAuthProfile.class), anyLong());
             verify(filterChain).doFilter(request, response);
         }
 
         @Test
-        @DisplayName("JWT 인증 성공 - 재활성화된 PENDING 사용자는 DB 조회 후 캐시에 저장한다")
+        @DisplayName("JWT 인증 성공 - 재활성화된 PENDING 사용자는 인증 프로필 조회 후 캐시에 저장한다")
         void doFilterInternal_Success_ReactivatedPendingUser_CacheMiss() throws Exception {
             // Given
-            User reactivatedUser = User.createSocialUser(SocialType.APPLE, "reactivatedSocialId", "old@example.com", "old.png");
-            reactivatedUser.updateUser("재활성화유저", "old@example.com", "탈퇴 전 설명");
-            reactivatedUser.withdraw();
-            reactivatedUser.reactivate("reactivated@example.com", "reactivated.png");
-            ReflectionTestUtils.setField(reactivatedUser, "id", userId);
+            UserAuthProfile reactivatedProfile = new UserAuthProfile(
+                    userId,
+                    Role.USER,
+                    UserStatus.PENDING,
+                    "reactivated@example.com",
+                    false
+            );
 
             given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
             willDoNothing().given(jwtUtil).validateToken(validAccessToken);
             willDoNothing().given(jwtUtil).validateTokenType(validAccessToken, TOKEN_TYPE_ACCESS);
             given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
             given(userAuthCacheService.get(userId)).willReturn(null);
-            given(userRepository.findById(userId)).willReturn(Optional.of(reactivatedUser));
+            given(userAuthAccountService.findAuthProfileById(userId)).willReturn(Optional.of(reactivatedProfile));
             given(jwtProperties.getAccessTokenExpiration()).willReturn(180000L);
 
             // When
@@ -169,8 +177,8 @@ class JwtAuthenticationFilterTest {
             assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
             assertThat(principal.getEmail()).isEqualTo("reactivated@example.com");
 
-            verify(userRepository).findById(userId);
-            verify(userAuthCacheService).put(userId, reactivatedUser, 180000L);
+            verify(userAuthAccountService).findAuthProfileById(userId);
+            verify(userAuthCacheService).put(userId, reactivatedProfile, 180000L);
             verify(filterChain).doFilter(request, response);
         }
     }
@@ -193,7 +201,7 @@ class JwtAuthenticationFilterTest {
             assertThat(authentication).isNull();
 
             verify(jwtUtil, never()).validateToken(anyString());
-            verify(userRepository, never()).findById(anyLong());
+            verify(userAuthAccountService, never()).findAuthProfileById(anyLong());
             verify(filterChain).doFilter(request, response);
         }
 
@@ -211,7 +219,7 @@ class JwtAuthenticationFilterTest {
             assertThat(authentication).isNull();
 
             verify(jwtUtil, never()).validateToken(anyString());
-            verify(userRepository, never()).findById(anyLong());
+            verify(userAuthAccountService, never()).findAuthProfileById(anyLong());
             verify(filterChain).doFilter(request, response);
         }
 
@@ -232,7 +240,7 @@ class JwtAuthenticationFilterTest {
             assertThat(authentication).isNull();
 
             verify(jwtUtil).validateToken(invalidToken);
-            verify(userRepository, never()).findById(anyLong());
+            verify(userAuthAccountService, never()).findAuthProfileById(anyLong());
             verifyJwtExceptionAttribute(invalidTokenException);
             verify(filterChain).doFilter(request, response);
         }
@@ -264,7 +272,7 @@ class JwtAuthenticationFilterTest {
             assertThat(authentication).isNull();
 
             verify(jwtUtil).validateToken(invalidToken);
-            verify(userRepository, never()).findById(anyLong());
+            verify(userAuthAccountService, never()).findAuthProfileById(anyLong());
             verifyJwtExceptionAttribute(invalidTokenException);
             verify(filterChain).doFilter(request, response);
         }
@@ -289,7 +297,7 @@ class JwtAuthenticationFilterTest {
 
             verify(jwtUtil).validateToken(refreshToken);
             verify(jwtUtil).validateTokenType(refreshToken, TOKEN_TYPE_ACCESS);
-            verify(userRepository, never()).findById(anyLong());
+            verify(userAuthAccountService, never()).findAuthProfileById(anyLong());
             verifyJwtExceptionAttribute(tokenTypeMismatchException);
             verify(filterChain).doFilter(request, response);
         }
@@ -303,7 +311,7 @@ class JwtAuthenticationFilterTest {
             willDoNothing().given(jwtUtil).validateToken(deletedUserToken);
             willDoNothing().given(jwtUtil).validateTokenType(deletedUserToken, TOKEN_TYPE_ACCESS);
             given(jwtUtil.getUserIdFromToken(deletedUserToken)).willReturn(999L);
-            given(userRepository.findById(999L)).willReturn(Optional.empty());
+            given(userAuthAccountService.findAuthProfileById(999L)).willReturn(Optional.empty());
 
             // When
             jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -314,26 +322,29 @@ class JwtAuthenticationFilterTest {
 
             verify(jwtUtil).validateToken(deletedUserToken);
             verify(jwtUtil).validateTokenType(deletedUserToken, TOKEN_TYPE_ACCESS);
-            verify(userRepository).findById(999L);
+            verify(userAuthAccountService).findAuthProfileById(999L);
             verifyJwtExceptionAttribute(AuthErrorCode.USER_NOT_FOUND);
             verify(filterChain).doFilter(request, response);
         }
 
         @Test
-        @DisplayName("JWT 인증 실패 - 탈퇴한 회원 (캐시 미스 후 DB 조회)")
+        @DisplayName("JWT 인증 실패 - 탈퇴한 회원 (캐시 미스 후 인증 프로필 조회)")
         void doFilterInternal_Fail_WithdrawnUser_CacheMiss() throws Exception {
             // Given
-            User withdrawnUser = User.createSocialUser(SocialType.KAKAO, "withdrawnSocialId", "withdrawn@example.com", null);
-            withdrawnUser.updateUser("탈퇴유저", "withdrawn@example.com", "개발자였습니다.");
-            withdrawnUser.withdraw();
-            ReflectionTestUtils.setField(withdrawnUser, "id", userId);
+            UserAuthProfile withdrawnProfile = new UserAuthProfile(
+                    userId,
+                    Role.USER,
+                    UserStatus.WITHDRAWN,
+                    null,
+                    false
+            );
 
             given(request.getHeader("Authorization")).willReturn("Bearer " + validAccessToken);
             willDoNothing().given(jwtUtil).validateToken(validAccessToken);
             willDoNothing().given(jwtUtil).validateTokenType(validAccessToken, TOKEN_TYPE_ACCESS);
             given(jwtUtil.getUserIdFromToken(validAccessToken)).willReturn(userId);
             given(userAuthCacheService.get(userId)).willReturn(null);
-            given(userRepository.findById(userId)).willReturn(Optional.of(withdrawnUser));
+            given(userAuthAccountService.findAuthProfileById(userId)).willReturn(Optional.of(withdrawnProfile));
 
             // When
             jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
@@ -342,8 +353,8 @@ class JwtAuthenticationFilterTest {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             assertThat(authentication).isNull();
 
-            verify(userRepository).findById(userId);
-            verify(userAuthCacheService, never()).put(anyLong(), any(User.class), anyLong()); // 탈퇴 유저는 캐시 저장 안 함
+            verify(userAuthAccountService).findAuthProfileById(userId);
+            verify(userAuthCacheService, never()).put(anyLong(), any(UserAuthProfile.class), anyLong()); // 탈퇴 유저는 캐시 저장 안 함
             verifyJwtExceptionAttribute(AuthErrorCode.WITHDRAWN_USER);
             verify(filterChain).doFilter(request, response);
         }
@@ -372,7 +383,7 @@ class JwtAuthenticationFilterTest {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             assertThat(authentication).isNull();
 
-            verify(userRepository, never()).findById(anyLong()); // 캐시 히트이므로 DB 조회 없음
+            verify(userAuthAccountService, never()).findAuthProfileById(anyLong()); // 캐시 히트이므로 인증 프로필 조회 없음
             verifyJwtExceptionAttribute(AuthErrorCode.WITHDRAWN_USER);
             verify(filterChain).doFilter(request, response);
         }

--- a/src/test/java/com/techfork/auth/security/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/techfork/auth/security/filter/JwtAuthenticationFilterTest.java
@@ -134,7 +134,7 @@ class JwtAuthenticationFilterTest {
             assertThat(authentication.getPrincipal()).isEqualTo(cachedPrincipal);
 
             verify(userRepository, never()).findById(anyLong());
-            verify(userAuthCacheService, never()).put(anyLong(), any(), anyLong());
+            verify(userAuthCacheService, never()).put(anyLong(), any(User.class), anyLong());
             verify(filterChain).doFilter(request, response);
         }
 
@@ -343,7 +343,7 @@ class JwtAuthenticationFilterTest {
             assertThat(authentication).isNull();
 
             verify(userRepository).findById(userId);
-            verify(userAuthCacheService, never()).put(anyLong(), any(), anyLong()); // 탈퇴 유저는 캐시 저장 안 함
+            verify(userAuthCacheService, never()).put(anyLong(), any(User.class), anyLong()); // 탈퇴 유저는 캐시 저장 안 함
             verifyJwtExceptionAttribute(AuthErrorCode.WITHDRAWN_USER);
             verify(filterChain).doFilter(request, response);
         }

--- a/src/test/java/com/techfork/auth/security/listener/UserAuthCacheEventListenerTest.java
+++ b/src/test/java/com/techfork/auth/security/listener/UserAuthCacheEventListenerTest.java
@@ -2,6 +2,7 @@ package com.techfork.auth.security.listener;
 
 import com.techfork.auth.security.service.UserAuthCacheService;
 import com.techfork.useraccount.application.event.OnboardingCompletedEvent;
+import com.techfork.useraccount.application.event.UserReactivatedEvent;
 import com.techfork.useraccount.application.event.UserWithdrawnEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,16 @@ class UserAuthCacheEventListenerTest {
     }
 
     @Test
+    @DisplayName("회원 재활성화 이벤트 - 커밋 이후 인증 캐시를 무효화한다")
+    void handle_UserReactivatedEvent_EvictsUserAuthCache() {
+        Long userId = 1L;
+
+        listener.handle(new UserReactivatedEvent(userId));
+
+        verify(userAuthCacheService).evict(userId);
+    }
+
+    @Test
     @DisplayName("회원 탈퇴 이벤트 - 커밋 직전 인증 캐시를 무효화한다")
     void handleBeforeCommit_UserWithdrawnEvent_EvictsUserAuthCache() {
         Long userId = 1L;
@@ -58,6 +69,7 @@ class UserAuthCacheEventListenerTest {
     @DisplayName("인증 캐시 리스너는 이벤트별 트랜잭션 단계를 명시한다")
     void listenerMethods_RunWithExpectedTransactionPhase() throws NoSuchMethodException {
         assertTransactionalEventListenerPhase("handle", OnboardingCompletedEvent.class, TransactionPhase.AFTER_COMMIT);
+        assertTransactionalEventListenerPhase("handle", UserReactivatedEvent.class, TransactionPhase.AFTER_COMMIT);
         assertTransactionalEventListenerPhase("handleBeforeCommit", UserWithdrawnEvent.class, TransactionPhase.BEFORE_COMMIT);
         assertTransactionalEventListenerPhase("handleAfterCommit", UserWithdrawnEvent.class, TransactionPhase.AFTER_COMMIT);
     }

--- a/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
@@ -58,7 +58,7 @@ class CustomOidcUserServiceTest {
         @DisplayName("신규 Apple 인증 프로필을 UserPrincipal로 반환한다")
         void loadUser_NewAppleUser_ReturnsPrincipal() {
             UserAuthProfile userAuthProfile = new UserAuthProfile(1L, Role.USER, UserStatus.PENDING, EMAIL, false);
-            given(userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+            given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
                     EMAIL,
@@ -73,7 +73,7 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getRole()).isEqualTo(Role.USER);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
             assertThat(principal.getEmail()).isEqualTo(EMAIL);
-            verify(userAuthAccountService).getOrCreateReactivatedSocialAuthProfile(
+            verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
                     EMAIL,
@@ -88,7 +88,7 @@ class CustomOidcUserServiceTest {
             String kakaoEmail = "kakao-user@example.com";
             String kakaoProfileImage = "https://cdn.example.com/kakao-user.png";
             UserAuthProfile userAuthProfile = new UserAuthProfile(4L, Role.USER, UserStatus.PENDING, kakaoEmail, false);
-            given(userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+            given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.KAKAO,
                     kakaoSocialId,
                     kakaoEmail,
@@ -105,7 +105,7 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getRole()).isEqualTo(Role.USER);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
             assertThat(principal.getEmail()).isEqualTo(kakaoEmail);
-            verify(userAuthAccountService).getOrCreateReactivatedSocialAuthProfile(
+            verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.KAKAO,
                     kakaoSocialId,
                     kakaoEmail,
@@ -117,7 +117,7 @@ class CustomOidcUserServiceTest {
         @DisplayName("기존 Apple 인증 프로필을 UserPrincipal로 반환한다")
         void loadUser_ExistingAppleUser_ReturnsPrincipal() {
             UserAuthProfile existingUserProfile = new UserAuthProfile(2L, Role.USER, UserStatus.ACTIVE, EMAIL, true);
-            given(userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+            given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
                     EMAIL,
@@ -130,7 +130,7 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getId()).isEqualTo(2L);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.ACTIVE);
             assertThat(principal.getEmail()).isEqualTo(EMAIL);
-            verify(userAuthAccountService).getOrCreateReactivatedSocialAuthProfile(
+            verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
                     EMAIL,
@@ -142,7 +142,7 @@ class CustomOidcUserServiceTest {
         @DisplayName("탈퇴 Apple 사용자의 재활성화된 PENDING 인증 프로필을 UserPrincipal로 반환한다")
         void loadUser_WithdrawnAppleUser_ReturnsReactivatedPendingPrincipal() {
             UserAuthProfile reactivatedUserProfile = new UserAuthProfile(3L, Role.USER, UserStatus.PENDING, EMAIL, false);
-            given(userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+            given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
                     EMAIL,
@@ -155,7 +155,7 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getId()).isEqualTo(3L);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
             assertThat(principal.getEmail()).isEqualTo(EMAIL);
-            verify(userAuthAccountService).getOrCreateReactivatedSocialAuthProfile(
+            verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
                     EMAIL,
@@ -177,7 +177,7 @@ class CustomOidcUserServiceTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("sub");
 
-            verify(userAuthAccountService, never()).getOrCreateReactivatedSocialAuthProfile(any(), any(), any(), any());
+            verify(userAuthAccountService, never()).getOrCreateSocialAuthProfile(any(), any(), any(), any());
         }
 
         @Test
@@ -191,7 +191,7 @@ class CustomOidcUserServiceTest {
                             .getError()
                             .getErrorCode()).isEqualTo("email not found"));
 
-            verify(userAuthAccountService, never()).getOrCreateReactivatedSocialAuthProfile(any(), any(), any(), any());
+            verify(userAuthAccountService, never()).getOrCreateSocialAuthProfile(any(), any(), any(), any());
         }
     }
 

--- a/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
@@ -1,16 +1,19 @@
 package com.techfork.auth.security.oauth;
 
-import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.enums.UserStatus;
-import com.techfork.useraccount.infrastructure.UserRepository;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
@@ -21,13 +24,6 @@ import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -44,13 +40,13 @@ class CustomOidcUserServiceTest {
     private static final String PROFILE_IMAGE = "https://cdn.example.com/apple-user.png";
 
     @Mock
-    private UserRepository userRepository;
+    private UserAuthAccountService userAuthAccountService;
 
     private CustomOidcUserService customOidcUserService;
 
     @BeforeEach
     void setUp() {
-        customOidcUserService = new CustomOidcUserService(userRepository);
+        customOidcUserService = new CustomOidcUserService(userAuthAccountService);
         customOidcUserService.setRetrieveUserInfo(request -> false);
     }
 
@@ -59,15 +55,15 @@ class CustomOidcUserServiceTest {
     class Success {
 
         @Test
-        @DisplayName("신규 Apple 사용자를 생성하고 UserPrincipal을 반환한다")
-        void loadUser_NewAppleUser_CreatesUserAndReturnsPrincipal() {
-            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
-                    .willReturn(Optional.empty());
-            given(userRepository.save(any(User.class))).willAnswer(invocation -> {
-                User savedUser = invocation.getArgument(0);
-                ReflectionTestUtils.setField(savedUser, "id", 1L);
-                return savedUser;
-            });
+        @DisplayName("신규 Apple 인증 프로필을 UserPrincipal로 반환한다")
+        void loadUser_NewAppleUser_ReturnsPrincipal() {
+            UserAuthProfile userAuthProfile = new UserAuthProfile(1L, Role.USER, UserStatus.PENDING, EMAIL, false);
+            given(userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.APPLE,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            )).willReturn(userAuthProfile);
 
             OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
 
@@ -77,29 +73,27 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getRole()).isEqualTo(Role.USER);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
             assertThat(principal.getEmail()).isEqualTo(EMAIL);
-
-            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-            verify(userRepository).save(userCaptor.capture());
-            User savedUser = userCaptor.getValue();
-            assertThat(savedUser.getSocialType()).isEqualTo(SocialType.APPLE);
-            assertThat(savedUser.getSocialId()).isEqualTo(SOCIAL_ID);
-            assertThat(savedUser.getEmail()).isEqualTo(EMAIL);
-            assertThat(savedUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
+            verify(userAuthAccountService).getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.APPLE,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            );
         }
 
         @Test
-        @DisplayName("신규 Kakao OIDC 사용자를 생성하고 UserPrincipal을 반환한다")
-        void loadUser_NewKakaoOidcUser_CreatesKakaoUserAndReturnsPrincipal() {
+        @DisplayName("신규 Kakao OIDC 인증 프로필을 UserPrincipal로 반환한다")
+        void loadUser_NewKakaoOidcUser_ReturnsPrincipal() {
             String kakaoSocialId = "kakao-sub-456";
             String kakaoEmail = "kakao-user@example.com";
             String kakaoProfileImage = "https://cdn.example.com/kakao-user.png";
-            given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, kakaoSocialId))
-                    .willReturn(Optional.empty());
-            given(userRepository.save(any(User.class))).willAnswer(invocation -> {
-                User savedUser = invocation.getArgument(0);
-                ReflectionTestUtils.setField(savedUser, "id", 4L);
-                return savedUser;
-            });
+            UserAuthProfile userAuthProfile = new UserAuthProfile(4L, Role.USER, UserStatus.PENDING, kakaoEmail, false);
+            given(userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.KAKAO,
+                    kakaoSocialId,
+                    kakaoEmail,
+                    kakaoProfileImage
+            )).willReturn(userAuthProfile);
 
             OidcUser oidcUser = customOidcUserService.loadUser(
                     userRequest("kakao", claims(kakaoSocialId, kakaoEmail, kakaoProfileImage))
@@ -111,23 +105,24 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getRole()).isEqualTo(Role.USER);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
             assertThat(principal.getEmail()).isEqualTo(kakaoEmail);
-
-            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
-            verify(userRepository).save(userCaptor.capture());
-            User savedUser = userCaptor.getValue();
-            assertThat(savedUser.getSocialType()).isEqualTo(SocialType.KAKAO);
-            assertThat(savedUser.getSocialId()).isEqualTo(kakaoSocialId);
-            assertThat(savedUser.getEmail()).isEqualTo(kakaoEmail);
-            assertThat(savedUser.getProfileImage()).isEqualTo(kakaoProfileImage);
+            verify(userAuthAccountService).getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.KAKAO,
+                    kakaoSocialId,
+                    kakaoEmail,
+                    kakaoProfileImage
+            );
         }
 
         @Test
-        @DisplayName("기존 Apple 사용자를 재사용하고 새 사용자를 저장하지 않는다")
-        void loadUser_ExistingAppleUser_ReusesUserWithoutSaving() {
-            User existingUser = appleUser(2L, EMAIL, PROFILE_IMAGE);
-            existingUser.updateUser("기존사용자", EMAIL, "온보딩 완료 사용자");
-            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
-                    .willReturn(Optional.of(existingUser));
+        @DisplayName("기존 Apple 인증 프로필을 UserPrincipal로 반환한다")
+        void loadUser_ExistingAppleUser_ReturnsPrincipal() {
+            UserAuthProfile existingUserProfile = new UserAuthProfile(2L, Role.USER, UserStatus.ACTIVE, EMAIL, true);
+            given(userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.APPLE,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            )).willReturn(existingUserProfile);
 
             OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
 
@@ -135,17 +130,24 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getId()).isEqualTo(2L);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.ACTIVE);
             assertThat(principal.getEmail()).isEqualTo(EMAIL);
-            verify(userRepository, never()).save(any(User.class));
+            verify(userAuthAccountService).getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.APPLE,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            );
         }
 
         @Test
-        @DisplayName("탈퇴 Apple 사용자를 재활성화하고 PENDING principal을 반환한다")
-        void loadUser_WithdrawnAppleUser_ReactivatesUserAndReturnsPendingPrincipal() {
-            User withdrawnUser = appleUser(3L, "old@example.com", "https://cdn.example.com/old.png");
-            withdrawnUser.updateUser("탈퇴사용자", "old@example.com", "탈퇴 전 설명");
-            withdrawnUser.withdraw();
-            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
-                    .willReturn(Optional.of(withdrawnUser));
+        @DisplayName("탈퇴 Apple 사용자의 재활성화된 PENDING 인증 프로필을 UserPrincipal로 반환한다")
+        void loadUser_WithdrawnAppleUser_ReturnsReactivatedPendingPrincipal() {
+            UserAuthProfile reactivatedUserProfile = new UserAuthProfile(3L, Role.USER, UserStatus.PENDING, EMAIL, false);
+            given(userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.APPLE,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            )).willReturn(reactivatedUserProfile);
 
             OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
 
@@ -153,10 +155,12 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getId()).isEqualTo(3L);
             assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
             assertThat(principal.getEmail()).isEqualTo(EMAIL);
-            assertThat(withdrawnUser.getEmail()).isEqualTo(EMAIL);
-            assertThat(withdrawnUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
-            assertThat(withdrawnUser.getStatus()).isEqualTo(UserStatus.PENDING);
-            verify(userRepository, never()).save(any(User.class));
+            verify(userAuthAccountService).getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.APPLE,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            );
         }
     }
 
@@ -173,12 +177,11 @@ class CustomOidcUserServiceTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("sub");
 
-            verify(userRepository, never()).findBySocialTypeAndSocialId(any(), any());
-            verify(userRepository, never()).save(any(User.class));
+            verify(userAuthAccountService, never()).getOrCreateReactivatedSocialAuthProfile(any(), any(), any(), any());
         }
 
         @Test
-        @DisplayName("email 클레임이 없으면 예외를 던지고 사용자를 저장하지 않는다")
+        @DisplayName("email 클레임이 없으면 예외를 던지고 인증 프로필을 조회하지 않는다")
         void loadUser_MissingEmail_ThrowsOAuth2AuthenticationException() {
             Map<String, Object> claims = claims(SOCIAL_ID, null, PROFILE_IMAGE);
 
@@ -188,15 +191,8 @@ class CustomOidcUserServiceTest {
                             .getError()
                             .getErrorCode()).isEqualTo("email not found"));
 
-            verify(userRepository, never()).findBySocialTypeAndSocialId(any(), any());
-            verify(userRepository, never()).save(any(User.class));
+            verify(userAuthAccountService, never()).getOrCreateReactivatedSocialAuthProfile(any(), any(), any(), any());
         }
-    }
-
-    private User appleUser(Long id, String email, String profileImage) {
-        User user = User.createSocialUser(SocialType.APPLE, SOCIAL_ID, email, profileImage);
-        ReflectionTestUtils.setField(user, "id", id);
-        return user;
     }
 
     private OidcUserRequest userRequest(Map<String, Object> claims) {

--- a/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
@@ -82,21 +82,21 @@ class CustomOidcUserServiceTest {
         }
 
         @Test
-        @DisplayName("신규 Kakao OIDC 인증 프로필을 UserPrincipal로 반환한다")
+        @DisplayName("Kakao OIDC sub를 REST id와 같은 service user ID socialId로 사용한다")
         void loadUser_NewKakaoOidcUser_ReturnsPrincipal() {
-            String kakaoSocialId = "kakao-sub-456";
+            String kakaoServiceUserId = "12345";
             String kakaoEmail = "kakao-user@example.com";
             String kakaoProfileImage = "https://cdn.example.com/kakao-user.png";
             UserAuthProfile userAuthProfile = new UserAuthProfile(4L, Role.USER, UserStatus.PENDING, kakaoEmail, false);
             given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.KAKAO,
-                    kakaoSocialId,
+                    kakaoServiceUserId,
                     kakaoEmail,
                     kakaoProfileImage
             )).willReturn(userAuthProfile);
 
             OidcUser oidcUser = customOidcUserService.loadUser(
-                    userRequest("kakao", claims(kakaoSocialId, kakaoEmail, kakaoProfileImage))
+                    userRequest("kakao", claims(kakaoServiceUserId, kakaoEmail, kakaoProfileImage))
             );
 
             assertThat(oidcUser).isInstanceOf(UserPrincipal.class);
@@ -107,7 +107,7 @@ class CustomOidcUserServiceTest {
             assertThat(principal.getEmail()).isEqualTo(kakaoEmail);
             verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.KAKAO,
-                    kakaoSocialId,
+                    kakaoServiceUserId,
                     kakaoEmail,
                     kakaoProfileImage
             );

--- a/src/test/java/com/techfork/auth/security/service/UserAuthCacheServiceTest.java
+++ b/src/test/java/com/techfork/auth/security/service/UserAuthCacheServiceTest.java
@@ -1,5 +1,6 @@
 package com.techfork.auth.security.service;
 
+import com.techfork.useraccount.application.auth.UserAuthProfile;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.SocialType;
@@ -133,6 +134,27 @@ class UserAuthCacheServiceTest {
 
         // Then
         verify(valueOperations).set(CACHE_KEY, "1|USER|PENDING|", 180000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("put - 인증 프로필 직렬화 후 저장")
+    void put_WithAuthProfile_SerializesAndSaves() {
+        // Given
+        UserAuthProfile userAuthProfile = new UserAuthProfile(
+                USER_ID,
+                Role.ADMIN,
+                UserStatus.ACTIVE,
+                "admin@example.com",
+                true
+        );
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // When
+        userAuthCacheService.put(USER_ID, userAuthProfile, 180000L);
+
+        // Then
+        verify(valueOperations).set(CACHE_KEY, "1|ADMIN|ACTIVE|admin@example.com", 180000L, TimeUnit.MILLISECONDS);
     }
 
     // ===== evict 테스트 =====

--- a/src/test/java/com/techfork/auth/security/service/UserAuthCacheServiceTest.java
+++ b/src/test/java/com/techfork/auth/security/service/UserAuthCacheServiceTest.java
@@ -1,11 +1,10 @@
 package com.techfork.auth.security.service;
 
-import com.techfork.useraccount.application.auth.UserAuthProfile;
-import com.techfork.useraccount.domain.User;
-import com.techfork.useraccount.domain.enums.Role;
-import com.techfork.useraccount.domain.enums.SocialType;
-import com.techfork.useraccount.domain.enums.UserStatus;
 import com.techfork.auth.security.oauth.UserPrincipal;
+import com.techfork.useraccount.application.auth.UserAuthProfile;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.UserStatus;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,9 +13,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
-import org.springframework.test.util.ReflectionTestUtils;
-
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -104,39 +100,6 @@ class UserAuthCacheServiceTest {
     // ===== put 테스트 =====
 
     @Test
-    @DisplayName("put - email이 있는 유저 직렬화 후 저장")
-    void put_WithEmail_SerializesAndSaves() {
-        // Given
-        User user = User.createSocialUser(SocialType.KAKAO, "socialId", "test@example.com", null);
-        ReflectionTestUtils.setField(user, "id", USER_ID);
-        ReflectionTestUtils.setField(user, "status", UserStatus.ACTIVE);
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-
-        // When
-        userAuthCacheService.put(USER_ID, user, 180000L);
-
-        // Then
-        verify(valueOperations).set(CACHE_KEY, "1|USER|ACTIVE|test@example.com", 180000L, TimeUnit.MILLISECONDS);
-    }
-
-    @Test
-    @DisplayName("put - email이 null인 유저 직렬화 후 저장")
-    void put_WithNullEmail_SerializesEmptyEmail() {
-        // Given
-        User user = User.createSocialUser(SocialType.KAKAO, "socialId", null, null);
-        ReflectionTestUtils.setField(user, "id", USER_ID);
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-
-        // When
-        userAuthCacheService.put(USER_ID, user, 180000L);
-
-        // Then
-        verify(valueOperations).set(CACHE_KEY, "1|USER|PENDING|", 180000L, TimeUnit.MILLISECONDS);
-    }
-
-    @Test
     @DisplayName("put - 인증 프로필 직렬화 후 저장")
     void put_WithAuthProfile_SerializesAndSaves() {
         // Given
@@ -155,6 +118,27 @@ class UserAuthCacheServiceTest {
 
         // Then
         verify(valueOperations).set(CACHE_KEY, "1|ADMIN|ACTIVE|admin@example.com", 180000L, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    @DisplayName("put - email이 null인 인증 프로필은 빈 email로 저장")
+    void put_WithNullEmail_SerializesEmptyEmail() {
+        // Given
+        UserAuthProfile userAuthProfile = new UserAuthProfile(
+                USER_ID,
+                Role.USER,
+                UserStatus.PENDING,
+                null,
+                false
+        );
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // When
+        userAuthCacheService.put(USER_ID, userAuthProfile, 180000L);
+
+        // Then
+        verify(valueOperations).set(CACHE_KEY, "1|USER|PENDING|", 180000L, TimeUnit.MILLISECONDS);
     }
 
     // ===== evict 테스트 =====

--- a/src/test/java/com/techfork/useraccount/application/auth/UserAuthAccountServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/auth/UserAuthAccountServiceTest.java
@@ -1,0 +1,213 @@
+package com.techfork.useraccount.application.auth;
+
+import com.techfork.useraccount.domain.User;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.SocialType;
+import com.techfork.useraccount.domain.enums.UserStatus;
+import com.techfork.useraccount.infrastructure.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserAuthAccountServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String SOCIAL_ID = "social-id-123";
+    private static final String EMAIL = "user@example.com";
+    private static final String PROFILE_IMAGE = "https://cdn.example.com/profile.png";
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserAuthAccountService userAuthAccountService;
+
+    @Nested
+    @DisplayName("findAuthProfileById")
+    class FindAuthProfileById {
+
+        @Test
+        @DisplayName("존재하는 사용자의 인증 프로필 스냅샷을 반환한다")
+        void returnsAuthProfileSnapshot() {
+            User user = pendingUser(USER_ID, SocialType.KAKAO, SOCIAL_ID, EMAIL, PROFILE_IMAGE);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+            Optional<UserAuthProfile> result = userAuthAccountService.findAuthProfileById(USER_ID);
+
+            assertThat(result).hasValueSatisfying(profile -> {
+                assertThat(profile.id()).isEqualTo(USER_ID);
+                assertThat(profile.role()).isEqualTo(Role.USER);
+                assertThat(profile.status()).isEqualTo(UserStatus.PENDING);
+                assertThat(profile.email()).isEqualTo(EMAIL);
+                assertThat(profile.active()).isFalse();
+            });
+            verify(userRepository).findById(USER_ID);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자는 빈 결과를 반환한다")
+        void returnsEmptyWhenUserNotFound() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            Optional<UserAuthProfile> result = userAuthAccountService.findAuthProfileById(USER_ID);
+
+            assertThat(result).isEmpty();
+            verify(userRepository).findById(USER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrCreateSocialAuthProfile")
+    class GetOrCreateSocialAuthProfile {
+
+        @Test
+        @DisplayName("신규 소셜 사용자를 생성하고 인증 프로필을 반환한다")
+        void createsNewSocialUserAndReturnsAuthProfile() {
+            User savedUser = pendingUser(USER_ID, SocialType.KAKAO, SOCIAL_ID, EMAIL, PROFILE_IMAGE);
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, SOCIAL_ID))
+                    .willReturn(Optional.empty());
+            given(userRepository.save(any(User.class))).willReturn(savedUser);
+
+            UserAuthProfile result = userAuthAccountService.getOrCreateSocialAuthProfile(
+                    SocialType.KAKAO,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            );
+
+            assertThat(result.id()).isEqualTo(USER_ID);
+            assertThat(result.role()).isEqualTo(Role.USER);
+            assertThat(result.status()).isEqualTo(UserStatus.PENDING);
+            assertThat(result.email()).isEqualTo(EMAIL);
+            assertThat(result.active()).isFalse();
+
+            ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(userCaptor.capture());
+            User newUser = userCaptor.getValue();
+            assertThat(newUser.getSocialType()).isEqualTo(SocialType.KAKAO);
+            assertThat(newUser.getSocialId()).isEqualTo(SOCIAL_ID);
+            assertThat(newUser.getEmail()).isEqualTo(EMAIL);
+            assertThat(newUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
+        }
+
+        @Test
+        @DisplayName("기존 소셜 사용자를 재사용하고 새로 저장하지 않는다")
+        void reusesExistingSocialUserWithoutSaving() {
+            User existingUser = activeUser(USER_ID, SocialType.KAKAO, SOCIAL_ID, EMAIL, PROFILE_IMAGE);
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, SOCIAL_ID))
+                    .willReturn(Optional.of(existingUser));
+
+            UserAuthProfile result = userAuthAccountService.getOrCreateSocialAuthProfile(
+                    SocialType.KAKAO,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            );
+
+            assertThat(result.id()).isEqualTo(USER_ID);
+            assertThat(result.status()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(result.active()).isTrue();
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("탈퇴 소셜 사용자는 재활성화하지 않고 현재 인증 상태만 반환한다")
+        void doesNotReactivateWithdrawnSocialUser() {
+            User withdrawnUser = activeUser(USER_ID, SocialType.KAKAO, SOCIAL_ID, "old@example.com", "old.png");
+            withdrawnUser.withdraw();
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, SOCIAL_ID))
+                    .willReturn(Optional.of(withdrawnUser));
+
+            UserAuthProfile result = userAuthAccountService.getOrCreateSocialAuthProfile(
+                    SocialType.KAKAO,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            );
+
+            assertThat(result.id()).isEqualTo(USER_ID);
+            assertThat(result.status()).isEqualTo(UserStatus.WITHDRAWN);
+            assertThat(result.email()).isNull();
+            assertThat(result.active()).isFalse();
+            assertThat(withdrawnUser.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
+            verify(userRepository, never()).save(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("getOrCreateReactivatedSocialAuthProfile")
+    class GetOrCreateReactivatedSocialAuthProfile {
+
+        @Test
+        @DisplayName("탈퇴 소셜 사용자를 재활성화하고 PENDING 인증 프로필을 반환한다")
+        void reactivatesWithdrawnSocialUserAndReturnsPendingAuthProfile() {
+            User withdrawnUser = activeUser(USER_ID, SocialType.APPLE, SOCIAL_ID, "old@example.com", "old.png");
+            withdrawnUser.withdraw();
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
+                    .willReturn(Optional.of(withdrawnUser));
+
+            UserAuthProfile result = userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.APPLE,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            );
+
+            assertThat(result.id()).isEqualTo(USER_ID);
+            assertThat(result.status()).isEqualTo(UserStatus.PENDING);
+            assertThat(result.email()).isEqualTo(EMAIL);
+            assertThat(result.active()).isFalse();
+            assertThat(withdrawnUser.getEmail()).isEqualTo(EMAIL);
+            assertThat(withdrawnUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
+            assertThat(withdrawnUser.getStatus()).isEqualTo(UserStatus.PENDING);
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("신규 소셜 사용자를 생성하고 인증 프로필을 반환한다")
+        void createsNewSocialUserAndReturnsAuthProfile() {
+            User savedUser = pendingUser(USER_ID, SocialType.APPLE, SOCIAL_ID, EMAIL, PROFILE_IMAGE);
+            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
+                    .willReturn(Optional.empty());
+            given(userRepository.save(any(User.class))).willReturn(savedUser);
+
+            UserAuthProfile result = userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
+                    SocialType.APPLE,
+                    SOCIAL_ID,
+                    EMAIL,
+                    PROFILE_IMAGE
+            );
+
+            assertThat(result.id()).isEqualTo(USER_ID);
+            assertThat(result.status()).isEqualTo(UserStatus.PENDING);
+            assertThat(result.email()).isEqualTo(EMAIL);
+            verify(userRepository).save(any(User.class));
+        }
+    }
+
+    private User pendingUser(Long id, SocialType socialType, String socialId, String email, String profileImage) {
+        User user = User.createSocialUser(socialType, socialId, email, profileImage);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private User activeUser(Long id, SocialType socialType, String socialId, String email, String profileImage) {
+        User user = pendingUser(id, socialType, socialId, email, profileImage);
+        user.updateUser("테크포크유저", email, "백엔드 개발자입니다.");
+        return user;
+    }
+}

--- a/src/test/java/com/techfork/useraccount/application/auth/UserAuthAccountServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/auth/UserAuthAccountServiceTest.java
@@ -125,8 +125,8 @@ class UserAuthAccountServiceTest {
         }
 
         @Test
-        @DisplayName("탈퇴 소셜 사용자는 재활성화하지 않고 현재 인증 상태만 반환한다")
-        void doesNotReactivateWithdrawnSocialUser() {
+        @DisplayName("탈퇴 소셜 사용자를 재활성화하고 PENDING 인증 프로필을 반환한다")
+        void reactivatesWithdrawnSocialUserAndReturnsPendingAuthProfile() {
             User withdrawnUser = activeUser(USER_ID, SocialType.KAKAO, SOCIAL_ID, "old@example.com", "old.png");
             withdrawnUser.withdraw();
             given(userRepository.findBySocialTypeAndSocialId(SocialType.KAKAO, SOCIAL_ID))
@@ -140,34 +140,6 @@ class UserAuthAccountServiceTest {
             );
 
             assertThat(result.id()).isEqualTo(USER_ID);
-            assertThat(result.status()).isEqualTo(UserStatus.WITHDRAWN);
-            assertThat(result.email()).isNull();
-            assertThat(result.active()).isFalse();
-            assertThat(withdrawnUser.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
-            verify(userRepository, never()).save(any(User.class));
-        }
-    }
-
-    @Nested
-    @DisplayName("getOrCreateReactivatedSocialAuthProfile")
-    class GetOrCreateReactivatedSocialAuthProfile {
-
-        @Test
-        @DisplayName("탈퇴 소셜 사용자를 재활성화하고 PENDING 인증 프로필을 반환한다")
-        void reactivatesWithdrawnSocialUserAndReturnsPendingAuthProfile() {
-            User withdrawnUser = activeUser(USER_ID, SocialType.APPLE, SOCIAL_ID, "old@example.com", "old.png");
-            withdrawnUser.withdraw();
-            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
-                    .willReturn(Optional.of(withdrawnUser));
-
-            UserAuthProfile result = userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
-                    SocialType.APPLE,
-                    SOCIAL_ID,
-                    EMAIL,
-                    PROFILE_IMAGE
-            );
-
-            assertThat(result.id()).isEqualTo(USER_ID);
             assertThat(result.status()).isEqualTo(UserStatus.PENDING);
             assertThat(result.email()).isEqualTo(EMAIL);
             assertThat(result.active()).isFalse();
@@ -175,27 +147,6 @@ class UserAuthAccountServiceTest {
             assertThat(withdrawnUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
             assertThat(withdrawnUser.getStatus()).isEqualTo(UserStatus.PENDING);
             verify(userRepository, never()).save(any(User.class));
-        }
-
-        @Test
-        @DisplayName("신규 소셜 사용자를 생성하고 인증 프로필을 반환한다")
-        void createsNewSocialUserAndReturnsAuthProfile() {
-            User savedUser = pendingUser(USER_ID, SocialType.APPLE, SOCIAL_ID, EMAIL, PROFILE_IMAGE);
-            given(userRepository.findBySocialTypeAndSocialId(SocialType.APPLE, SOCIAL_ID))
-                    .willReturn(Optional.empty());
-            given(userRepository.save(any(User.class))).willReturn(savedUser);
-
-            UserAuthProfile result = userAuthAccountService.getOrCreateReactivatedSocialAuthProfile(
-                    SocialType.APPLE,
-                    SOCIAL_ID,
-                    EMAIL,
-                    PROFILE_IMAGE
-            );
-
-            assertThat(result.id()).isEqualTo(USER_ID);
-            assertThat(result.status()).isEqualTo(UserStatus.PENDING);
-            assertThat(result.email()).isEqualTo(EMAIL);
-            verify(userRepository).save(any(User.class));
         }
     }
 

--- a/src/test/java/com/techfork/useraccount/application/auth/UserAuthAccountServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/auth/UserAuthAccountServiceTest.java
@@ -1,5 +1,6 @@
 package com.techfork.useraccount.application.auth;
 
+import com.techfork.useraccount.application.event.UserReactivatedEvent;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.SocialType;
@@ -14,6 +15,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,6 +34,9 @@ class UserAuthAccountServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private UserAuthAccountService userAuthAccountService;
@@ -102,6 +107,7 @@ class UserAuthAccountServiceTest {
             assertThat(newUser.getSocialId()).isEqualTo(SOCIAL_ID);
             assertThat(newUser.getEmail()).isEqualTo(EMAIL);
             assertThat(newUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
+            verify(eventPublisher, never()).publishEvent(any());
         }
 
         @Test
@@ -122,6 +128,7 @@ class UserAuthAccountServiceTest {
             assertThat(result.status()).isEqualTo(UserStatus.ACTIVE);
             assertThat(result.active()).isTrue();
             verify(userRepository, never()).save(any(User.class));
+            verify(eventPublisher, never()).publishEvent(any());
         }
 
         @Test
@@ -147,6 +154,9 @@ class UserAuthAccountServiceTest {
             assertThat(withdrawnUser.getProfileImage()).isEqualTo(PROFILE_IMAGE);
             assertThat(withdrawnUser.getStatus()).isEqualTo(UserStatus.PENDING);
             verify(userRepository, never()).save(any(User.class));
+            ArgumentCaptor<UserReactivatedEvent> eventCaptor = ArgumentCaptor.forClass(UserReactivatedEvent.class);
+            verify(eventPublisher).publishEvent(eventCaptor.capture());
+            assertThat(eventCaptor.getValue().userId()).isEqualTo(USER_ID);
         }
     }
 

--- a/src/test/java/com/techfork/useraccount/application/command/InterestCommandServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/command/InterestCommandServiceTest.java
@@ -4,7 +4,7 @@ import com.techfork.global.exception.GeneralException;
 import com.techfork.useraccount.application.command.input.UpdateUserInterestsCommand;
 import com.techfork.useraccount.application.command.input.UserInterestCommand;
 import com.techfork.useraccount.application.event.UserInterestsChangedEvent;
-import com.techfork.useraccount.application.reader.UserReader;
+import com.techfork.useraccount.application.reader.UserAggregateReader;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.UserInterestCategory;
 import com.techfork.useraccount.domain.UserInterestKeyword;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.verify;
 class InterestCommandServiceTest {
 
     @Mock
-    private UserReader userReader;
+    private UserAggregateReader userAggregateReader;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -138,12 +138,12 @@ class InterestCommandServiceTest {
         List<UserInterestCommand> interests = List.of(
                 UserInterestCommand.builder().category("AI_ML").keywords(List.of("TENSORFLOW", "PYTORCH")).build()
         );
-        given(userReader.getByIdWithInterestCategories(userId)).willReturn(user);
+        given(userAggregateReader.getByIdWithInterestCategories(userId)).willReturn(user);
 
         interestCommandService.updateUserInterests(new UpdateUserInterestsCommand(userId, interests));
 
         assertThat(user.getInterestCategories()).hasSize(1);
-        verify(userReader).getByIdWithInterestCategories(userId);
+        verify(userAggregateReader).getByIdWithInterestCategories(userId);
         verifyPublishedEvent(userId);
     }
 
@@ -154,7 +154,7 @@ class InterestCommandServiceTest {
         List<UserInterestCommand> interests = List.of(
                 UserInterestCommand.builder().category("BACKEND").keywords(List.of("JAVA")).build()
         );
-        given(userReader.getByIdWithInterestCategories(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
+        given(userAggregateReader.getByIdWithInterestCategories(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         assertThatThrownBy(() -> interestCommandService.updateUserInterests(new UpdateUserInterestsCommand(userId, interests)))
                 .isInstanceOf(GeneralException.class)

--- a/src/test/java/com/techfork/useraccount/application/command/UserCommandServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/command/UserCommandServiceTest.java
@@ -7,7 +7,7 @@ import com.techfork.useraccount.application.command.input.UserInterestCommand;
 import com.techfork.useraccount.application.command.input.WithdrawUserCommand;
 import com.techfork.useraccount.application.event.OnboardingCompletedEvent;
 import com.techfork.useraccount.application.event.UserWithdrawnEvent;
-import com.techfork.useraccount.application.reader.UserReader;
+import com.techfork.useraccount.application.reader.UserAggregateReader;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.enums.UserStatus;
@@ -40,7 +40,7 @@ class UserCommandServiceTest {
     private InterestCommandService interestCommandService;
 
     @Mock
-    private UserReader userReader;
+    private UserAggregateReader userAggregateReader;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -68,14 +68,14 @@ class UserCommandServiceTest {
                 UserInterestCommand.builder().category("DATABASE").keywords(List.of("MYSQL", "REDIS")).build()
         );
         CompleteOnboardingCommand command = new CompleteOnboardingCommand(userId, "테크포크유저", "user@techfork.com", "백엔드 개발자입니다", interests);
-        given(userReader.getByIdWithInterestCategories(userId)).willReturn(mockUser);
+        given(userAggregateReader.getByIdWithInterestCategories(userId)).willReturn(mockUser);
 
         userCommandService.completeOnboarding(command);
 
         assertThat(mockUser.getNickName()).isEqualTo("테크포크유저");
         assertThat(mockUser.getEmail()).isEqualTo("user@techfork.com");
         assertThat(mockUser.getDescription()).isEqualTo("백엔드 개발자입니다");
-        verify(userReader).getByIdWithInterestCategories(userId);
+        verify(userAggregateReader).getByIdWithInterestCategories(userId);
         verify(interestCommandService).saveUserInterests(eq(mockUser), any());
         verifyPublishedEvent(OnboardingCompletedEvent.class, userId);
     }
@@ -90,7 +90,7 @@ class UserCommandServiceTest {
                 null,
                 List.of(UserInterestCommand.builder().category("BACKEND").keywords(List.of("JAVA")).build())
         );
-        given(userReader.getByIdWithInterestCategories(999L)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
+        given(userAggregateReader.getByIdWithInterestCategories(999L)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         assertThatThrownBy(() -> userCommandService.completeOnboarding(command))
                 .isInstanceOf(GeneralException.class)
@@ -111,7 +111,7 @@ class UserCommandServiceTest {
                 null,
                 List.of(UserInterestCommand.builder().category("FRONTEND").keywords(List.of("REACT", "TYPESCRIPT")).build())
         );
-        given(userReader.getByIdWithInterestCategories(userId)).willReturn(mockUser);
+        given(userAggregateReader.getByIdWithInterestCategories(userId)).willReturn(mockUser);
 
         userCommandService.completeOnboarding(command);
 
@@ -132,7 +132,7 @@ class UserCommandServiceTest {
                 UserInterestCommand.builder().category("DATABASE").keywords(List.of("MYSQL", "POSTGRESQL", "REDIS")).build()
         );
         CompleteOnboardingCommand command = new CompleteOnboardingCommand(userId, "풀스택개발자", "fullstack@techfork.com", "백엔드와 인프라를 다룹니다", interests);
-        given(userReader.getByIdWithInterestCategories(userId)).willReturn(mockUser);
+        given(userAggregateReader.getByIdWithInterestCategories(userId)).willReturn(mockUser);
 
         userCommandService.completeOnboarding(command);
 
@@ -145,71 +145,71 @@ class UserCommandServiceTest {
     @DisplayName("계정 프로필 수정 성공 - 닉네임만 수정")
     void updateAccountProfile_Success_OnlyNickName() {
         UpdateAccountProfileCommand command = new UpdateAccountProfileCommand(userId, "새로운닉네임", null);
-        given(userReader.getById(userId)).willReturn(testUser);
+        given(userAggregateReader.getById(userId)).willReturn(testUser);
 
         userCommandService.updateAccountProfile(command);
 
         assertThat(testUser.getNickName()).isEqualTo("새로운닉네임");
         assertThat(testUser.getDescription()).isEqualTo("백엔드 개발자입니다.");
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
     }
 
     @Test
     @DisplayName("계정 프로필 수정 성공 - 자기소개만 수정")
     void updateAccountProfile_Success_OnlyDescription() {
         UpdateAccountProfileCommand command = new UpdateAccountProfileCommand(userId, null, "새로운 자기소개");
-        given(userReader.getById(userId)).willReturn(testUser);
+        given(userAggregateReader.getById(userId)).willReturn(testUser);
 
         userCommandService.updateAccountProfile(command);
 
         assertThat(testUser.getNickName()).isEqualTo("테스트유저");
         assertThat(testUser.getDescription()).isEqualTo("새로운 자기소개");
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
     }
 
     @Test
     @DisplayName("계정 프로필 수정 성공 - 닉네임과 자기소개 모두 수정")
     void updateAccountProfile_Success_BothFields() {
         UpdateAccountProfileCommand command = new UpdateAccountProfileCommand(userId, "새닉네임", "새 자기소개");
-        given(userReader.getById(userId)).willReturn(testUser);
+        given(userAggregateReader.getById(userId)).willReturn(testUser);
 
         userCommandService.updateAccountProfile(command);
 
         assertThat(testUser.getNickName()).isEqualTo("새닉네임");
         assertThat(testUser.getDescription()).isEqualTo("새 자기소개");
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
     }
 
     @Test
     @DisplayName("계정 프로필 수정 성공 - 아무것도 수정하지 않음")
     void updateAccountProfile_Success_NoChanges() {
         UpdateAccountProfileCommand command = new UpdateAccountProfileCommand(userId, null, null);
-        given(userReader.getById(userId)).willReturn(testUser);
+        given(userAggregateReader.getById(userId)).willReturn(testUser);
 
         userCommandService.updateAccountProfile(command);
 
         assertThat(testUser.getNickName()).isEqualTo("테스트유저");
         assertThat(testUser.getDescription()).isEqualTo("백엔드 개발자입니다.");
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
     }
 
     @Test
     @DisplayName("계정 프로필 수정 실패 - 사용자를 찾을 수 없음")
     void updateAccountProfile_Fail_UserNotFound() {
         UpdateAccountProfileCommand command = new UpdateAccountProfileCommand(userId, "새닉네임", "새 자기소개");
-        given(userReader.getById(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
+        given(userAggregateReader.getById(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         assertThatThrownBy(() -> userCommandService.updateAccountProfile(command))
                 .isInstanceOf(GeneralException.class)
                 .extracting(ex -> ((GeneralException) ex).getCode())
                 .isEqualTo(UserErrorCode.USER_NOT_FOUND);
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
     }
 
     @Test
     @DisplayName("회원 탈퇴 성공 - 개인정보 익명화 확인")
     void withdrawUser_Success() {
-        given(userReader.getById(userId)).willReturn(testUser);
+        given(userAggregateReader.getById(userId)).willReturn(testUser);
         String originalSocialId = testUser.getSocialId();
 
         userCommandService.withdrawUser(new WithdrawUserCommand(userId));
@@ -221,20 +221,20 @@ class UserCommandServiceTest {
         assertThat(testUser.getProfileImage()).isNull();
         assertThat(testUser.getDescription()).isNull();
         assertThat(testUser.getSocialId()).isEqualTo(originalSocialId);
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
         verifyPublishedEvent(UserWithdrawnEvent.class, userId);
     }
 
     @Test
     @DisplayName("회원 탈퇴 실패 - 사용자를 찾을 수 없음")
     void withdrawUser_Fail_UserNotFound() {
-        given(userReader.getById(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
+        given(userAggregateReader.getById(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         assertThatThrownBy(() -> userCommandService.withdrawUser(new WithdrawUserCommand(userId)))
                 .isInstanceOf(GeneralException.class)
                 .extracting(ex -> ((GeneralException) ex).getCode())
                 .isEqualTo(UserErrorCode.USER_NOT_FOUND);
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
         verify(eventPublisher, never()).publishEvent(any());
     }
 
@@ -242,13 +242,13 @@ class UserCommandServiceTest {
     @DisplayName("회원 탈퇴 실패 - 이미 탈퇴한 회원")
     void withdrawUser_Fail_AlreadyWithdrawn() {
         testUser.withdraw();
-        given(userReader.getById(userId)).willReturn(testUser);
+        given(userAggregateReader.getById(userId)).willReturn(testUser);
 
         assertThatThrownBy(() -> userCommandService.withdrawUser(new WithdrawUserCommand(userId)))
                 .isInstanceOf(GeneralException.class)
                 .extracting(ex -> ((GeneralException) ex).getCode())
                 .isEqualTo(UserErrorCode.ALREADY_WITHDRAWN);
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
         verify(eventPublisher, never()).publishEvent(any());
     }
 

--- a/src/test/java/com/techfork/useraccount/application/query/InterestQueryServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/query/InterestQueryServiceTest.java
@@ -2,7 +2,7 @@ package com.techfork.useraccount.application.query;
 
 import com.techfork.global.exception.GeneralException;
 import com.techfork.useraccount.application.query.result.GetUserInterestsResult;
-import com.techfork.useraccount.application.reader.UserReader;
+import com.techfork.useraccount.application.reader.UserAggregateReader;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.exception.UserErrorCode;
 import com.techfork.useraccount.infrastructure.UserInterestCategoryRepository;
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.verify;
 class InterestQueryServiceTest {
 
     @Mock
-    private UserReader userReader;
+    private UserAggregateReader userAggregateReader;
 
     @Mock
     private UserInterestCategoryRepository userInterestCategoryRepository;
@@ -40,13 +40,13 @@ class InterestQueryServiceTest {
         Long userId = 1L;
         User user = mock(User.class);
         given(user.getId()).willReturn(userId);
-        given(userReader.getById(userId)).willReturn(user);
+        given(userAggregateReader.getById(userId)).willReturn(user);
         given(userInterestCategoryRepository.findByUserIdWithKeywords(userId)).willReturn(List.of());
 
         GetUserInterestsResult result = interestQueryService.getUserInterests(new GetUserInterestsQuery(userId));
 
         assertThat(result.interests()).isEmpty();
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
         verify(userInterestCategoryRepository).findByUserIdWithKeywords(userId);
     }
 
@@ -54,12 +54,12 @@ class InterestQueryServiceTest {
     @DisplayName("사용자 관심사 조회 - 사용자가 없으면 관심사를 조회하지 않는다")
     void getUserInterests_UserNotFound_ThrowsException() {
         Long userId = 999L;
-        given(userReader.getById(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
+        given(userAggregateReader.getById(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         assertThatThrownBy(() -> interestQueryService.getUserInterests(new GetUserInterestsQuery(userId)))
                 .isInstanceOf(GeneralException.class)
                 .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
         verify(userInterestCategoryRepository, never()).findByUserIdWithKeywords(userId);
     }
 }

--- a/src/test/java/com/techfork/useraccount/application/query/UserQueryServiceTest.java
+++ b/src/test/java/com/techfork/useraccount/application/query/UserQueryServiceTest.java
@@ -1,7 +1,7 @@
 package com.techfork.useraccount.application.query;
 
 import com.techfork.useraccount.application.query.result.GetAccountProfileResult;
-import com.techfork.useraccount.application.reader.UserReader;
+import com.techfork.useraccount.application.reader.UserAggregateReader;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.exception.UserErrorCode;
@@ -24,7 +24,7 @@ import static org.mockito.Mockito.verify;
 class UserQueryServiceTest {
 
     @Mock
-    private UserReader userReader;
+    private UserAggregateReader userAggregateReader;
 
     @InjectMocks
     private UserQueryService userQueryService;
@@ -43,7 +43,7 @@ class UserQueryServiceTest {
     @Test
     @DisplayName("계정 프로필 조회 성공")
     void getAccountProfile_Success() {
-        given(userReader.getById(userId)).willReturn(testUser);
+        given(userAggregateReader.getById(userId)).willReturn(testUser);
 
         GetAccountProfileResult result = userQueryService.getAccountProfile(new GetAccountProfileQuery(userId));
 
@@ -52,18 +52,18 @@ class UserQueryServiceTest {
         assertThat(result.nickName()).isEqualTo("테스트유저");
         assertThat(result.email()).isEqualTo("test@example.com");
         assertThat(result.description()).isEqualTo("백엔드 개발자입니다.");
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
     }
 
     @Test
     @DisplayName("계정 프로필 조회 실패 - 사용자를 찾을 수 없음")
     void getAccountProfile_Fail_UserNotFound() {
-        given(userReader.getById(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
+        given(userAggregateReader.getById(userId)).willThrow(new GeneralException(UserErrorCode.USER_NOT_FOUND));
 
         assertThatThrownBy(() -> userQueryService.getAccountProfile(new GetAccountProfileQuery(userId)))
                 .isInstanceOf(GeneralException.class)
                 .extracting(ex -> ((GeneralException) ex).getCode())
                 .isEqualTo(UserErrorCode.USER_NOT_FOUND);
-        verify(userReader).getById(userId);
+        verify(userAggregateReader).getById(userId);
     }
 }

--- a/src/test/java/com/techfork/useraccount/application/reader/UserAggregateReaderTest.java
+++ b/src/test/java/com/techfork/useraccount/application/reader/UserAggregateReaderTest.java
@@ -20,13 +20,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
-class UserReaderTest {
+class UserAggregateReaderTest {
 
     @Mock
     private UserRepository userRepository;
 
     @InjectMocks
-    private UserReader userReader;
+    private UserAggregateReader userAggregateReader;
 
     @Test
     @DisplayName("ID로 사용자를 조회한다")
@@ -35,7 +35,7 @@ class UserReaderTest {
         User user = mock(User.class);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
-        User result = userReader.getById(userId);
+        User result = userAggregateReader.getById(userId);
 
         assertThat(result).isSameAs(user);
         verify(userRepository).findById(userId);
@@ -47,7 +47,7 @@ class UserReaderTest {
         Long userId = 999L;
         given(userRepository.findById(userId)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> userReader.getById(userId))
+        assertThatThrownBy(() -> userAggregateReader.getById(userId))
                 .isInstanceOf(GeneralException.class)
                 .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
         verify(userRepository).findById(userId);
@@ -60,7 +60,7 @@ class UserReaderTest {
         User user = mock(User.class);
         given(userRepository.findByIdWithInterestCategories(userId)).willReturn(Optional.of(user));
 
-        User result = userReader.getByIdWithInterestCategories(userId);
+        User result = userAggregateReader.getByIdWithInterestCategories(userId);
 
         assertThat(result).isSameAs(user);
         verify(userRepository).findByIdWithInterestCategories(userId);
@@ -72,7 +72,7 @@ class UserReaderTest {
         Long userId = 999L;
         given(userRepository.findByIdWithInterestCategories(userId)).willReturn(Optional.empty());
 
-        assertThatThrownBy(() -> userReader.getByIdWithInterestCategories(userId))
+        assertThatThrownBy(() -> userAggregateReader.getByIdWithInterestCategories(userId))
                 .isInstanceOf(GeneralException.class)
                 .hasFieldOrPropertyWithValue("code", UserErrorCode.USER_NOT_FOUND);
         verify(userRepository).findByIdWithInterestCategories(userId);

--- a/src/test/java/com/techfork/useraccount/integration/UserAccountAfterCommitEventIntegrationTest.java
+++ b/src/test/java/com/techfork/useraccount/integration/UserAccountAfterCommitEventIntegrationTest.java
@@ -9,8 +9,10 @@ import com.techfork.useraccount.application.command.input.CompleteOnboardingComm
 import com.techfork.useraccount.application.command.input.UpdateUserInterestsCommand;
 import com.techfork.useraccount.application.command.input.UserInterestCommand;
 import com.techfork.useraccount.application.command.input.WithdrawUserCommand;
+import com.techfork.useraccount.application.auth.UserAuthAccountService;
 import com.techfork.useraccount.application.event.OnboardingCompletedEvent;
 import com.techfork.useraccount.application.event.UserInterestsChangedEvent;
+import com.techfork.useraccount.application.event.UserReactivatedEvent;
 import com.techfork.useraccount.application.event.UserWithdrawnEvent;
 import com.techfork.useraccount.domain.User;
 import com.techfork.useraccount.domain.enums.SocialType;
@@ -38,6 +40,9 @@ class UserAccountAfterCommitEventIntegrationTest extends IntegrationTestBase {
 
     @Autowired
     private UserCommandService userCommandService;
+
+    @Autowired
+    private UserAuthAccountService userAuthAccountService;
 
     @Autowired
     private InterestCommandService interestCommandService;
@@ -107,6 +112,22 @@ class UserAccountAfterCommitEventIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    @DisplayName("회원 재활성화 이벤트는 실제 트랜잭션 커밋 이후 인증 캐시 무효화만 실행한다")
+    void reactivateUser_AfterCommit_EvictsAuthCacheOnly() {
+        User user = saveWithdrawnUser();
+
+        userAuthAccountService.getOrCreateSocialAuthProfile(
+                user.getSocialType(),
+                user.getSocialId(),
+                "reactivated@example.com",
+                "https://cdn.example.com/reactivated.png"
+        );
+
+        verify(userAuthCacheService).evict(user.getId());
+        verifyNoInteractions(personalizationProfileService);
+    }
+
+    @Test
     @DisplayName("회원 탈퇴 커밋 직전 인증 캐시 무효화에 실패하면 탈퇴 트랜잭션을 롤백한다")
     void withdrawUser_BeforeCommitCacheEvictionFails_RollsBackWithdrawal() {
         User user = saveActiveUser();
@@ -131,6 +152,7 @@ class UserAccountAfterCommitEventIntegrationTest extends IntegrationTestBase {
         transactionTemplate.executeWithoutResult(status -> {
             eventPublisher.publishEvent(new OnboardingCompletedEvent(userId));
             eventPublisher.publishEvent(new UserInterestsChangedEvent(userId));
+            eventPublisher.publishEvent(new UserReactivatedEvent(userId));
             eventPublisher.publishEvent(new UserWithdrawnEvent(userId));
             status.setRollbackOnly();
         });
@@ -147,6 +169,12 @@ class UserAccountAfterCommitEventIntegrationTest extends IntegrationTestBase {
         User user = User.createSocialUser(SocialType.KAKAO, uniqueSocialId(), "active@example.com", null);
         user.updateUser("테스트유저", "active@example.com", "백엔드 개발자입니다");
         return userRepository.save(user);
+    }
+
+    private User saveWithdrawnUser() {
+        User user = saveActiveUser();
+        user.withdraw();
+        return userRepository.saveAndFlush(user);
     }
 
     private UserInterestCommand backendInterest() {


### PR DESCRIPTION
## ❤️ 기능 설명

Auth / Security 코드가 User Account repository와 aggregate에 직접 의존하던 경계를 Auth 전용 useraccount seam으로 정리했습니다.

- `UserAuthAccountService`, `UserAuthProfile` 추가로 Auth/Security가 필요한 최소 인증 스냅샷만 조회하도록 변경
- `AuthCommandService`, `KakaoLoginCommandService`, `JwtAuthenticationFilter`, `CustomOidcUserService`의 `UserRepository` 직접 의존 제거
- iOS direct Kakao 로그인과 OIDC 로그인 모두 탈퇴 사용자를 동일하게 재활성화하도록 정책 통일
- `UserReactivatedEvent` 발행 및 auth cache evict listener 추가로 재활성화 이후 stale principal 위험 완화
- Redis auth cache 복원 경로를 `UserAuthProfile -> UserPrincipal`로 통일해 principal 매핑 drift 위험 축소
- Kakao REST `id`와 OIDC `sub`를 같은 service user ID socialId로 정규화하는 `KakaoSocialId` 추가
- useraccount 내부 aggregate loader 이름을 `UserAggregateReader`로 변경해 외부 lookup seam과 구분

Swagger 테스트 성공 결과 스크린샷 첨부

- API path, JSON field, status code 변경 없는 Auth/UserAccount 경계 리팩터링이라 Swagger 스크린샷은 해당 없습니다.
- 아래 CLI 검증 결과와 PR CI로 대체합니다.

<br>

## 연결된 issue

close #429

<br>
<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (API 계약 변경 없는 리팩터링이라 CLI 결과로 대체)
- [x] 이슈넘버를 적었는가?

## 🧪 테스트 결과

```bash
git diff --check
# 통과

./gradlew test \
  --tests 'com.techfork.useraccount.application.auth.UserAuthAccountServiceTest' \
  --tests 'com.techfork.auth.security.listener.UserAuthCacheEventListenerTest' \
  --tests 'com.techfork.useraccount.integration.UserAccountAfterCommitEventIntegrationTest'
# BUILD SUCCESSFUL

./gradlew test \
  --tests 'com.techfork.auth.security.oauth.CustomOidcUserServiceTest' \
  --tests 'com.techfork.auth.security.service.UserAuthCacheServiceTest' \
  --tests 'com.techfork.auth.security.filter.JwtAuthenticationFilterTest'
# BUILD SUCCESSFUL

./gradlew test \
  --tests 'com.techfork.auth.infrastructure.kakao.KakaoSocialIdTest' \
  --tests 'com.techfork.auth.application.command.KakaoLoginCommandServiceTest' \
  --tests 'com.techfork.auth.security.oauth.CustomOidcUserServiceTest'
# BUILD SUCCESSFUL

./gradlew test \
  --tests 'com.techfork.useraccount.application.reader.UserAggregateReaderTest' \
  --tests 'com.techfork.useraccount.application.command.UserCommandServiceTest' \
  --tests 'com.techfork.useraccount.application.command.InterestCommandServiceTest' \
  --tests 'com.techfork.useraccount.application.query.UserQueryServiceTest' \
  --tests 'com.techfork.useraccount.application.query.InterestQueryServiceTest'
# BUILD SUCCESSFUL
```
