### PR TITLE
[refactor/#430] Auth cache 이벤트 seam 안정화

### DIFF
--- a/src/main/java/com/techfork/auth/security/listener/UserAuthCacheEventListener.java
+++ b/src/main/java/com/techfork/auth/security/listener/UserAuthCacheEventListener.java
@@ -15,26 +15,35 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class UserAuthCacheEventListener {
 
+    private static final String ONBOARDING_COMPLETED_AFTER_COMMIT = "onboarding-completed-after-commit";
+    private static final String USER_REACTIVATED_AFTER_COMMIT = "user-reactivated-after-commit";
+    private static final String USER_WITHDRAWN_BEFORE_COMMIT = "user-withdrawn-before-commit";
+    private static final String USER_WITHDRAWN_AFTER_COMMIT = "user-withdrawn-after-commit";
+
     private final UserAuthCacheService userAuthCacheService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(OnboardingCompletedEvent event) {
-        evictUserAuthCache(event.userId(), "onboarding-completed");
+    public void evictOnOnboardingCompletedAfterCommit(OnboardingCompletedEvent event) {
+        evictUserAuthCache(event.userId(), ONBOARDING_COMPLETED_AFTER_COMMIT);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handle(UserReactivatedEvent event) {
-        evictUserAuthCache(event.userId(), "user-reactivated");
+    public void evictOnUserReactivatedAfterCommit(UserReactivatedEvent event) {
+        evictUserAuthCache(event.userId(), USER_REACTIVATED_AFTER_COMMIT);
     }
 
+    /**
+     * 탈퇴 전 캐시 무효화는 탈퇴 사용자 인증 차단을 위한 커밋 게이트다.
+     * 실패하면 탈퇴 트랜잭션을 롤백해야 하므로 예외를 잡거나 완화하지 않는다.
+     */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
-    public void handleBeforeCommit(UserWithdrawnEvent event) {
-        evictUserAuthCache(event.userId(), "user-withdrawn-before-commit");
+    public void evictOnUserWithdrawnBeforeCommit(UserWithdrawnEvent event) {
+        evictUserAuthCache(event.userId(), USER_WITHDRAWN_BEFORE_COMMIT);
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void handleAfterCommit(UserWithdrawnEvent event) {
-        evictUserAuthCache(event.userId(), "user-withdrawn-after-commit");
+    public void evictOnUserWithdrawnAfterCommit(UserWithdrawnEvent event) {
+        evictUserAuthCache(event.userId(), USER_WITHDRAWN_AFTER_COMMIT);
     }
 
     private void evictUserAuthCache(Long userId, String reason) {

--- a/src/test/java/com/techfork/auth/security/listener/UserAuthCacheEventListenerTest.java
+++ b/src/test/java/com/techfork/auth/security/listener/UserAuthCacheEventListenerTest.java
@@ -38,10 +38,10 @@ class UserAuthCacheEventListenerTest {
 
         @Test
         @DisplayName("커밋 이후 인증 캐시를 무효화한다")
-        void handle_EvictsUserAuthCacheAfterCommit() {
+        void evictOnOnboardingCompletedAfterCommit_EvictsUserAuthCache() {
             Long userId = 1L;
 
-            listener.handle(new OnboardingCompletedEvent(userId));
+            listener.evictOnOnboardingCompletedAfterCommit(new OnboardingCompletedEvent(userId));
 
             verify(userAuthCacheService).evict(userId);
         }
@@ -59,10 +59,10 @@ class UserAuthCacheEventListenerTest {
 
         @Test
         @DisplayName("커밋 이후 인증 캐시를 무효화한다")
-        void handle_EvictsUserAuthCacheAfterCommit() {
+        void evictOnUserReactivatedAfterCommit_EvictsUserAuthCache() {
             Long userId = 1L;
 
-            listener.handle(new UserReactivatedEvent(userId));
+            listener.evictOnUserReactivatedAfterCommit(new UserReactivatedEvent(userId));
 
             verify(userAuthCacheService).evict(userId);
         }
@@ -80,20 +80,20 @@ class UserAuthCacheEventListenerTest {
 
         @Test
         @DisplayName("커밋 직전 인증 캐시를 무효화한다")
-        void handleBeforeCommit_EvictsUserAuthCache() {
+        void evictOnUserWithdrawnBeforeCommit_EvictsUserAuthCache() {
             Long userId = 1L;
 
-            listener.handleBeforeCommit(new UserWithdrawnEvent(userId));
+            listener.evictOnUserWithdrawnBeforeCommit(new UserWithdrawnEvent(userId));
 
             verify(userAuthCacheService).evict(userId);
         }
 
         @Test
         @DisplayName("커밋 이후 인증 캐시를 한 번 더 무효화한다")
-        void handleAfterCommit_EvictsUserAuthCache() {
+        void evictOnUserWithdrawnAfterCommit_EvictsUserAuthCache() {
             Long userId = 1L;
 
-            listener.handleAfterCommit(new UserWithdrawnEvent(userId));
+            listener.evictOnUserWithdrawnAfterCommit(new UserWithdrawnEvent(userId));
 
             verify(userAuthCacheService).evict(userId);
         }
@@ -110,12 +110,12 @@ class UserAuthCacheEventListenerTest {
 
         @Test
         @DisplayName("커밋 직전 인증 캐시 무효화 실패는 예외를 전파한다")
-        void handleBeforeCommit_PropagatesEvictionFailure() {
+        void evictOnUserWithdrawnBeforeCommit_PropagatesEvictionFailure() {
             Long userId = 1L;
             RuntimeException evictionFailure = new RuntimeException("redis eviction failed");
             doThrow(evictionFailure).when(userAuthCacheService).evict(userId);
 
-            assertThatThrownBy(() -> listener.handleBeforeCommit(new UserWithdrawnEvent(userId)))
+            assertThatThrownBy(() -> listener.evictOnUserWithdrawnBeforeCommit(new UserWithdrawnEvent(userId)))
                     .isSameAs(evictionFailure);
         }
     }

--- a/src/test/java/com/techfork/auth/security/listener/UserAuthCacheEventListenerTest.java
+++ b/src/test/java/com/techfork/auth/security/listener/UserAuthCacheEventListenerTest.java
@@ -5,6 +5,7 @@ import com.techfork.useraccount.application.event.OnboardingCompletedEvent;
 import com.techfork.useraccount.application.event.UserReactivatedEvent;
 import com.techfork.useraccount.application.event.UserWithdrawnEvent;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -13,7 +14,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,65 +32,113 @@ class UserAuthCacheEventListenerTest {
     @InjectMocks
     private UserAuthCacheEventListener listener;
 
-    @Test
-    @DisplayName("온보딩 완료 이벤트 - 커밋 이후 인증 캐시를 무효화한다")
-    void handle_OnboardingCompletedEvent_EvictsUserAuthCache() {
-        Long userId = 1L;
+    @Nested
+    @DisplayName("온보딩 완료 이벤트")
+    class OnboardingCompleted {
 
-        listener.handle(new OnboardingCompletedEvent(userId));
+        @Test
+        @DisplayName("커밋 이후 인증 캐시를 무효화한다")
+        void handle_EvictsUserAuthCacheAfterCommit() {
+            Long userId = 1L;
 
-        verify(userAuthCacheService).evict(userId);
+            listener.handle(new OnboardingCompletedEvent(userId));
+
+            verify(userAuthCacheService).evict(userId);
+        }
+
+        @Test
+        @DisplayName("AFTER_COMMIT 단계에서만 실행한다")
+        void listenerMethod_RunsAfterCommitOnly() {
+            assertTransactionalEventListenerPhases(OnboardingCompletedEvent.class, TransactionPhase.AFTER_COMMIT);
+        }
     }
 
-    @Test
-    @DisplayName("회원 재활성화 이벤트 - 커밋 이후 인증 캐시를 무효화한다")
-    void handle_UserReactivatedEvent_EvictsUserAuthCache() {
-        Long userId = 1L;
+    @Nested
+    @DisplayName("회원 재활성화 이벤트")
+    class UserReactivated {
 
-        listener.handle(new UserReactivatedEvent(userId));
+        @Test
+        @DisplayName("커밋 이후 인증 캐시를 무효화한다")
+        void handle_EvictsUserAuthCacheAfterCommit() {
+            Long userId = 1L;
 
-        verify(userAuthCacheService).evict(userId);
+            listener.handle(new UserReactivatedEvent(userId));
+
+            verify(userAuthCacheService).evict(userId);
+        }
+
+        @Test
+        @DisplayName("AFTER_COMMIT 단계에서만 실행한다")
+        void listenerMethod_RunsAfterCommitOnly() {
+            assertTransactionalEventListenerPhases(UserReactivatedEvent.class, TransactionPhase.AFTER_COMMIT);
+        }
     }
 
-    @Test
-    @DisplayName("회원 탈퇴 이벤트 - 커밋 직전 인증 캐시를 무효화한다")
-    void handleBeforeCommit_UserWithdrawnEvent_EvictsUserAuthCache() {
-        Long userId = 1L;
+    @Nested
+    @DisplayName("회원 탈퇴 이벤트")
+    class UserWithdrawn {
 
-        listener.handleBeforeCommit(new UserWithdrawnEvent(userId));
+        @Test
+        @DisplayName("커밋 직전 인증 캐시를 무효화한다")
+        void handleBeforeCommit_EvictsUserAuthCache() {
+            Long userId = 1L;
 
-        verify(userAuthCacheService).evict(userId);
+            listener.handleBeforeCommit(new UserWithdrawnEvent(userId));
+
+            verify(userAuthCacheService).evict(userId);
+        }
+
+        @Test
+        @DisplayName("커밋 이후 인증 캐시를 한 번 더 무효화한다")
+        void handleAfterCommit_EvictsUserAuthCache() {
+            Long userId = 1L;
+
+            listener.handleAfterCommit(new UserWithdrawnEvent(userId));
+
+            verify(userAuthCacheService).evict(userId);
+        }
+
+        @Test
+        @DisplayName("BEFORE_COMMIT과 AFTER_COMMIT 단계에서 모두 실행한다")
+        void listenerMethods_RunBeforeAndAfterCommit() {
+            assertTransactionalEventListenerPhases(
+                    UserWithdrawnEvent.class,
+                    TransactionPhase.BEFORE_COMMIT,
+                    TransactionPhase.AFTER_COMMIT
+            );
+        }
+
+        @Test
+        @DisplayName("커밋 직전 인증 캐시 무효화 실패는 예외를 전파한다")
+        void handleBeforeCommit_PropagatesEvictionFailure() {
+            Long userId = 1L;
+            RuntimeException evictionFailure = new RuntimeException("redis eviction failed");
+            doThrow(evictionFailure).when(userAuthCacheService).evict(userId);
+
+            assertThatThrownBy(() -> listener.handleBeforeCommit(new UserWithdrawnEvent(userId)))
+                    .isSameAs(evictionFailure);
+        }
     }
 
-    @Test
-    @DisplayName("회원 탈퇴 이벤트 - 커밋 이후 인증 캐시를 한 번 더 무효화한다")
-    void handleAfterCommit_UserWithdrawnEvent_EvictsUserAuthCache() {
-        Long userId = 1L;
-
-        listener.handleAfterCommit(new UserWithdrawnEvent(userId));
-
-        verify(userAuthCacheService).evict(userId);
-    }
-
-    @Test
-    @DisplayName("인증 캐시 리스너는 이벤트별 트랜잭션 단계를 명시한다")
-    void listenerMethods_RunWithExpectedTransactionPhase() throws NoSuchMethodException {
-        assertTransactionalEventListenerPhase("handle", OnboardingCompletedEvent.class, TransactionPhase.AFTER_COMMIT);
-        assertTransactionalEventListenerPhase("handle", UserReactivatedEvent.class, TransactionPhase.AFTER_COMMIT);
-        assertTransactionalEventListenerPhase("handleBeforeCommit", UserWithdrawnEvent.class, TransactionPhase.BEFORE_COMMIT);
-        assertTransactionalEventListenerPhase("handleAfterCommit", UserWithdrawnEvent.class, TransactionPhase.AFTER_COMMIT);
-    }
-
-    private void assertTransactionalEventListenerPhase(
-            String methodName,
+    private void assertTransactionalEventListenerPhases(
             Class<?> eventType,
-            TransactionPhase expectedPhase
-    ) throws NoSuchMethodException {
-        TransactionalEventListener annotation = UserAuthCacheEventListener.class
-                .getDeclaredMethod(methodName, eventType)
-                .getAnnotation(TransactionalEventListener.class);
+            TransactionPhase... expectedPhases
+    ) {
+        List<TransactionalEventListener> annotations = Arrays.stream(UserAuthCacheEventListener.class.getDeclaredMethods())
+                .filter(method -> listensToEvent(method, eventType))
+                .map(method -> method.getAnnotation(TransactionalEventListener.class))
+                .toList();
 
-        assertThat(annotation).isNotNull();
-        assertThat(annotation.phase()).isEqualTo(expectedPhase);
+        assertThat(annotations)
+                .extracting(TransactionalEventListener::phase)
+                .containsExactlyInAnyOrder(expectedPhases);
+        assertThat(annotations)
+                .allSatisfy(annotation -> assertThat(annotation.fallbackExecution()).isFalse());
+    }
+
+    private boolean listensToEvent(Method method, Class<?> eventType) {
+        return method.isAnnotationPresent(TransactionalEventListener.class)
+                && method.getParameterCount() == 1
+                && method.getParameterTypes()[0].equals(eventType);
     }
 }

--- a/src/test/java/com/techfork/auth/security/oauth/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -2,6 +2,7 @@ package com.techfork.auth.security.oauth;
 
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -18,93 +19,108 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
     private final HttpCookieOAuth2AuthorizationRequestRepository repository =
             new HttpCookieOAuth2AuthorizationRequestRepository();
 
-    @Test
-    @DisplayName("OAuth2 authorization request 저장 시 직렬화된 httpOnly 쿠키를 생성한다")
-    void saveAuthorizationRequest_CreatesSerializedHttpOnlyCookie() {
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        OAuth2AuthorizationRequest authorizationRequest = authorizationRequest();
+    @Nested
+    @DisplayName("saveAuthorizationRequest")
+    class SaveAuthorizationRequest {
 
-        repository.saveAuthorizationRequest(
-                authorizationRequest,
-                new MockHttpServletRequest(),
-                response
-        );
+        @Test
+        @DisplayName("OAuth2 authorization request 저장 시 직렬화된 httpOnly 쿠키를 생성한다")
+        void createsSerializedHttpOnlyCookie() {
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            OAuth2AuthorizationRequest authorizationRequest = authorizationRequest();
 
-        Cookie cookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-        assertThat(cookie).isNotNull();
-        assertThat(cookie.getValue()).isNotBlank();
-        assertThat(cookie.getPath()).isEqualTo("/");
-        assertThat(cookie.isHttpOnly()).isTrue();
-        assertThat(cookie.getMaxAge()).isEqualTo(180);
+            repository.saveAuthorizationRequest(
+                    authorizationRequest,
+                    new MockHttpServletRequest(),
+                    response
+            );
+
+            Cookie cookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            assertThat(cookie).isNotNull();
+            assertThat(cookie.getValue()).isNotBlank();
+            assertThat(cookie.getPath()).isEqualTo("/");
+            assertThat(cookie.isHttpOnly()).isTrue();
+            assertThat(cookie.getMaxAge()).isEqualTo(180);
+        }
+
+        @Test
+        @DisplayName("null request를 넘기면 기존 authorization request 쿠키를 삭제한다")
+        void nullRequest_AddsDeleteCookieWhenCookieExists() {
+            Cookie existingCookie = new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, "serialized-request");
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            request.setCookies(existingCookie);
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            repository.saveAuthorizationRequest(null, request, response);
+
+            Cookie deleteCookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            assertThat(deleteCookie).isNotNull();
+            assertThat(deleteCookie.getValue()).isEmpty();
+            assertThat(deleteCookie.getPath()).isEqualTo("/");
+            assertThat(deleteCookie.getMaxAge()).isZero();
+        }
     }
 
-    @Test
-    @DisplayName("OAuth2 authorization request 쿠키가 있으면 역직렬화해서 로드한다")
-    void loadAuthorizationRequest_WithCookie_ReturnsDeserializedAuthorizationRequest() {
-        OAuth2AuthorizationRequest original = authorizationRequest();
-        MockHttpServletResponse saveResponse = new MockHttpServletResponse();
-        repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
+    @Nested
+    @DisplayName("loadAuthorizationRequest")
+    class LoadAuthorizationRequest {
 
-        MockHttpServletRequest loadRequest = new MockHttpServletRequest();
-        loadRequest.setCookies(saveResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
+        @Test
+        @DisplayName("OAuth2 authorization request 쿠키가 있으면 역직렬화해서 로드한다")
+        void withCookie_ReturnsDeserializedAuthorizationRequest() {
+            OAuth2AuthorizationRequest original = authorizationRequest();
+            MockHttpServletResponse saveResponse = new MockHttpServletResponse();
+            repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
 
-        OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(loadRequest);
+            MockHttpServletRequest loadRequest = new MockHttpServletRequest();
+            loadRequest.setCookies(saveResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
 
-        assertThat(loaded).isNotNull();
-        assertThat(loaded.getAuthorizationUri()).isEqualTo(original.getAuthorizationUri());
-        assertThat(loaded.getClientId()).isEqualTo(original.getClientId());
-        assertThat(loaded.getRedirectUri()).isEqualTo(original.getRedirectUri());
-        assertThat(loaded.getScopes()).isEqualTo(original.getScopes());
-        assertThat(loaded.getState()).isEqualTo(original.getState());
-        assertThat(loaded.getAdditionalParameters()).containsEntry("nonce", "nonce-123");
-        assertThat(loaded.getAttributes()).containsEntry("registration_id", "apple");
+            OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(loadRequest);
+
+            assertThat(loaded).isNotNull();
+            assertThat(loaded.getAuthorizationUri()).isEqualTo(original.getAuthorizationUri());
+            assertThat(loaded.getClientId()).isEqualTo(original.getClientId());
+            assertThat(loaded.getRedirectUri()).isEqualTo(original.getRedirectUri());
+            assertThat(loaded.getScopes()).isEqualTo(original.getScopes());
+            assertThat(loaded.getState()).isEqualTo(original.getState());
+            assertThat(loaded.getAdditionalParameters()).containsEntry("nonce", "nonce-123");
+            assertThat(loaded.getAttributes()).containsEntry("registration_id", "apple");
+        }
+
+        @Test
+        @DisplayName("OAuth2 authorization request 쿠키가 없으면 null을 반환한다")
+        void withoutCookie_ReturnsNull() {
+            OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(new MockHttpServletRequest());
+
+            assertThat(loaded).isNull();
+        }
     }
 
-    @Test
-    @DisplayName("OAuth2 authorization request 쿠키가 없으면 null을 반환한다")
-    void loadAuthorizationRequest_WithoutCookie_ReturnsNull() {
-        OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(new MockHttpServletRequest());
+    @Nested
+    @DisplayName("removeAuthorizationRequest")
+    class RemoveAuthorizationRequest {
 
-        assertThat(loaded).isNull();
-    }
+        @Test
+        @DisplayName("기존 request를 반환하고 삭제 쿠키를 추가한다")
+        void returnsExistingRequestAndAddsDeleteCookie() {
+            OAuth2AuthorizationRequest original = authorizationRequest();
+            MockHttpServletResponse saveResponse = new MockHttpServletResponse();
+            repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
 
-    @Test
-    @DisplayName("removeAuthorizationRequest는 기존 request를 반환하고 삭제 쿠키를 추가한다")
-    void removeAuthorizationRequest_ReturnsExistingRequestAndAddsDeleteCookie() {
-        OAuth2AuthorizationRequest original = authorizationRequest();
-        MockHttpServletResponse saveResponse = new MockHttpServletResponse();
-        repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
+            MockHttpServletRequest removeRequest = new MockHttpServletRequest();
+            removeRequest.setCookies(saveResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
+            MockHttpServletResponse removeResponse = new MockHttpServletResponse();
 
-        MockHttpServletRequest removeRequest = new MockHttpServletRequest();
-        removeRequest.setCookies(saveResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
-        MockHttpServletResponse removeResponse = new MockHttpServletResponse();
+            OAuth2AuthorizationRequest removed = repository.removeAuthorizationRequest(removeRequest, removeResponse);
 
-        OAuth2AuthorizationRequest removed = repository.removeAuthorizationRequest(removeRequest, removeResponse);
-
-        assertThat(removed).isNotNull();
-        assertThat(removed.getState()).isEqualTo(original.getState());
-        Cookie deleteCookie = removeResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-        assertThat(deleteCookie).isNotNull();
-        assertThat(deleteCookie.getValue()).isEmpty();
-        assertThat(deleteCookie.getPath()).isEqualTo("/");
-        assertThat(deleteCookie.getMaxAge()).isZero();
-    }
-
-    @Test
-    @DisplayName("saveAuthorizationRequest에 null을 넘기면 기존 authorization request 쿠키를 삭제한다")
-    void saveAuthorizationRequest_NullRequest_AddsDeleteCookieWhenCookieExists() {
-        Cookie existingCookie = new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, "serialized-request");
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setCookies(existingCookie);
-        MockHttpServletResponse response = new MockHttpServletResponse();
-
-        repository.saveAuthorizationRequest(null, request, response);
-
-        Cookie deleteCookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-        assertThat(deleteCookie).isNotNull();
-        assertThat(deleteCookie.getValue()).isEmpty();
-        assertThat(deleteCookie.getPath()).isEqualTo("/");
-        assertThat(deleteCookie.getMaxAge()).isZero();
+            assertThat(removed).isNotNull();
+            assertThat(removed.getState()).isEqualTo(original.getState());
+            Cookie deleteCookie = removeResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            assertThat(deleteCookie).isNotNull();
+            assertThat(deleteCookie.getValue()).isEmpty();
+            assertThat(deleteCookie.getPath()).isEqualTo("/");
+            assertThat(deleteCookie.getMaxAge()).isZero();
+        }
     }
 
     private OAuth2AuthorizationRequest authorizationRequest() {

--- a/src/test/java/com/techfork/auth/security/service/UserAuthCacheServiceTest.java
+++ b/src/test/java/com/techfork/auth/security/service/UserAuthCacheServiceTest.java
@@ -6,6 +6,7 @@ import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.UserStatus;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -32,124 +33,151 @@ class UserAuthCacheServiceTest {
 
     private static final Long USER_ID = 1L;
     private static final String CACHE_KEY = "user:auth:" + USER_ID;
+    private static final String ACTIVE_USER_CACHE_VALUE = "1|USER|ACTIVE|test@example.com";
+    private static final String WITHDRAWN_USER_CACHE_VALUE = "1|USER|WITHDRAWN|";
 
-    // ===== get 테스트 =====
+    @Nested
+    @DisplayName("get")
+    class Get {
 
-    @Test
-    @DisplayName("get - 캐시 미스: null 반환")
-    void get_CacheMiss_ReturnsNull() {
-        // Given
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(CACHE_KEY)).willReturn(null);
+        @Test
+        @DisplayName("캐시 미스면 null을 반환한다")
+        void cacheMiss_ReturnsNull() {
+            // Given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(CACHE_KEY)).willReturn(null);
 
-        // When
-        UserPrincipal result = userAuthCacheService.get(USER_ID);
+            // When
+            UserPrincipal result = userAuthCacheService.get(USER_ID);
 
-        // Then
-        assertThat(result).isNull();
+            // Then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("캐시 히트면 기존 wire format을 역직렬화해 UserPrincipal을 반환한다")
+        void cacheHit_ReturnsDeserializedPrincipal() {
+            // Given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(CACHE_KEY)).willReturn(ACTIVE_USER_CACHE_VALUE);
+
+            // When
+            UserPrincipal result = userAuthCacheService.get(USER_ID);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getId()).isEqualTo(1L);
+            assertThat(result.getRole()).isEqualTo(Role.USER);
+            assertThat(result.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(result.getEmail()).isEqualTo("test@example.com");
+        }
+
+        @Test
+        @DisplayName("빈 email은 null email로 역직렬화한다")
+        void cacheHit_EmptyEmail_ReturnsNullEmail() {
+            // Given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(CACHE_KEY)).willReturn(WITHDRAWN_USER_CACHE_VALUE);
+
+            // When
+            UserPrincipal result = userAuthCacheService.get(USER_ID);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
+            assertThat(result.getEmail()).isNull();
+            assertThat(result.isEnabled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("ACTIVE 상태는 enabled principal로 역직렬화한다")
+        void cacheHit_ActiveStatus_ReturnsEnabledPrincipal() {
+            // Given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(CACHE_KEY)).willReturn(ACTIVE_USER_CACHE_VALUE);
+
+            // When
+            UserPrincipal result = userAuthCacheService.get(USER_ID);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.isEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("잘못된 포맷이면 null을 반환한다")
+        void invalidFormat_ReturnsNull() {
+            // Given
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+            given(valueOperations.get(CACHE_KEY)).willReturn("invalid-format");
+
+            // When
+            UserPrincipal result = userAuthCacheService.get(USER_ID);
+
+            // Then
+            assertThat(result).isNull();
+        }
     }
 
-    @Test
-    @DisplayName("get - 캐시 히트: 역직렬화 후 UserPrincipal 반환")
-    void get_CacheHit_ReturnsDeserializedPrincipal() {
-        // Given
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(CACHE_KEY)).willReturn("1|USER|ACTIVE|test@example.com");
+    @Nested
+    @DisplayName("put")
+    class Put {
 
-        // When
-        UserPrincipal result = userAuthCacheService.get(USER_ID);
+        @Test
+        @DisplayName("인증 프로필을 기존 wire format으로 직렬화해 저장한다")
+        void withAuthProfile_SerializesAndSaves() {
+            // Given
+            UserAuthProfile userAuthProfile = new UserAuthProfile(
+                    USER_ID,
+                    Role.ADMIN,
+                    UserStatus.ACTIVE,
+                    "admin@example.com",
+                    true
+            );
 
-        // Then
-        assertThat(result).isNotNull();
-        assertThat(result.getId()).isEqualTo(1L);
-        assertThat(result.getRole()).isEqualTo(Role.USER);
-        assertThat(result.getStatus()).isEqualTo(UserStatus.ACTIVE);
-        assertThat(result.getEmail()).isEqualTo("test@example.com");
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+            // When
+            userAuthCacheService.put(USER_ID, userAuthProfile, 180000L);
+
+            // Then
+            verify(valueOperations).set(CACHE_KEY, "1|ADMIN|ACTIVE|admin@example.com", 180000L, TimeUnit.MILLISECONDS);
+        }
+
+        @Test
+        @DisplayName("email이 null이면 빈 email로 저장한다")
+        void withNullEmail_SerializesEmptyEmail() {
+            // Given
+            UserAuthProfile userAuthProfile = new UserAuthProfile(
+                    USER_ID,
+                    Role.USER,
+                    UserStatus.PENDING,
+                    null,
+                    false
+            );
+
+            given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+            // When
+            userAuthCacheService.put(USER_ID, userAuthProfile, 180000L);
+
+            // Then
+            verify(valueOperations).set(CACHE_KEY, "1|USER|PENDING|", 180000L, TimeUnit.MILLISECONDS);
+        }
     }
 
-    @Test
-    @DisplayName("get - 캐시 히트: email이 빈 문자열이면 null로 역직렬화")
-    void get_CacheHit_EmptyEmail_ReturnsNullEmail() {
-        // Given
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(CACHE_KEY)).willReturn("1|USER|WITHDRAWN|");
+    @Nested
+    @DisplayName("evict")
+    class Evict {
 
-        // When
-        UserPrincipal result = userAuthCacheService.get(USER_ID);
+        @Test
+        @DisplayName("사용자 인증 캐시 키를 삭제한다")
+        void deletesCacheKey() {
+            // When
+            userAuthCacheService.evict(USER_ID);
 
-        // Then
-        assertThat(result).isNotNull();
-        assertThat(result.getStatus()).isEqualTo(UserStatus.WITHDRAWN);
-        assertThat(result.getEmail()).isNull();
-    }
-
-    @Test
-    @DisplayName("get - 잘못된 포맷: null 반환")
-    void get_InvalidFormat_ReturnsNull() {
-        // Given
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-        given(valueOperations.get(CACHE_KEY)).willReturn("invalid-format");
-
-        // When
-        UserPrincipal result = userAuthCacheService.get(USER_ID);
-
-        // Then
-        assertThat(result).isNull();
-    }
-
-    // ===== put 테스트 =====
-
-    @Test
-    @DisplayName("put - 인증 프로필 직렬화 후 저장")
-    void put_WithAuthProfile_SerializesAndSaves() {
-        // Given
-        UserAuthProfile userAuthProfile = new UserAuthProfile(
-                USER_ID,
-                Role.ADMIN,
-                UserStatus.ACTIVE,
-                "admin@example.com",
-                true
-        );
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-
-        // When
-        userAuthCacheService.put(USER_ID, userAuthProfile, 180000L);
-
-        // Then
-        verify(valueOperations).set(CACHE_KEY, "1|ADMIN|ACTIVE|admin@example.com", 180000L, TimeUnit.MILLISECONDS);
-    }
-
-    @Test
-    @DisplayName("put - email이 null인 인증 프로필은 빈 email로 저장")
-    void put_WithNullEmail_SerializesEmptyEmail() {
-        // Given
-        UserAuthProfile userAuthProfile = new UserAuthProfile(
-                USER_ID,
-                Role.USER,
-                UserStatus.PENDING,
-                null,
-                false
-        );
-
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
-
-        // When
-        userAuthCacheService.put(USER_ID, userAuthProfile, 180000L);
-
-        // Then
-        verify(valueOperations).set(CACHE_KEY, "1|USER|PENDING|", 180000L, TimeUnit.MILLISECONDS);
-    }
-
-    // ===== evict 테스트 =====
-
-    @Test
-    @DisplayName("evict - 캐시 키 삭제")
-    void evict_DeletesCacheKey() {
-        // When
-        userAuthCacheService.evict(USER_ID);
-
-        // Then
-        verify(redisTemplate).delete(CACHE_KEY);
+            // Then
+            verify(redisTemplate).delete(CACHE_KEY);
+        }
     }
 }

--- a/src/test/java/com/techfork/useraccount/integration/UserAccountAfterCommitEventIntegrationTest.java
+++ b/src/test/java/com/techfork/useraccount/integration/UserAccountAfterCommitEventIntegrationTest.java
@@ -140,6 +140,9 @@ class UserAccountAfterCommitEventIntegrationTest extends IntegrationTestBase {
 
         User savedUser = userRepository.findById(user.getId()).orElseThrow();
         assertThat(savedUser.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        assertThat(savedUser.getNickName()).isEqualTo("테스트유저");
+        assertThat(savedUser.getEmail()).isEqualTo("active@example.com");
+        assertThat(savedUser.getDescription()).isEqualTo("백엔드 개발자입니다");
         verify(userAuthCacheService).evict(user.getId());
         verifyNoInteractions(personalizationProfileService);
     }


### PR DESCRIPTION
## ❤️ 기능 설명

Auth cache 이벤트 seam을 보안 정책 관점에서 명확히 고정했습니다.

- `OnboardingCompletedEvent` 후 auth cache evict가 `AFTER_COMMIT`으로만 실행되는 정책을 테스트로 고정
- `UserWithdrawnEvent` 후 auth cache evict가 `BEFORE_COMMIT + AFTER_COMMIT`으로 실행되는 정책을 테스트로 고정
- 탈퇴 `BEFORE_COMMIT` auth cache evict 실패 시 탈퇴 트랜잭션이 rollback되는 경로를 통합 테스트로 보강
- `UserAuthCacheEventListener` 핸들러명을 이벤트/트랜잭션 phase가 드러나도록 정리
- `UserAuthCacheServiceTest`를 `get` / `put` / `evict` Nested 구조로 정리하고 기존 wire format 유지 검증 보강
- `HttpCookieOAuth2AuthorizationRequestRepositoryTest`를 `saveAuthorizationRequest` / `loadAuthorizationRequest` / `removeAuthorizationRequest` Nested 구조로 정리

Swagger 테스트 성공 결과 스크린샷 첨부

- API path, JSON field, status code 변경 없는 Auth/Security 리팩터링 및 테스트 보강이라 Swagger 스크린샷은 해당 없습니다.
- 아래 CLI 검증 결과와 PR CI로 대체합니다.

<br>

## 연결된 issue

close #430

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 탈퇴 `BEFORE_COMMIT` auth cache evict 실패는 의도적으로 탈퇴 트랜잭션 rollback을 유발하는 fail-closed 보안 정책입니다.
- [ ] 이 정책은 탈퇴 사용자 인증 차단을 우선하지만, Redis delete 실패가 탈퇴 실패로 노출될 수 있는 운영 tradeoff가 있습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (API 계약 변경 없는 리팩터링이라 CLI 결과로 대체)
- [x] 이슈넘버를 적었는가?

## 🧪 테스트 결과

```bash
git diff --check
# 통과

./gradlew test -PexcludeIntegration
# BUILD SUCCESSFUL

./gradlew test --tests 'com.techfork.useraccount.integration.UserAccountAfterCommitEventIntegrationTest'
# BUILD SUCCESSFUL
```

## 🔎 리뷰 결과

```text
$code-review
- code-reviewer recommendation: APPROVE
- architect status: WATCH
- final recommendation: COMMENT
```

- 추가 수정 필수 사항은 발견되지 않았습니다.
- WATCH 항목은 위 Approve 전 확인사항의 Redis fail-closed 운영 tradeoff입니다.
