### PR TITLE
[refactor/#431] OAuth/OIDC 보안 인프라 책임 분리

### DIFF
--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationFailureHandler.java
@@ -1,6 +1,5 @@
 package com.techfork.auth.security.handler.login;
 
-import com.techfork.auth.security.jwt.JwtProperties;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
@@ -22,7 +20,7 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
 
-    private final JwtProperties jwtProperties;
+    private final OAuth2LoginRedirectUrlFactory redirectUrlFactory;
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
@@ -30,11 +28,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
         log.error("OAuth2 login failed - Error: {}", exception.getMessage(), exception);
 
-        // 프론트엔드 에러 페이지로 리다이렉트 (에러 메시지 포함)
-        String targetUrl = UriComponentsBuilder.fromUriString(jwtProperties.getLoginFailureRedirectUri())
-                .queryParam("error", exception.getLocalizedMessage())
-                .build()
-                .toUriString();
+        String targetUrl = redirectUrlFactory.createFailureRedirectUrl(exception);
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationFailureHandler.java
@@ -28,7 +28,7 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
 
         log.error("OAuth2 login failed - Error: {}", exception.getMessage(), exception);
 
-        String targetUrl = redirectUrlFactory.createFailureRedirectUrl(exception);
+        String targetUrl = redirectUrlFactory.createFailureRedirectUrl();
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandler.java
@@ -1,17 +1,11 @@
 package com.techfork.auth.security.handler.login;
 
-import com.techfork.auth.security.service.RefreshTokenService;
-import com.techfork.auth.security.jwt.JwtDTO;
-import com.techfork.auth.security.jwt.JwtProperties;
-import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.oauth.UserPrincipal;
-import com.techfork.auth.security.util.CookieUtil;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -23,33 +17,21 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtUtil jwtUtil;
-    private final JwtProperties jwtProperties;
-    private final RefreshTokenService refreshTokenService;
+    private final OAuth2LoginTokenIssuer tokenIssuer;
     private final OAuth2LoginRedirectUrlFactory redirectUrlFactory;
-
-    @Value("${server.domain}")
-    private String domain;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
 
-        JwtDTO tokens = jwtUtil.generateTokens(userPrincipal.getId(), userPrincipal.getRole());
-        long expiration = jwtProperties.getRefreshTokenExpiration();
-        saveAndSetRefreshToken(response, userPrincipal.getId(), tokens.refreshToken(), expiration);
+        String accessToken = tokenIssuer.issueAccessToken(userPrincipal, response);
 
         log.info("OAuth2 login success - userId: {}, role: {}, status: {}, email: {}",
                 userPrincipal.getId(), userPrincipal.getRole(), userPrincipal.getStatus(), userPrincipal.getEmail());
 
-        String targetUrl = redirectUrlFactory.createSuccessRedirectUrl(userPrincipal, tokens.accessToken());
+        String targetUrl = redirectUrlFactory.createSuccessRedirectUrl(userPrincipal, accessToken);
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
-    }
-
-    private void saveAndSetRefreshToken(HttpServletResponse response, Long userId, String refreshToken, long expiration) {
-        refreshTokenService.saveRefreshToken(userId, refreshToken, expiration);
-        CookieUtil.addRefreshTokenCookie(response, domain, refreshToken, expiration);
     }
 }

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandler.java
@@ -1,6 +1,5 @@
 package com.techfork.auth.security.handler.login;
 
-import com.techfork.useraccount.domain.enums.UserStatus;
 import com.techfork.auth.security.service.RefreshTokenService;
 import com.techfork.auth.security.jwt.JwtDTO;
 import com.techfork.auth.security.jwt.JwtProperties;
@@ -16,10 +15,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-import org.springframework.web.util.UriUtils;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Component
@@ -29,6 +26,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;
     private final RefreshTokenService refreshTokenService;
+    private final OAuth2LoginRedirectUrlFactory redirectUrlFactory;
 
     @Value("${server.domain}")
     private String domain;
@@ -45,13 +43,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         log.info("OAuth2 login success - userId: {}, role: {}, status: {}, email: {}",
                 userPrincipal.getId(), userPrincipal.getRole(), userPrincipal.getStatus(), userPrincipal.getEmail());
 
-        // 온보딩 완료 여부에 따라 리다이렉트
-        boolean isRegistered = userPrincipal.getStatus() == UserStatus.ACTIVE;
-        String email = userPrincipal.getEmail() != null ?
-                UriUtils.encode(userPrincipal.getEmail(), StandardCharsets.UTF_8) : "";
-
-        String targetUrl = String.format(jwtProperties.getRedirectUri(),
-                isRegistered, tokens.accessToken(), email);
+        String targetUrl = redirectUrlFactory.createSuccessRedirectUrl(userPrincipal, tokens.accessToken());
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
@@ -61,4 +53,3 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         CookieUtil.addRefreshTokenCookie(response, domain, refreshToken, expiration);
     }
 }
-

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandler.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final OAuth2LoginTokenIssuer tokenIssuer;
+    private final OAuth2LoginRefreshTokenWriter refreshTokenWriter;
     private final OAuth2LoginRedirectUrlFactory redirectUrlFactory;
 
     @Override
@@ -25,12 +26,13 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                                         Authentication authentication) throws IOException, ServletException {
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
 
-        String accessToken = tokenIssuer.issueAccessToken(userPrincipal, response);
+        OAuth2LoginTokens tokens = tokenIssuer.issue(userPrincipal);
+        refreshTokenWriter.write(userPrincipal.getId(), tokens, response);
 
         log.info("OAuth2 login success - userId: {}, role: {}, status: {}, email: {}",
                 userPrincipal.getId(), userPrincipal.getRole(), userPrincipal.getStatus(), userPrincipal.getEmail());
 
-        String targetUrl = redirectUrlFactory.createSuccessRedirectUrl(userPrincipal, accessToken);
+        String targetUrl = redirectUrlFactory.createSuccessRedirectUrl(userPrincipal, tokens.accessToken());
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactory.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactory.java
@@ -12,7 +12,7 @@ import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
-public class OAuth2LoginRedirectUrlFactory {
+class OAuth2LoginRedirectUrlFactory {
 
     private static final String PUBLIC_FAILURE_ERROR_CODE = "oauth_failed";
 

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactory.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactory.java
@@ -4,7 +4,6 @@ import com.techfork.auth.security.jwt.JwtProperties;
 import com.techfork.auth.security.oauth.UserPrincipal;
 import com.techfork.useraccount.domain.enums.UserStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
@@ -14,6 +13,8 @@ import java.nio.charset.StandardCharsets;
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginRedirectUrlFactory {
+
+    private static final String PUBLIC_FAILURE_ERROR_CODE = "oauth_failed";
 
     private final JwtProperties jwtProperties;
 
@@ -25,9 +26,9 @@ public class OAuth2LoginRedirectUrlFactory {
         return String.format(jwtProperties.getRedirectUri(), isRegistered, accessToken, email);
     }
 
-    public String createFailureRedirectUrl(AuthenticationException exception) {
+    public String createFailureRedirectUrl() {
         return UriComponentsBuilder.fromUriString(jwtProperties.getLoginFailureRedirectUri())
-                .queryParam("error", exception.getLocalizedMessage())
+                .queryParam("errorCode", PUBLIC_FAILURE_ERROR_CODE)
                 .build()
                 .toUriString();
     }

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactory.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactory.java
@@ -1,0 +1,34 @@
+package com.techfork.auth.security.handler.login;
+
+import com.techfork.auth.security.jwt.JwtProperties;
+import com.techfork.auth.security.oauth.UserPrincipal;
+import com.techfork.useraccount.domain.enums.UserStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginRedirectUrlFactory {
+
+    private final JwtProperties jwtProperties;
+
+    public String createSuccessRedirectUrl(UserPrincipal userPrincipal, String accessToken) {
+        boolean isRegistered = userPrincipal.getStatus() == UserStatus.ACTIVE;
+        String email = userPrincipal.getEmail() != null ?
+                UriUtils.encode(userPrincipal.getEmail(), StandardCharsets.UTF_8) : "";
+
+        return String.format(jwtProperties.getRedirectUri(), isRegistered, accessToken, email);
+    }
+
+    public String createFailureRedirectUrl(AuthenticationException exception) {
+        return UriComponentsBuilder.fromUriString(jwtProperties.getLoginFailureRedirectUri())
+                .queryParam("error", exception.getLocalizedMessage())
+                .build()
+                .toUriString();
+    }
+}

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRefreshTokenWriter.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRefreshTokenWriter.java
@@ -1,0 +1,23 @@
+package com.techfork.auth.security.handler.login;
+
+import com.techfork.auth.security.service.RefreshTokenService;
+import com.techfork.auth.security.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginRefreshTokenWriter {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${server.domain}")
+    private String domain;
+
+    public void write(Long userId, OAuth2LoginTokens tokens, HttpServletResponse response) {
+        refreshTokenService.saveRefreshToken(userId, tokens.refreshToken(), tokens.refreshTokenExpiration());
+        CookieUtil.addRefreshTokenCookie(response, domain, tokens.refreshToken(), tokens.refreshTokenExpiration());
+    }
+}

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRefreshTokenWriter.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginRefreshTokenWriter.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class OAuth2LoginRefreshTokenWriter {
+class OAuth2LoginRefreshTokenWriter {
 
     private final RefreshTokenService refreshTokenService;
 

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuer.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuer.java
@@ -1,0 +1,32 @@
+package com.techfork.auth.security.handler.login;
+
+import com.techfork.auth.security.jwt.JwtDTO;
+import com.techfork.auth.security.jwt.JwtProperties;
+import com.techfork.auth.security.jwt.JwtUtil;
+import com.techfork.auth.security.oauth.UserPrincipal;
+import com.techfork.auth.security.service.RefreshTokenService;
+import com.techfork.auth.security.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginTokenIssuer {
+
+    private final JwtUtil jwtUtil;
+    private final JwtProperties jwtProperties;
+    private final RefreshTokenService refreshTokenService;
+
+    @Value("${server.domain}")
+    private String domain;
+
+    public String issueAccessToken(UserPrincipal userPrincipal, HttpServletResponse response) {
+        JwtDTO tokens = jwtUtil.generateTokens(userPrincipal.getId(), userPrincipal.getRole());
+        long expiration = jwtProperties.getRefreshTokenExpiration();
+        refreshTokenService.saveRefreshToken(userPrincipal.getId(), tokens.refreshToken(), expiration);
+        CookieUtil.addRefreshTokenCookie(response, domain, tokens.refreshToken(), expiration);
+        return tokens.accessToken();
+    }
+}

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuer.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuer.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class OAuth2LoginTokenIssuer {
+class OAuth2LoginTokenIssuer {
 
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuer.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuer.java
@@ -4,11 +4,7 @@ import com.techfork.auth.security.jwt.JwtDTO;
 import com.techfork.auth.security.jwt.JwtProperties;
 import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.oauth.UserPrincipal;
-import com.techfork.auth.security.service.RefreshTokenService;
-import com.techfork.auth.security.util.CookieUtil;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -17,16 +13,13 @@ public class OAuth2LoginTokenIssuer {
 
     private final JwtUtil jwtUtil;
     private final JwtProperties jwtProperties;
-    private final RefreshTokenService refreshTokenService;
 
-    @Value("${server.domain}")
-    private String domain;
-
-    public String issueAccessToken(UserPrincipal userPrincipal, HttpServletResponse response) {
+    public OAuth2LoginTokens issue(UserPrincipal userPrincipal) {
         JwtDTO tokens = jwtUtil.generateTokens(userPrincipal.getId(), userPrincipal.getRole());
-        long expiration = jwtProperties.getRefreshTokenExpiration();
-        refreshTokenService.saveRefreshToken(userPrincipal.getId(), tokens.refreshToken(), expiration);
-        CookieUtil.addRefreshTokenCookie(response, domain, tokens.refreshToken(), expiration);
-        return tokens.accessToken();
+        return new OAuth2LoginTokens(
+                tokens.accessToken(),
+                tokens.refreshToken(),
+                jwtProperties.getRefreshTokenExpiration()
+        );
     }
 }

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokens.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokens.java
@@ -1,0 +1,8 @@
+package com.techfork.auth.security.handler.login;
+
+public record OAuth2LoginTokens(
+        String accessToken,
+        String refreshToken,
+        long refreshTokenExpiration
+) {
+}

--- a/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokens.java
+++ b/src/main/java/com/techfork/auth/security/handler/login/OAuth2LoginTokens.java
@@ -1,6 +1,6 @@
 package com.techfork.auth.security.handler.login;
 
-public record OAuth2LoginTokens(
+record OAuth2LoginTokens(
         String accessToken,
         String refreshToken,
         long refreshTokenExpiration

--- a/src/main/java/com/techfork/auth/security/oauth/CustomOidcUserService.java
+++ b/src/main/java/com/techfork/auth/security/oauth/CustomOidcUserService.java
@@ -1,9 +1,7 @@
 package com.techfork.auth.security.oauth;
 
-import com.techfork.auth.infrastructure.kakao.KakaoSocialId;
 import com.techfork.useraccount.application.auth.UserAuthAccountService;
 import com.techfork.useraccount.application.auth.UserAuthProfile;
-import com.techfork.useraccount.domain.enums.SocialType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
@@ -19,43 +17,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class CustomOidcUserService extends OidcUserService {
 
     private final UserAuthAccountService userAuthAccountService;
+    private final OidcSocialIdentityExtractor socialIdentityExtractor;
 
     @Override
     @Transactional
     public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
         OidcUser oidcUser = super.loadUser(userRequest);
-
-        String registrationId = userRequest.getClientRegistration().getRegistrationId();
-        SocialType socialType = SocialType.fromRegistrationId(registrationId);
-
-        String socialId = resolveSocialId(socialType, oidcUser);
-        String email = oidcUser.getAttribute("email");
-        if (email == null) {
-            throw new OAuth2AuthenticationException("email not found");
-        }
-        String profileImage = oidcUser.getAttribute("picture");
+        OidcSocialIdentity socialIdentity = socialIdentityExtractor.extract(userRequest, oidcUser);
 
         UserAuthProfile userAuthProfile = userAuthAccountService.getOrCreateSocialAuthProfile(
-                socialType,
-                socialId,
-                email,
-                profileImage
+                socialIdentity.socialType(),
+                socialIdentity.socialId(),
+                socialIdentity.email(),
+                socialIdentity.profileImage()
         );
 
         log.info("CustomOAuth2UserService - loaded user: id={}, email={}, socialType={}",
-                userAuthProfile.id(), email, socialType);
+                userAuthProfile.id(), socialIdentity.email(), socialIdentity.socialType());
 
         return UserPrincipal.from(userAuthProfile);
-    }
-
-    private String resolveSocialId(SocialType socialType, OidcUser oidcUser) {
-        String subject = oidcUser.getAttribute("sub");
-        if (subject == null) {
-            throw new OAuth2AuthenticationException("socialId(sub) not found");
-        }
-        if (socialType == SocialType.KAKAO) {
-            return KakaoSocialId.fromOidcSubject(subject);
-        }
-        return subject;
     }
 }

--- a/src/main/java/com/techfork/auth/security/oauth/OidcSocialIdentity.java
+++ b/src/main/java/com/techfork/auth/security/oauth/OidcSocialIdentity.java
@@ -1,0 +1,11 @@
+package com.techfork.auth.security.oauth;
+
+import com.techfork.useraccount.domain.enums.SocialType;
+
+public record OidcSocialIdentity(
+        SocialType socialType,
+        String socialId,
+        String email,
+        String profileImage
+) {
+}

--- a/src/main/java/com/techfork/auth/security/oauth/OidcSocialIdentityExtractor.java
+++ b/src/main/java/com/techfork/auth/security/oauth/OidcSocialIdentityExtractor.java
@@ -1,0 +1,36 @@
+package com.techfork.auth.security.oauth;
+
+import com.techfork.auth.infrastructure.kakao.KakaoSocialId;
+import com.techfork.useraccount.domain.enums.SocialType;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OidcSocialIdentityExtractor {
+
+    public OidcSocialIdentity extract(OidcUserRequest userRequest, OidcUser oidcUser) {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        SocialType socialType = SocialType.fromRegistrationId(registrationId);
+        String socialId = resolveSocialId(socialType, oidcUser);
+        String email = oidcUser.getAttribute("email");
+        if (email == null) {
+            throw new OAuth2AuthenticationException("email not found");
+        }
+        String profileImage = oidcUser.getAttribute("picture");
+
+        return new OidcSocialIdentity(socialType, socialId, email, profileImage);
+    }
+
+    private String resolveSocialId(SocialType socialType, OidcUser oidcUser) {
+        String subject = oidcUser.getAttribute("sub");
+        if (subject == null) {
+            throw new OAuth2AuthenticationException("socialId(sub) not found");
+        }
+        if (socialType == SocialType.KAKAO) {
+            return KakaoSocialId.fromOidcSubject(subject);
+        }
+        return subject;
+    }
+}

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationFailureHandlerTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class OAuth2AuthenticationFailureHandlerTest {
 
-    private static final String TARGET_URL = "http://localhost:5173/login?error=true&error=oauth_failed";
+    private static final String TARGET_URL = "http://localhost:5173/login?error=true&errorCode=oauth_failed";
 
     @Mock
     private OAuth2LoginRedirectUrlFactory redirectUrlFactory;
@@ -34,7 +34,7 @@ class OAuth2AuthenticationFailureHandlerTest {
     void onAuthenticationFailure_RedirectsToFactoryUrl() throws Exception {
         MockHttpServletResponse response = new MockHttpServletResponse();
         BadCredentialsException exception = new BadCredentialsException("oauth_failed");
-        given(redirectUrlFactory.createFailureRedirectUrl(exception)).willReturn(TARGET_URL);
+        given(redirectUrlFactory.createFailureRedirectUrl()).willReturn(TARGET_URL);
 
         failureHandler.onAuthenticationFailure(
                 new MockHttpServletRequest(),
@@ -42,7 +42,7 @@ class OAuth2AuthenticationFailureHandlerTest {
                 exception
         );
 
-        verify(redirectUrlFactory).createFailureRedirectUrl(exception);
+        verify(redirectUrlFactory).createFailureRedirectUrl();
         assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
     }
 }

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationFailureHandlerTest.java
@@ -1,40 +1,48 @@
 package com.techfork.auth.security.handler.login;
 
-import com.techfork.auth.security.jwt.JwtProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.BadCredentialsException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
+@ExtendWith(MockitoExtension.class)
 class OAuth2AuthenticationFailureHandlerTest {
 
-    private static final String LOGIN_FAILURE_REDIRECT_URI = "http://localhost:5173/login?error=true";
+    private static final String TARGET_URL = "http://localhost:5173/login?error=true&error=oauth_failed";
+
+    @Mock
+    private OAuth2LoginRedirectUrlFactory redirectUrlFactory;
 
     private OAuth2AuthenticationFailureHandler failureHandler;
 
     @BeforeEach
     void setUp() {
-        JwtProperties jwtProperties = new JwtProperties();
-        jwtProperties.setLoginFailureRedirectUri(LOGIN_FAILURE_REDIRECT_URI);
-        failureHandler = new OAuth2AuthenticationFailureHandler(jwtProperties);
+        failureHandler = new OAuth2AuthenticationFailureHandler(redirectUrlFactory);
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 실패 - 실패 리다이렉트 URI에 에러 메시지를 query parameter로 추가한다")
-    void onAuthenticationFailure_RedirectsWithErrorQueryParameter() throws Exception {
+    @DisplayName("OAuth2 로그인 실패 - factory가 생성한 실패 URL로 리다이렉트한다")
+    void onAuthenticationFailure_RedirectsToFactoryUrl() throws Exception {
         MockHttpServletResponse response = new MockHttpServletResponse();
+        BadCredentialsException exception = new BadCredentialsException("oauth_failed");
+        given(redirectUrlFactory.createFailureRedirectUrl(exception)).willReturn(TARGET_URL);
 
         failureHandler.onAuthenticationFailure(
                 new MockHttpServletRequest(),
                 response,
-                new BadCredentialsException("oauth_failed")
+                exception
         );
 
-        assertThat(response.getRedirectedUrl())
-                .isEqualTo(LOGIN_FAILURE_REDIRECT_URI + "&error=oauth_failed");
+        verify(redirectUrlFactory).createFailureRedirectUrl(exception);
+        assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
     }
 }

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandlerTest.java
@@ -17,9 +17,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.web.util.UriUtils;
-
-import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -32,7 +29,7 @@ class OAuth2AuthenticationSuccessHandlerTest {
     private static final String ACCESS_TOKEN = "access-token";
     private static final String REFRESH_TOKEN = "refresh-token";
     private static final long REFRESH_TOKEN_EXPIRATION_MILLIS = 900_000L;
-    private static final String REDIRECT_URI = "http://localhost:5173/auth/callback?registered=%s&token=%s&email=%s";
+    private static final String TARGET_URL = "http://localhost:5173/auth/callback";
 
     @Mock
     private JwtUtil jwtUtil;
@@ -43,6 +40,9 @@ class OAuth2AuthenticationSuccessHandlerTest {
     @Mock
     private Authentication authentication;
 
+    @Mock
+    private OAuth2LoginRedirectUrlFactory redirectUrlFactory;
+
     private JwtProperties jwtProperties;
     private OAuth2AuthenticationSuccessHandler successHandler;
 
@@ -50,18 +50,23 @@ class OAuth2AuthenticationSuccessHandlerTest {
     void setUp() {
         jwtProperties = new JwtProperties();
         jwtProperties.setRefreshTokenExpiration(REFRESH_TOKEN_EXPIRATION_MILLIS);
-        jwtProperties.setRedirectUri(REDIRECT_URI);
 
-        successHandler = new OAuth2AuthenticationSuccessHandler(jwtUtil, jwtProperties, refreshTokenService);
+        successHandler = new OAuth2AuthenticationSuccessHandler(
+                jwtUtil,
+                jwtProperties,
+                refreshTokenService,
+                redirectUrlFactory
+        );
         ReflectionTestUtils.setField(successHandler, "domain", "localhost");
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 성공 - ACTIVE 사용자는 등록 완료 상태로 토큰과 함께 리다이렉트한다")
-    void onAuthenticationSuccess_ActiveUser_RedirectsWithRegisteredTrueAndTokens() throws Exception {
+    @DisplayName("OAuth2 로그인 성공 - ACTIVE 사용자는 토큰 발급 후 factory가 생성한 URL로 리다이렉트한다")
+    void onAuthenticationSuccess_ActiveUser_RedirectsToFactoryUrlWithTokens() throws Exception {
         UserPrincipal principal = principal(UserStatus.ACTIVE, "dev user@example.com");
         given(authentication.getPrincipal()).willReturn(principal);
         given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
+        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         MockHttpServletResponse response = new MockHttpServletResponse();
 
@@ -69,53 +74,43 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
         verify(jwtUtil).generateTokens(USER_ID, Role.USER);
         verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
-        assertThat(response.getRedirectedUrl()).isEqualTo(String.format(
-                REDIRECT_URI,
-                true,
-                ACCESS_TOKEN,
-                UriUtils.encode("dev user@example.com", StandardCharsets.UTF_8)
-        ));
+        verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
+        assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
         assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 성공 - PENDING 사용자는 등록 미완료 상태로 리다이렉트한다")
-    void onAuthenticationSuccess_PendingUser_RedirectsWithRegisteredFalse() throws Exception {
+    @DisplayName("OAuth2 로그인 성공 - PENDING 사용자도 factory가 생성한 URL로 리다이렉트한다")
+    void onAuthenticationSuccess_PendingUser_RedirectsToFactoryUrl() throws Exception {
         UserPrincipal principal = principal(UserStatus.PENDING, "pending@example.com");
         given(authentication.getPrincipal()).willReturn(principal);
         given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
+        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
 
-        assertThat(response.getRedirectedUrl()).isEqualTo(String.format(
-                REDIRECT_URI,
-                false,
-                ACCESS_TOKEN,
-                UriUtils.encode("pending@example.com", StandardCharsets.UTF_8)
-        ));
+        verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
+        assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
         verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
         assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 성공 - 이메일이 없으면 빈 이메일 파라미터로 리다이렉트한다")
-    void onAuthenticationSuccess_NullEmail_RedirectsWithEmptyEmail() throws Exception {
+    @DisplayName("OAuth2 로그인 성공 - 이메일이 없어도 factory에 principal과 access token을 전달한다")
+    void onAuthenticationSuccess_NullEmail_DelegatesRedirectUrlCreation() throws Exception {
         UserPrincipal principal = principal(UserStatus.ACTIVE, null);
         given(authentication.getPrincipal()).willReturn(principal);
         given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
+        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         MockHttpServletResponse response = new MockHttpServletResponse();
 
         successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
 
-        assertThat(response.getRedirectedUrl()).isEqualTo(String.format(
-                REDIRECT_URI,
-                true,
-                ACCESS_TOKEN,
-                ""
-        ));
+        verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
+        assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
         verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
         assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
     }

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandlerTest.java
@@ -22,10 +22,15 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
     private static final Long USER_ID = 1L;
     private static final String ACCESS_TOKEN = "access-token";
+    private static final String REFRESH_TOKEN = "refresh-token";
+    private static final long REFRESH_TOKEN_EXPIRATION_MILLIS = 900_000L;
     private static final String TARGET_URL = "http://localhost:5173/auth/callback";
 
     @Mock
     private OAuth2LoginTokenIssuer tokenIssuer;
+
+    @Mock
+    private OAuth2LoginRefreshTokenWriter refreshTokenWriter;
 
     @Mock
     private Authentication authentication;
@@ -37,55 +42,65 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
     @BeforeEach
     void setUp() {
-        successHandler = new OAuth2AuthenticationSuccessHandler(tokenIssuer, redirectUrlFactory);
+        successHandler = new OAuth2AuthenticationSuccessHandler(tokenIssuer, refreshTokenWriter, redirectUrlFactory);
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 성공 - ACTIVE 사용자는 토큰 발급 후 factory가 생성한 URL로 리다이렉트한다")
+    @DisplayName("OAuth2 로그인 성공 - ACTIVE 사용자는 토큰 발급/refresh 저장 후 factory가 생성한 URL로 리다이렉트한다")
     void onAuthenticationSuccess_ActiveUser_RedirectsToFactoryUrlWithTokens() throws Exception {
         UserPrincipal principal = principal(UserStatus.ACTIVE, "dev user@example.com");
+        OAuth2LoginTokens tokens = tokens();
         MockHttpServletResponse response = new MockHttpServletResponse();
         given(authentication.getPrincipal()).willReturn(principal);
-        given(tokenIssuer.issueAccessToken(principal, response)).willReturn(ACCESS_TOKEN);
+        given(tokenIssuer.issue(principal)).willReturn(tokens);
         given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
 
-        verify(tokenIssuer).issueAccessToken(principal, response);
+        verify(tokenIssuer).issue(principal);
+        verify(refreshTokenWriter).write(USER_ID, tokens, response);
         verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
         assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 성공 - PENDING 사용자도 토큰 발급 후 factory가 생성한 URL로 리다이렉트한다")
+    @DisplayName("OAuth2 로그인 성공 - PENDING 사용자도 토큰 발급/refresh 저장 후 factory가 생성한 URL로 리다이렉트한다")
     void onAuthenticationSuccess_PendingUser_RedirectsToFactoryUrl() throws Exception {
         UserPrincipal principal = principal(UserStatus.PENDING, "pending@example.com");
+        OAuth2LoginTokens tokens = tokens();
         MockHttpServletResponse response = new MockHttpServletResponse();
         given(authentication.getPrincipal()).willReturn(principal);
-        given(tokenIssuer.issueAccessToken(principal, response)).willReturn(ACCESS_TOKEN);
+        given(tokenIssuer.issue(principal)).willReturn(tokens);
         given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
 
-        verify(tokenIssuer).issueAccessToken(principal, response);
+        verify(tokenIssuer).issue(principal);
+        verify(refreshTokenWriter).write(USER_ID, tokens, response);
         verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
         assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 성공 - 이메일이 없어도 토큰 발급과 redirect URL 생성을 위임한다")
-    void onAuthenticationSuccess_NullEmail_DelegatesTokenIssuingAndRedirectUrlCreation() throws Exception {
+    @DisplayName("OAuth2 로그인 성공 - 이메일이 없어도 토큰 발급/refresh 저장과 redirect URL 생성을 위임한다")
+    void onAuthenticationSuccess_NullEmail_DelegatesTokenIssuingRefreshWritingAndRedirectUrlCreation() throws Exception {
         UserPrincipal principal = principal(UserStatus.ACTIVE, null);
+        OAuth2LoginTokens tokens = tokens();
         MockHttpServletResponse response = new MockHttpServletResponse();
         given(authentication.getPrincipal()).willReturn(principal);
-        given(tokenIssuer.issueAccessToken(principal, response)).willReturn(ACCESS_TOKEN);
+        given(tokenIssuer.issue(principal)).willReturn(tokens);
         given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
 
-        verify(tokenIssuer).issueAccessToken(principal, response);
+        verify(tokenIssuer).issue(principal);
+        verify(refreshTokenWriter).write(USER_ID, tokens, response);
         verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
         assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
+    }
+
+    private OAuth2LoginTokens tokens() {
+        return new OAuth2LoginTokens(ACCESS_TOKEN, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
     }
 
     private UserPrincipal principal(UserStatus status, String email) {

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,9 +1,5 @@
 package com.techfork.auth.security.handler.login;
 
-import com.techfork.auth.security.service.RefreshTokenService;
-import com.techfork.auth.security.jwt.JwtDTO;
-import com.techfork.auth.security.jwt.JwtProperties;
-import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.oauth.UserPrincipal;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.UserStatus;
@@ -16,7 +12,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.Authentication;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -27,15 +22,10 @@ class OAuth2AuthenticationSuccessHandlerTest {
 
     private static final Long USER_ID = 1L;
     private static final String ACCESS_TOKEN = "access-token";
-    private static final String REFRESH_TOKEN = "refresh-token";
-    private static final long REFRESH_TOKEN_EXPIRATION_MILLIS = 900_000L;
     private static final String TARGET_URL = "http://localhost:5173/auth/callback";
 
     @Mock
-    private JwtUtil jwtUtil;
-
-    @Mock
-    private RefreshTokenService refreshTokenService;
+    private OAuth2LoginTokenIssuer tokenIssuer;
 
     @Mock
     private Authentication authentication;
@@ -43,76 +33,59 @@ class OAuth2AuthenticationSuccessHandlerTest {
     @Mock
     private OAuth2LoginRedirectUrlFactory redirectUrlFactory;
 
-    private JwtProperties jwtProperties;
     private OAuth2AuthenticationSuccessHandler successHandler;
 
     @BeforeEach
     void setUp() {
-        jwtProperties = new JwtProperties();
-        jwtProperties.setRefreshTokenExpiration(REFRESH_TOKEN_EXPIRATION_MILLIS);
-
-        successHandler = new OAuth2AuthenticationSuccessHandler(
-                jwtUtil,
-                jwtProperties,
-                refreshTokenService,
-                redirectUrlFactory
-        );
-        ReflectionTestUtils.setField(successHandler, "domain", "localhost");
+        successHandler = new OAuth2AuthenticationSuccessHandler(tokenIssuer, redirectUrlFactory);
     }
 
     @Test
     @DisplayName("OAuth2 로그인 성공 - ACTIVE 사용자는 토큰 발급 후 factory가 생성한 URL로 리다이렉트한다")
     void onAuthenticationSuccess_ActiveUser_RedirectsToFactoryUrlWithTokens() throws Exception {
         UserPrincipal principal = principal(UserStatus.ACTIVE, "dev user@example.com");
-        given(authentication.getPrincipal()).willReturn(principal);
-        given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
-        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
-
         MockHttpServletResponse response = new MockHttpServletResponse();
+        given(authentication.getPrincipal()).willReturn(principal);
+        given(tokenIssuer.issueAccessToken(principal, response)).willReturn(ACCESS_TOKEN);
+        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
 
-        verify(jwtUtil).generateTokens(USER_ID, Role.USER);
-        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
+        verify(tokenIssuer).issueAccessToken(principal, response);
         verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
         assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
-        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 성공 - PENDING 사용자도 factory가 생성한 URL로 리다이렉트한다")
+    @DisplayName("OAuth2 로그인 성공 - PENDING 사용자도 토큰 발급 후 factory가 생성한 URL로 리다이렉트한다")
     void onAuthenticationSuccess_PendingUser_RedirectsToFactoryUrl() throws Exception {
         UserPrincipal principal = principal(UserStatus.PENDING, "pending@example.com");
-        given(authentication.getPrincipal()).willReturn(principal);
-        given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
-        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
-
         MockHttpServletResponse response = new MockHttpServletResponse();
+        given(authentication.getPrincipal()).willReturn(principal);
+        given(tokenIssuer.issueAccessToken(principal, response)).willReturn(ACCESS_TOKEN);
+        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
 
+        verify(tokenIssuer).issueAccessToken(principal, response);
         verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
         assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
-        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
-        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
     }
 
     @Test
-    @DisplayName("OAuth2 로그인 성공 - 이메일이 없어도 factory에 principal과 access token을 전달한다")
-    void onAuthenticationSuccess_NullEmail_DelegatesRedirectUrlCreation() throws Exception {
+    @DisplayName("OAuth2 로그인 성공 - 이메일이 없어도 토큰 발급과 redirect URL 생성을 위임한다")
+    void onAuthenticationSuccess_NullEmail_DelegatesTokenIssuingAndRedirectUrlCreation() throws Exception {
         UserPrincipal principal = principal(UserStatus.ACTIVE, null);
-        given(authentication.getPrincipal()).willReturn(principal);
-        given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
-        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
-
         MockHttpServletResponse response = new MockHttpServletResponse();
+        given(authentication.getPrincipal()).willReturn(principal);
+        given(tokenIssuer.issueAccessToken(principal, response)).willReturn(ACCESS_TOKEN);
+        given(redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN)).willReturn(TARGET_URL);
 
         successHandler.onAuthenticationSuccess(new MockHttpServletRequest(), response, authentication);
 
+        verify(tokenIssuer).issueAccessToken(principal, response);
         verify(redirectUrlFactory).createSuccessRedirectUrl(principal, ACCESS_TOKEN);
         assertThat(response.getRedirectedUrl()).isEqualTo(TARGET_URL);
-        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
-        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
     }
 
     private UserPrincipal principal(UserStatus status, String email) {
@@ -122,16 +95,5 @@ class OAuth2AuthenticationSuccessHandlerTest {
                 .status(status)
                 .email(email)
                 .build();
-    }
-
-    private void assertRefreshTokenCookie(String setCookieHeader) {
-        assertThat(setCookieHeader)
-                .contains("refreshToken=" + REFRESH_TOKEN)
-                .contains("Path=/")
-                .contains("Domain=localhost")
-                .contains("Max-Age=900")
-                .contains("Secure")
-                .contains("HttpOnly")
-                .contains("SameSite=None");
     }
 }

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactoryTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactoryTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.util.UriUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -87,13 +86,11 @@ class OAuth2LoginRedirectUrlFactoryTest {
     class CreateFailureRedirectUrl {
 
         @Test
-        @DisplayName("실패 리다이렉트 URI에 에러 메시지를 query parameter로 추가한다")
-        void appendsErrorQueryParameter() {
-            String redirectUrl = redirectUrlFactory.createFailureRedirectUrl(
-                    new BadCredentialsException("oauth_failed")
-            );
+        @DisplayName("실패 리다이렉트 URI에 공개 에러 코드를 query parameter로 추가한다")
+        void appendsPublicErrorCodeQueryParameter() {
+            String redirectUrl = redirectUrlFactory.createFailureRedirectUrl();
 
-            assertThat(redirectUrl).isEqualTo(LOGIN_FAILURE_REDIRECT_URI + "&error=oauth_failed");
+            assertThat(redirectUrl).isEqualTo(LOGIN_FAILURE_REDIRECT_URI + "&errorCode=oauth_failed");
         }
     }
 

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactoryTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginRedirectUrlFactoryTest.java
@@ -1,0 +1,108 @@
+package com.techfork.auth.security.handler.login;
+
+import com.techfork.auth.security.jwt.JwtProperties;
+import com.techfork.auth.security.oauth.UserPrincipal;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.util.UriUtils;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OAuth2LoginRedirectUrlFactoryTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String ACCESS_TOKEN = "access-token";
+    private static final String REDIRECT_URI = "http://localhost:5173/auth/callback?registered=%s&token=%s&email=%s";
+    private static final String LOGIN_FAILURE_REDIRECT_URI = "http://localhost:5173/login?error=true";
+
+    private OAuth2LoginRedirectUrlFactory redirectUrlFactory;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setRedirectUri(REDIRECT_URI);
+        jwtProperties.setLoginFailureRedirectUri(LOGIN_FAILURE_REDIRECT_URI);
+        redirectUrlFactory = new OAuth2LoginRedirectUrlFactory(jwtProperties);
+    }
+
+    @Nested
+    @DisplayName("createSuccessRedirectUrl")
+    class CreateSuccessRedirectUrl {
+
+        @Test
+        @DisplayName("ACTIVE 사용자는 등록 완료 상태와 인코딩된 이메일로 성공 URL을 생성한다")
+        void activeUser_ReturnsRegisteredTrueAndEncodedEmail() {
+            UserPrincipal principal = principal(UserStatus.ACTIVE, "dev user@example.com");
+
+            String redirectUrl = redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN);
+
+            assertThat(redirectUrl).isEqualTo(String.format(
+                    REDIRECT_URI,
+                    true,
+                    ACCESS_TOKEN,
+                    UriUtils.encode("dev user@example.com", StandardCharsets.UTF_8)
+            ));
+        }
+
+        @Test
+        @DisplayName("PENDING 사용자는 등록 미완료 상태로 성공 URL을 생성한다")
+        void pendingUser_ReturnsRegisteredFalse() {
+            UserPrincipal principal = principal(UserStatus.PENDING, "pending@example.com");
+
+            String redirectUrl = redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN);
+
+            assertThat(redirectUrl).isEqualTo(String.format(
+                    REDIRECT_URI,
+                    false,
+                    ACCESS_TOKEN,
+                    UriUtils.encode("pending@example.com", StandardCharsets.UTF_8)
+            ));
+        }
+
+        @Test
+        @DisplayName("이메일이 없으면 빈 이메일 파라미터로 성공 URL을 생성한다")
+        void nullEmail_ReturnsEmptyEmailParameter() {
+            UserPrincipal principal = principal(UserStatus.ACTIVE, null);
+
+            String redirectUrl = redirectUrlFactory.createSuccessRedirectUrl(principal, ACCESS_TOKEN);
+
+            assertThat(redirectUrl).isEqualTo(String.format(
+                    REDIRECT_URI,
+                    true,
+                    ACCESS_TOKEN,
+                    ""
+            ));
+        }
+    }
+
+    @Nested
+    @DisplayName("createFailureRedirectUrl")
+    class CreateFailureRedirectUrl {
+
+        @Test
+        @DisplayName("실패 리다이렉트 URI에 에러 메시지를 query parameter로 추가한다")
+        void appendsErrorQueryParameter() {
+            String redirectUrl = redirectUrlFactory.createFailureRedirectUrl(
+                    new BadCredentialsException("oauth_failed")
+            );
+
+            assertThat(redirectUrl).isEqualTo(LOGIN_FAILURE_REDIRECT_URI + "&error=oauth_failed");
+        }
+    }
+
+    private UserPrincipal principal(UserStatus status, String email) {
+        return UserPrincipal.builder()
+                .id(USER_ID)
+                .role(Role.USER)
+                .status(status)
+                .email(email)
+                .build();
+    }
+}

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginRefreshTokenWriterTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginRefreshTokenWriterTest.java
@@ -1,0 +1,57 @@
+package com.techfork.auth.security.handler.login;
+
+import com.techfork.auth.security.service.RefreshTokenService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2LoginRefreshTokenWriterTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String ACCESS_TOKEN = "access-token";
+    private static final String REFRESH_TOKEN = "refresh-token";
+    private static final long REFRESH_TOKEN_EXPIRATION_MILLIS = 900_000L;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    private OAuth2LoginRefreshTokenWriter refreshTokenWriter;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenWriter = new OAuth2LoginRefreshTokenWriter(refreshTokenService);
+        ReflectionTestUtils.setField(refreshTokenWriter, "domain", "localhost");
+    }
+
+    @Test
+    @DisplayName("refresh token을 저장하고 기존 cookie 정책으로 응답에 설정한다")
+    void write_SavesRefreshTokenAndAddsCookie() {
+        OAuth2LoginTokens tokens = new OAuth2LoginTokens(ACCESS_TOKEN, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        refreshTokenWriter.write(USER_ID, tokens, response);
+
+        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
+        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
+    }
+
+    private void assertRefreshTokenCookie(String setCookieHeader) {
+        assertThat(setCookieHeader)
+                .contains("refreshToken=" + REFRESH_TOKEN)
+                .contains("Path=/")
+                .contains("Domain=localhost")
+                .contains("Max-Age=900")
+                .contains("Secure")
+                .contains("HttpOnly")
+                .contains("SameSite=None");
+    }
+}

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuerTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuerTest.java
@@ -1,0 +1,81 @@
+package com.techfork.auth.security.handler.login;
+
+import com.techfork.auth.security.jwt.JwtDTO;
+import com.techfork.auth.security.jwt.JwtProperties;
+import com.techfork.auth.security.jwt.JwtUtil;
+import com.techfork.auth.security.oauth.UserPrincipal;
+import com.techfork.auth.security.service.RefreshTokenService;
+import com.techfork.useraccount.domain.enums.Role;
+import com.techfork.useraccount.domain.enums.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2LoginTokenIssuerTest {
+
+    private static final Long USER_ID = 1L;
+    private static final String ACCESS_TOKEN = "access-token";
+    private static final String REFRESH_TOKEN = "refresh-token";
+    private static final long REFRESH_TOKEN_EXPIRATION_MILLIS = 900_000L;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private RefreshTokenService refreshTokenService;
+
+    private OAuth2LoginTokenIssuer tokenIssuer;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setRefreshTokenExpiration(REFRESH_TOKEN_EXPIRATION_MILLIS);
+        tokenIssuer = new OAuth2LoginTokenIssuer(jwtUtil, jwtProperties, refreshTokenService);
+        ReflectionTestUtils.setField(tokenIssuer, "domain", "localhost");
+    }
+
+    @Test
+    @DisplayName("JWT 토큰을 발급하고 refresh token 저장과 cookie 설정 후 access token을 반환한다")
+    void issueAccessToken_SavesRefreshTokenAndAddsCookieThenReturnsAccessToken() {
+        UserPrincipal principal = principal();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
+
+        String accessToken = tokenIssuer.issueAccessToken(principal, response);
+
+        assertThat(accessToken).isEqualTo(ACCESS_TOKEN);
+        verify(jwtUtil).generateTokens(USER_ID, Role.USER);
+        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
+        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
+    }
+
+    private UserPrincipal principal() {
+        return UserPrincipal.builder()
+                .id(USER_ID)
+                .role(Role.USER)
+                .status(UserStatus.ACTIVE)
+                .email("dev user@example.com")
+                .build();
+    }
+
+    private void assertRefreshTokenCookie(String setCookieHeader) {
+        assertThat(setCookieHeader)
+                .contains("refreshToken=" + REFRESH_TOKEN)
+                .contains("Path=/")
+                .contains("Domain=localhost")
+                .contains("Max-Age=900")
+                .contains("Secure")
+                .contains("HttpOnly")
+                .contains("SameSite=None");
+    }
+}

--- a/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuerTest.java
+++ b/src/test/java/com/techfork/auth/security/handler/login/OAuth2LoginTokenIssuerTest.java
@@ -4,7 +4,6 @@ import com.techfork.auth.security.jwt.JwtDTO;
 import com.techfork.auth.security.jwt.JwtProperties;
 import com.techfork.auth.security.jwt.JwtUtil;
 import com.techfork.auth.security.oauth.UserPrincipal;
-import com.techfork.auth.security.service.RefreshTokenService;
 import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.UserStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,8 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -31,32 +28,27 @@ class OAuth2LoginTokenIssuerTest {
     @Mock
     private JwtUtil jwtUtil;
 
-    @Mock
-    private RefreshTokenService refreshTokenService;
-
     private OAuth2LoginTokenIssuer tokenIssuer;
 
     @BeforeEach
     void setUp() {
         JwtProperties jwtProperties = new JwtProperties();
         jwtProperties.setRefreshTokenExpiration(REFRESH_TOKEN_EXPIRATION_MILLIS);
-        tokenIssuer = new OAuth2LoginTokenIssuer(jwtUtil, jwtProperties, refreshTokenService);
-        ReflectionTestUtils.setField(tokenIssuer, "domain", "localhost");
+        tokenIssuer = new OAuth2LoginTokenIssuer(jwtUtil, jwtProperties);
     }
 
     @Test
-    @DisplayName("JWT 토큰을 발급하고 refresh token 저장과 cookie 설정 후 access token을 반환한다")
-    void issueAccessToken_SavesRefreshTokenAndAddsCookieThenReturnsAccessToken() {
+    @DisplayName("JWT 토큰을 발급하고 refresh token 만료 시간을 포함한 OAuth2 로그인 토큰을 반환한다")
+    void issue_ReturnsOAuth2LoginTokensWithoutSideEffects() {
         UserPrincipal principal = principal();
-        MockHttpServletResponse response = new MockHttpServletResponse();
         given(jwtUtil.generateTokens(USER_ID, Role.USER)).willReturn(JwtDTO.of(ACCESS_TOKEN, REFRESH_TOKEN));
 
-        String accessToken = tokenIssuer.issueAccessToken(principal, response);
+        OAuth2LoginTokens tokens = tokenIssuer.issue(principal);
 
-        assertThat(accessToken).isEqualTo(ACCESS_TOKEN);
+        assertThat(tokens.accessToken()).isEqualTo(ACCESS_TOKEN);
+        assertThat(tokens.refreshToken()).isEqualTo(REFRESH_TOKEN);
+        assertThat(tokens.refreshTokenExpiration()).isEqualTo(REFRESH_TOKEN_EXPIRATION_MILLIS);
         verify(jwtUtil).generateTokens(USER_ID, Role.USER);
-        verify(refreshTokenService).saveRefreshToken(USER_ID, REFRESH_TOKEN, REFRESH_TOKEN_EXPIRATION_MILLIS);
-        assertRefreshTokenCookie(response.getHeader("Set-Cookie"));
     }
 
     private UserPrincipal principal() {
@@ -66,16 +58,5 @@ class OAuth2LoginTokenIssuerTest {
                 .status(UserStatus.ACTIVE)
                 .email("dev user@example.com")
                 .build();
-    }
-
-    private void assertRefreshTokenCookie(String setCookieHeader) {
-        assertThat(setCookieHeader)
-                .contains("refreshToken=" + REFRESH_TOKEN)
-                .contains("Path=/")
-                .contains("Domain=localhost")
-                .contains("Max-Age=900")
-                .contains("Secure")
-                .contains("HttpOnly")
-                .contains("SameSite=None");
     }
 }

--- a/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
@@ -46,7 +46,7 @@ class CustomOidcUserServiceTest {
 
     @BeforeEach
     void setUp() {
-        customOidcUserService = new CustomOidcUserService(userAuthAccountService);
+        customOidcUserService = new CustomOidcUserService(userAuthAccountService, new OidcSocialIdentityExtractor());
         customOidcUserService.setRetrieveUserInfo(request -> false);
     }
 

--- a/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/CustomOidcUserServiceTest.java
@@ -6,7 +6,6 @@ import com.techfork.useraccount.domain.enums.Role;
 import com.techfork.useraccount.domain.enums.SocialType;
 import com.techfork.useraccount.domain.enums.UserStatus;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,11 +41,14 @@ class CustomOidcUserServiceTest {
     @Mock
     private UserAuthAccountService userAuthAccountService;
 
+    @Mock
+    private OidcSocialIdentityExtractor socialIdentityExtractor;
+
     private CustomOidcUserService customOidcUserService;
 
     @BeforeEach
     void setUp() {
-        customOidcUserService = new CustomOidcUserService(userAuthAccountService, new OidcSocialIdentityExtractor());
+        customOidcUserService = new CustomOidcUserService(userAuthAccountService, socialIdentityExtractor);
         customOidcUserService.setRetrieveUserInfo(request -> false);
     }
 
@@ -58,6 +60,7 @@ class CustomOidcUserServiceTest {
         @DisplayName("신규 Apple 인증 프로필을 UserPrincipal로 반환한다")
         void loadUser_NewAppleUser_ReturnsPrincipal() {
             UserAuthProfile userAuthProfile = new UserAuthProfile(1L, Role.USER, UserStatus.PENDING, EMAIL, false);
+            givenSocialIdentity(SocialType.APPLE, SOCIAL_ID, EMAIL, PROFILE_IMAGE);
             given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
@@ -65,14 +68,10 @@ class CustomOidcUserServiceTest {
                     PROFILE_IMAGE
             )).willReturn(userAuthProfile);
 
-            OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
+            OidcUser oidcUser = customOidcUserService.loadUser(userRequest());
 
-            assertThat(oidcUser).isInstanceOf(UserPrincipal.class);
-            UserPrincipal principal = (UserPrincipal) oidcUser;
-            assertThat(principal.getId()).isEqualTo(1L);
-            assertThat(principal.getRole()).isEqualTo(Role.USER);
-            assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
-            assertThat(principal.getEmail()).isEqualTo(EMAIL);
+            assertPrincipal(oidcUser, 1L, Role.USER, UserStatus.PENDING, EMAIL);
+            verifySocialIdentityExtracted();
             verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
@@ -82,12 +81,13 @@ class CustomOidcUserServiceTest {
         }
 
         @Test
-        @DisplayName("Kakao OIDC sub를 REST id와 같은 service user ID socialId로 사용한다")
-        void loadUser_NewKakaoOidcUser_ReturnsPrincipal() {
+        @DisplayName("Kakao 인증 식별자로 인증 프로필을 조회하고 UserPrincipal로 반환한다")
+        void loadUser_KakaoIdentity_ReturnsPrincipal() {
             String kakaoServiceUserId = "12345";
             String kakaoEmail = "kakao-user@example.com";
             String kakaoProfileImage = "https://cdn.example.com/kakao-user.png";
             UserAuthProfile userAuthProfile = new UserAuthProfile(4L, Role.USER, UserStatus.PENDING, kakaoEmail, false);
+            givenSocialIdentity(SocialType.KAKAO, kakaoServiceUserId, kakaoEmail, kakaoProfileImage);
             given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.KAKAO,
                     kakaoServiceUserId,
@@ -95,16 +95,10 @@ class CustomOidcUserServiceTest {
                     kakaoProfileImage
             )).willReturn(userAuthProfile);
 
-            OidcUser oidcUser = customOidcUserService.loadUser(
-                    userRequest("kakao", claims(kakaoServiceUserId, kakaoEmail, kakaoProfileImage))
-            );
+            OidcUser oidcUser = customOidcUserService.loadUser(userRequest("kakao"));
 
-            assertThat(oidcUser).isInstanceOf(UserPrincipal.class);
-            UserPrincipal principal = (UserPrincipal) oidcUser;
-            assertThat(principal.getId()).isEqualTo(4L);
-            assertThat(principal.getRole()).isEqualTo(Role.USER);
-            assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
-            assertThat(principal.getEmail()).isEqualTo(kakaoEmail);
+            assertPrincipal(oidcUser, 4L, Role.USER, UserStatus.PENDING, kakaoEmail);
+            verifySocialIdentityExtracted();
             verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.KAKAO,
                     kakaoServiceUserId,
@@ -117,6 +111,7 @@ class CustomOidcUserServiceTest {
         @DisplayName("기존 Apple 인증 프로필을 UserPrincipal로 반환한다")
         void loadUser_ExistingAppleUser_ReturnsPrincipal() {
             UserAuthProfile existingUserProfile = new UserAuthProfile(2L, Role.USER, UserStatus.ACTIVE, EMAIL, true);
+            givenSocialIdentity(SocialType.APPLE, SOCIAL_ID, EMAIL, PROFILE_IMAGE);
             given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
@@ -124,12 +119,10 @@ class CustomOidcUserServiceTest {
                     PROFILE_IMAGE
             )).willReturn(existingUserProfile);
 
-            OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
+            OidcUser oidcUser = customOidcUserService.loadUser(userRequest());
 
-            UserPrincipal principal = (UserPrincipal) oidcUser;
-            assertThat(principal.getId()).isEqualTo(2L);
-            assertThat(principal.getStatus()).isEqualTo(UserStatus.ACTIVE);
-            assertThat(principal.getEmail()).isEqualTo(EMAIL);
+            assertPrincipal(oidcUser, 2L, Role.USER, UserStatus.ACTIVE, EMAIL);
+            verifySocialIdentityExtracted();
             verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
@@ -142,6 +135,7 @@ class CustomOidcUserServiceTest {
         @DisplayName("탈퇴 Apple 사용자의 재활성화된 PENDING 인증 프로필을 UserPrincipal로 반환한다")
         void loadUser_WithdrawnAppleUser_ReturnsReactivatedPendingPrincipal() {
             UserAuthProfile reactivatedUserProfile = new UserAuthProfile(3L, Role.USER, UserStatus.PENDING, EMAIL, false);
+            givenSocialIdentity(SocialType.APPLE, SOCIAL_ID, EMAIL, PROFILE_IMAGE);
             given(userAuthAccountService.getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
@@ -149,12 +143,10 @@ class CustomOidcUserServiceTest {
                     PROFILE_IMAGE
             )).willReturn(reactivatedUserProfile);
 
-            OidcUser oidcUser = customOidcUserService.loadUser(userRequest(claims(SOCIAL_ID, EMAIL, PROFILE_IMAGE)));
+            OidcUser oidcUser = customOidcUserService.loadUser(userRequest());
 
-            UserPrincipal principal = (UserPrincipal) oidcUser;
-            assertThat(principal.getId()).isEqualTo(3L);
-            assertThat(principal.getStatus()).isEqualTo(UserStatus.PENDING);
-            assertThat(principal.getEmail()).isEqualTo(EMAIL);
+            assertPrincipal(oidcUser, 3L, Role.USER, UserStatus.PENDING, EMAIL);
+            verifySocialIdentityExtracted();
             verify(userAuthAccountService).getOrCreateSocialAuthProfile(
                     SocialType.APPLE,
                     SOCIAL_ID,
@@ -169,23 +161,27 @@ class CustomOidcUserServiceTest {
     class Failure {
 
         @Test
-        @DisplayName("sub 클레임이 없으면 예외를 던진다")
-        void loadUser_MissingSubject_ThrowsException() {
-            Map<String, Object> claims = claims(null, EMAIL, PROFILE_IMAGE);
+        @DisplayName("소셜 식별자 추출에 실패하면 인증 프로필을 조회하지 않는다")
+        void loadUser_SocialIdentityExtractionFails_DoesNotRequestAuthProfile() {
+            given(socialIdentityExtractor.extract(any(OidcUserRequest.class), any(OidcUser.class)))
+                    .willThrow(new OAuth2AuthenticationException("socialId(sub) not found"));
 
-            assertThatThrownBy(() -> customOidcUserService.loadUser(userRequest(claims)))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("sub");
+            assertThatThrownBy(() -> customOidcUserService.loadUser(userRequest()))
+                    .isInstanceOf(OAuth2AuthenticationException.class)
+                    .satisfies(exception -> assertThat(((OAuth2AuthenticationException) exception)
+                            .getError()
+                            .getErrorCode()).isEqualTo("socialId(sub) not found"));
 
             verify(userAuthAccountService, never()).getOrCreateSocialAuthProfile(any(), any(), any(), any());
         }
 
         @Test
-        @DisplayName("email 클레임이 없으면 예외를 던지고 인증 프로필을 조회하지 않는다")
-        void loadUser_MissingEmail_ThrowsOAuth2AuthenticationException() {
-            Map<String, Object> claims = claims(SOCIAL_ID, null, PROFILE_IMAGE);
+        @DisplayName("이메일 추출에 실패하면 인증 프로필을 조회하지 않는다")
+        void loadUser_EmailExtractionFails_DoesNotRequestAuthProfile() {
+            given(socialIdentityExtractor.extract(any(OidcUserRequest.class), any(OidcUser.class)))
+                    .willThrow(new OAuth2AuthenticationException("email not found"));
 
-            assertThatThrownBy(() -> customOidcUserService.loadUser(userRequest(claims)))
+            assertThatThrownBy(() -> customOidcUserService.loadUser(userRequest()))
                     .isInstanceOf(OAuth2AuthenticationException.class)
                     .satisfies(exception -> assertThat(((OAuth2AuthenticationException) exception)
                             .getError()
@@ -195,14 +191,36 @@ class CustomOidcUserServiceTest {
         }
     }
 
-    private OidcUserRequest userRequest(Map<String, Object> claims) {
-        return userRequest("apple", claims);
+    private void givenSocialIdentity(SocialType socialType, String socialId, String email, String profileImage) {
+        given(socialIdentityExtractor.extract(any(OidcUserRequest.class), any(OidcUser.class)))
+                .willReturn(new OidcSocialIdentity(socialType, socialId, email, profileImage));
     }
 
-    private OidcUserRequest userRequest(String registrationId, Map<String, Object> claims) {
+    private void verifySocialIdentityExtracted() {
+        verify(socialIdentityExtractor).extract(any(OidcUserRequest.class), any(OidcUser.class));
+    }
+
+    private void assertPrincipal(OidcUser oidcUser, Long id, Role role, UserStatus status, String email) {
+        assertThat(oidcUser).isInstanceOf(UserPrincipal.class);
+        UserPrincipal principal = (UserPrincipal) oidcUser;
+        assertThat(principal.getId()).isEqualTo(id);
+        assertThat(principal.getRole()).isEqualTo(role);
+        assertThat(principal.getStatus()).isEqualTo(status);
+        assertThat(principal.getEmail()).isEqualTo(email);
+    }
+
+    private OidcUserRequest userRequest() {
+        return userRequest("apple");
+    }
+
+    private OidcUserRequest userRequest(String registrationId) {
         Instant issuedAt = Instant.now();
         Instant expiresAt = issuedAt.plusSeconds(300);
-        OidcIdToken idToken = new OidcIdToken("id-token", issuedAt, expiresAt, claims);
+        OidcIdToken idToken = new OidcIdToken("id-token", issuedAt, expiresAt, Map.of(
+                "sub", "id-token-sub",
+                "email", EMAIL,
+                "picture", PROFILE_IMAGE
+        ));
         OAuth2AccessToken accessToken = new OAuth2AccessToken(
                 OAuth2AccessToken.TokenType.BEARER,
                 "access-token",
@@ -229,19 +247,5 @@ class CustomOidcUserServiceTest {
                 .userNameAttributeName("sub")
                 .clientName(registrationId)
                 .build();
-    }
-
-    private Map<String, Object> claims(String subject, String email, String profileImage) {
-        Map<String, Object> claims = new HashMap<>();
-        if (subject != null) {
-            claims.put("sub", subject);
-        }
-        if (email != null) {
-            claims.put("email", email);
-        }
-        if (profileImage != null) {
-            claims.put("picture", profileImage);
-        }
-        return claims;
     }
 }

--- a/src/test/java/com/techfork/auth/security/oauth/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -54,10 +54,18 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
             repository.saveAuthorizationRequest(null, request, response);
 
             Cookie deleteCookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-            assertThat(deleteCookie).isNotNull();
-            assertThat(deleteCookie.getValue()).isEmpty();
-            assertThat(deleteCookie.getPath()).isEqualTo("/");
-            assertThat(deleteCookie.getMaxAge()).isZero();
+            assertDeleteCookie(deleteCookie);
+        }
+
+        @Test
+        @DisplayName("null request를 넘겨도 기존 쿠키가 없으면 삭제 쿠키를 추가하지 않는다")
+        void nullRequest_DoesNotAddDeleteCookieWhenCookieDoesNotExist() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            repository.saveAuthorizationRequest(null, request, response);
+
+            assertThat(response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)).isNull();
         }
     }
 
@@ -116,11 +124,27 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
             assertThat(removed).isNotNull();
             assertThat(removed.getState()).isEqualTo(original.getState());
             Cookie deleteCookie = removeResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-            assertThat(deleteCookie).isNotNull();
-            assertThat(deleteCookie.getValue()).isEmpty();
-            assertThat(deleteCookie.getPath()).isEqualTo("/");
-            assertThat(deleteCookie.getMaxAge()).isZero();
+            assertDeleteCookie(deleteCookie);
         }
+
+        @Test
+        @DisplayName("기존 쿠키가 없으면 null을 반환하고 삭제 쿠키를 추가하지 않는다")
+        void withoutCookie_ReturnsNullAndDoesNotAddDeleteCookie() {
+            MockHttpServletRequest request = new MockHttpServletRequest();
+            MockHttpServletResponse response = new MockHttpServletResponse();
+
+            OAuth2AuthorizationRequest removed = repository.removeAuthorizationRequest(request, response);
+
+            assertThat(removed).isNull();
+            assertThat(response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)).isNull();
+        }
+    }
+
+    private void assertDeleteCookie(Cookie deleteCookie) {
+        assertThat(deleteCookie).isNotNull();
+        assertThat(deleteCookie.getValue()).isEmpty();
+        assertThat(deleteCookie.getPath()).isEqualTo("/");
+        assertThat(deleteCookie.getMaxAge()).isZero();
     }
 
     private OAuth2AuthorizationRequest authorizationRequest() {

--- a/src/test/java/com/techfork/auth/security/oauth/OidcSocialIdentityExtractorTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/OidcSocialIdentityExtractorTest.java
@@ -1,0 +1,143 @@
+package com.techfork.auth.security.oauth;
+
+import com.techfork.useraccount.domain.enums.SocialType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OidcSocialIdentityExtractorTest {
+
+    private static final String SOCIAL_ID = "apple-sub-123";
+    private static final String EMAIL = "apple-user@example.com";
+    private static final String PROFILE_IMAGE = "https://cdn.example.com/apple-user.png";
+
+    @Mock
+    private OidcUser oidcUser;
+
+    private OidcSocialIdentityExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        extractor = new OidcSocialIdentityExtractor();
+    }
+
+    @Nested
+    @DisplayName("extract")
+    class Extract {
+
+        @Test
+        @DisplayName("Apple OIDC user에서 소셜 인증 식별자를 추출한다")
+        void appleUser_ReturnsAppleSocialIdentity() {
+            givenOidcUserClaims(SOCIAL_ID, EMAIL, PROFILE_IMAGE);
+
+            OidcSocialIdentity identity = extractor.extract(userRequest("apple"), oidcUser);
+
+            assertThat(identity.socialType()).isEqualTo(SocialType.APPLE);
+            assertThat(identity.socialId()).isEqualTo(SOCIAL_ID);
+            assertThat(identity.email()).isEqualTo(EMAIL);
+            assertThat(identity.profileImage()).isEqualTo(PROFILE_IMAGE);
+        }
+
+        @Test
+        @DisplayName("Kakao OIDC sub를 REST id와 같은 service user ID socialId로 추출한다")
+        void kakaoUser_ReturnsKakaoServiceUserId() {
+            String kakaoServiceUserId = "12345";
+            String kakaoEmail = "kakao-user@example.com";
+            givenOidcUserClaims(kakaoServiceUserId, kakaoEmail, null);
+
+            OidcSocialIdentity identity = extractor.extract(userRequest("kakao"), oidcUser);
+
+            assertThat(identity.socialType()).isEqualTo(SocialType.KAKAO);
+            assertThat(identity.socialId()).isEqualTo(kakaoServiceUserId);
+            assertThat(identity.email()).isEqualTo(kakaoEmail);
+            assertThat(identity.profileImage()).isNull();
+        }
+
+        @Test
+        @DisplayName("sub 클레임이 없으면 예외를 던진다")
+        void missingSubject_ThrowsOAuth2AuthenticationException() {
+            givenOidcUserClaims(null, EMAIL, PROFILE_IMAGE);
+
+            assertThatThrownBy(() -> extractor.extract(userRequest("apple"), oidcUser))
+                    .isInstanceOf(OAuth2AuthenticationException.class)
+                    .satisfies(exception -> assertThat(((OAuth2AuthenticationException) exception)
+                            .getError()
+                            .getErrorCode()).isEqualTo("socialId(sub) not found"));
+        }
+
+        @Test
+        @DisplayName("email 클레임이 없으면 예외를 던진다")
+        void missingEmail_ThrowsOAuth2AuthenticationException() {
+            givenOidcUserClaims(SOCIAL_ID, null, PROFILE_IMAGE);
+
+            assertThatThrownBy(() -> extractor.extract(userRequest("apple"), oidcUser))
+                    .isInstanceOf(OAuth2AuthenticationException.class)
+                    .satisfies(exception -> assertThat(((OAuth2AuthenticationException) exception)
+                            .getError()
+                            .getErrorCode()).isEqualTo("email not found"));
+        }
+    }
+
+    private void givenOidcUserClaims(String subject, String email, String profileImage) {
+        given(oidcUser.getAttribute("sub")).willReturn(subject);
+        if (subject != null) {
+            given(oidcUser.getAttribute("email")).willReturn(email);
+        }
+        if (subject != null && email != null) {
+            given(oidcUser.getAttribute("picture")).willReturn(profileImage);
+        }
+    }
+
+    private OidcUserRequest userRequest(String registrationId) {
+        Instant issuedAt = Instant.now();
+        Instant expiresAt = issuedAt.plusSeconds(300);
+        OidcIdToken idToken = new OidcIdToken("id-token", issuedAt, expiresAt, Map.of("sub", "id-token-sub"));
+        OAuth2AccessToken accessToken = new OAuth2AccessToken(
+                OAuth2AccessToken.TokenType.BEARER,
+                "access-token",
+                issuedAt,
+                expiresAt,
+                Set.of("openid")
+        );
+
+        return new OidcUserRequest(clientRegistration(registrationId), accessToken, idToken);
+    }
+
+    private ClientRegistration clientRegistration(String registrationId) {
+        return ClientRegistration.withRegistrationId(registrationId)
+                .clientId("techfork-client")
+                .clientSecret("techfork-secret")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_POST)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("https://techfork.site/login/oauth2/code/" + registrationId)
+                .scope("openid")
+                .authorizationUri("https://auth.example.com/oauth/authorize")
+                .tokenUri("https://auth.example.com/oauth/token")
+                .jwkSetUri("https://auth.example.com/oauth/keys")
+                .issuerUri("https://auth.example.com")
+                .userNameAttributeName("sub")
+                .clientName(registrationId)
+                .build();
+    }
+}


### PR DESCRIPTION
## ❤️ 기능 설명

OAuth/OIDC 로그인 보안 인프라의 책임 경계를 분리했습니다.

- `HttpCookieOAuth2AuthorizationRequestRepositoryTest`로 authorization request cookie 저장/조회/삭제 동작을 보강
- OAuth2 로그인 성공/실패 redirect URL 생성을 `OAuth2LoginRedirectUrlFactory`로 분리
- OAuth2 로그인 실패 redirect는 raw exception message 대신 공개용 `errorCode=oauth_failed`만 노출하도록 변경
- OAuth2 로그인 token 발급을 side-effect 없는 `OAuth2LoginTokenIssuer`로 분리
- refresh token 저장과 cookie 쓰기 side effect를 `OAuth2LoginRefreshTokenWriter`로 분리
- OIDC provider별 social identity 추출을 `OidcSocialIdentityExtractor`로 분리해 `CustomOidcUserService`는 오케스트레이션만 담당하도록 정리
- `CustomOidcUserServiceTest`를 흐름이 보이도록 helper method 기반으로 정리
- `handler.login` 패키지 내부 helper/factory/value 타입은 package-private으로 닫아 handler 내부 협력 객체임을 명시

Swagger 테스트 성공 결과 스크린샷 첨부

- API path, JSON field, status code 변경 없는 Auth/Security 리팩터링이라 Swagger 스크린샷은 해당 없습니다.
- 아래 CLI 검증 결과와 PR CI로 대체합니다.

<br>

## 연결된 issue

close #431

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 성공 redirect URL에 access token을 싣는 기존 계약은 이번 PR에서 동작 보존했습니다. 제거 및 frontend refresh 연동은 후속 #440에서 처리합니다.
- [ ] OAuth2/OIDC 실패 redirect와 state cookie 보안 정책 정리는 #433, 성공 redirect access token 제거와 redirect 계약 정리는 #440으로 범위를 분리했습니다.
- [ ] `handler.login`의 `OAuth2LoginRedirectUrlFactory`, `OAuth2LoginTokenIssuer`, `OAuth2LoginRefreshTokenWriter`, `OAuth2LoginTokens`는 의도적으로 package-private입니다. 외부 패키지 재사용 대상이 아니라 login handler 내부 협력 객체입니다.
- [ ] OAuth provider 추가 계획이 없어 Apple/Kakao 분기는 현재 extractor 내부 정책으로 유지했습니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (API 계약 변경 없는 리팩터링이라 CLI 결과로 대체)
- [x] 이슈넘버를 적었는가?

## 🧪 테스트 결과

```bash
git diff --check origin/develop...HEAD
# 통과

./gradlew test --tests 'com.techfork.auth.security.handler.login.*' --tests 'com.techfork.auth.security.oauth.*'
# BUILD SUCCESSFUL, 27 tests passed
```

참고 검증:

```text
SecurityIntegrationTest를 임시로 MySqlRedisIntegrationTestBase 기반으로 전환해 MySQL/Redis 통합 환경에서 12개 테스트 통과 확인 후 원복했습니다.
```

## 🔎 리뷰 결과

```text
$code-review
- HIGH: 성공 redirect access token query 노출 → #440 후속 이슈로 분리
- MEDIUM: 실패 redirect raw exception 노출 → 이번 PR에서 errorCode로 수정 완료
- WATCH: redirect URL String.format 계약 → #440 본문에 후속 정리 범위로 명시
- WATCH: OAuth2LoginTokenIssuer side effect → refresh writer 분리로 수정 완료
- WATCH: provider 분기 확장성 → provider 추가 계획 없음으로 현재 정책 유지
```
