### PR TITLE
[improve/#433] OAuth state 쿠키 보안 속성 정리

### DIFF
--- a/src/main/java/com/techfork/auth/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/techfork/auth/security/oauth/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -3,11 +3,14 @@ package com.techfork.auth.security.oauth;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.util.SerializationUtils;
 
+import java.time.Duration;
 import java.util.Base64;
 
 /**
@@ -19,6 +22,8 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
 
     public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
     private static final int COOKIE_EXPIRE_SECONDS = 180; // 3분
+    private static final String COOKIE_PATH = "/";
+    private static final String COOKIE_SAME_SITE = "None";
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
@@ -34,11 +39,7 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
             return;
         }
 
-        Cookie cookie = new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, serialize(authorizationRequest));
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(COOKIE_EXPIRE_SECONDS);
-        response.addCookie(cookie);
+        addAuthorizationRequestCookie(response, serialize(authorizationRequest), COOKIE_EXPIRE_SECONDS);
     }
 
     @Override
@@ -51,11 +52,20 @@ public class HttpCookieOAuth2AuthorizationRequestRepository implements Authoriza
     public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
         getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
                 .ifPresent(cookie -> {
-                    Cookie deleteCookie = new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, "");
-                    deleteCookie.setPath("/");
-                    deleteCookie.setMaxAge(0);
-                    response.addCookie(deleteCookie);
+                    addAuthorizationRequestCookie(response, "", 0);
                 });
+    }
+
+    private void addAuthorizationRequestCookie(HttpServletResponse response, String value, long maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, value)
+                .httpOnly(true)
+                .secure(true)
+                .path(COOKIE_PATH)
+                .maxAge(Duration.ofSeconds(maxAge))
+                .sameSite(COOKIE_SAME_SITE)
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 
     private java.util.Optional<Cookie> getCookie(HttpServletRequest request, String name) {

--- a/src/test/java/com/techfork/auth/security/oauth/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
+++ b/src/test/java/com/techfork/auth/security/oauth/HttpCookieOAuth2AuthorizationRequestRepositoryTest.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
@@ -24,8 +25,8 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
     class SaveAuthorizationRequest {
 
         @Test
-        @DisplayName("OAuth2 authorization request 저장 시 직렬화된 httpOnly 쿠키를 생성한다")
-        void createsSerializedHttpOnlyCookie() {
+        @DisplayName("OAuth2 authorization request 저장 시 보안 속성이 포함된 쿠키를 생성한다")
+        void createsSerializedSecureCookie() {
             MockHttpServletResponse response = new MockHttpServletResponse();
             OAuth2AuthorizationRequest authorizationRequest = authorizationRequest();
 
@@ -35,12 +36,9 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
                     response
             );
 
-            Cookie cookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-            assertThat(cookie).isNotNull();
-            assertThat(cookie.getValue()).isNotBlank();
-            assertThat(cookie.getPath()).isEqualTo("/");
-            assertThat(cookie.isHttpOnly()).isTrue();
-            assertThat(cookie.getMaxAge()).isEqualTo(180);
+            String setCookie = response.getHeader(HttpHeaders.SET_COOKIE);
+            assertAuthorizationRequestCookie(setCookie, 180);
+            assertThat(extractCookieValue(setCookie)).isNotBlank();
         }
 
         @Test
@@ -53,8 +51,8 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
 
             repository.saveAuthorizationRequest(null, request, response);
 
-            Cookie deleteCookie = response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-            assertDeleteCookie(deleteCookie);
+            String setCookie = response.getHeader(HttpHeaders.SET_COOKIE);
+            assertDeleteCookie(setCookie);
         }
 
         @Test
@@ -65,7 +63,7 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
 
             repository.saveAuthorizationRequest(null, request, response);
 
-            assertThat(response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)).isNull();
+            assertThat(response.getHeader(HttpHeaders.SET_COOKIE)).isNull();
         }
     }
 
@@ -81,7 +79,7 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
             repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
 
             MockHttpServletRequest loadRequest = new MockHttpServletRequest();
-            loadRequest.setCookies(saveResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
+            loadRequest.setCookies(cookieFromSetCookieHeader(saveResponse));
 
             OAuth2AuthorizationRequest loaded = repository.loadAuthorizationRequest(loadRequest);
 
@@ -116,15 +114,15 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
             repository.saveAuthorizationRequest(original, new MockHttpServletRequest(), saveResponse);
 
             MockHttpServletRequest removeRequest = new MockHttpServletRequest();
-            removeRequest.setCookies(saveResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME));
+            removeRequest.setCookies(cookieFromSetCookieHeader(saveResponse));
             MockHttpServletResponse removeResponse = new MockHttpServletResponse();
 
             OAuth2AuthorizationRequest removed = repository.removeAuthorizationRequest(removeRequest, removeResponse);
 
             assertThat(removed).isNotNull();
             assertThat(removed.getState()).isEqualTo(original.getState());
-            Cookie deleteCookie = removeResponse.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
-            assertDeleteCookie(deleteCookie);
+            String setCookie = removeResponse.getHeader(HttpHeaders.SET_COOKIE);
+            assertDeleteCookie(setCookie);
         }
 
         @Test
@@ -136,15 +134,36 @@ class HttpCookieOAuth2AuthorizationRequestRepositoryTest {
             OAuth2AuthorizationRequest removed = repository.removeAuthorizationRequest(request, response);
 
             assertThat(removed).isNull();
-            assertThat(response.getCookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)).isNull();
+            assertThat(response.getHeader(HttpHeaders.SET_COOKIE)).isNull();
         }
     }
 
-    private void assertDeleteCookie(Cookie deleteCookie) {
-        assertThat(deleteCookie).isNotNull();
-        assertThat(deleteCookie.getValue()).isEmpty();
-        assertThat(deleteCookie.getPath()).isEqualTo("/");
-        assertThat(deleteCookie.getMaxAge()).isZero();
+    private void assertDeleteCookie(String setCookie) {
+        assertAuthorizationRequestCookie(setCookie, 0);
+        assertThat(extractCookieValue(setCookie)).isEmpty();
+    }
+
+    private void assertAuthorizationRequestCookie(String setCookie, int maxAge) {
+        assertThat(setCookie).isNotNull();
+        assertThat(setCookie).startsWith(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME + "=");
+        assertThat(setCookie).contains("Path=/");
+        assertThat(setCookie).contains("Max-Age=" + maxAge);
+        assertThat(setCookie).contains("Secure");
+        assertThat(setCookie).contains("HttpOnly");
+        assertThat(setCookie).contains("SameSite=None");
+        assertThat(setCookie).doesNotContain("Domain=");
+    }
+
+    private Cookie cookieFromSetCookieHeader(MockHttpServletResponse response) {
+        String setCookie = response.getHeader(HttpHeaders.SET_COOKIE);
+        return new Cookie(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, extractCookieValue(setCookie));
+    }
+
+    private String extractCookieValue(String setCookie) {
+        assertThat(setCookie).isNotNull();
+        String nameValue = setCookie.split(";", 2)[0];
+        assertThat(nameValue).startsWith(OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME + "=");
+        return nameValue.substring((OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME + "=").length());
     }
 
     private OAuth2AuthorizationRequest authorizationRequest() {


### PR DESCRIPTION
## ❤️ 기능 설명

OAuth2/OIDC authorization request(state) cookie의 보안 속성을 명시했습니다.

- `oauth2_auth_request` 저장 cookie에 `HttpOnly`, `Secure`, `SameSite=None`, `Path=/`, `Max-Age=180` 적용
- 삭제 cookie도 동일한 `HttpOnly`, `Secure`, `SameSite=None`, `Path=/` 속성과 `Max-Age=0`으로 생성
- `Domain`은 설정하지 않아 기존처럼 host-only cookie로 유지
- Servlet `Cookie`가 표현하지 못하는 `SameSite` 검증을 위해 `ResponseCookie` + `Set-Cookie` header 방식으로 변경
- authorization request save/load/remove 기존 serialization 흐름은 유지
- 실패 redirect는 #431에서 이미 `errorCode=oauth_failed`로 정리된 상태라, 이번 PR에서는 추가 변경하지 않았습니다.

Swagger 테스트 성공 결과 스크린샷 첨부

- API path, JSON field, status code 변경 없는 OAuth state cookie 보안 속성 정리라 Swagger 스크린샷은 해당 없습니다.
- 아래 CLI 검증 결과와 PR CI로 대체합니다.

<br>

## 연결된 issue

close #433

<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] `oauth2_auth_request` cookie는 `SameSite=None; Secure` 고정 정책입니다. local HTTP OAuth 브라우저 플로우는 보장하지 않고, local 검증은 HTTPS/local-tunnel 기준입니다.
- [ ] OAuth 성공 redirect에서 access token을 제거하는 작업은 #440에서 별도로 처리합니다.
- [ ] `auth/security` 내부 store/cache/cookie 책임 명명 정리는 #442에서 별도로 처리합니다.
- [ ] refresh/logout CSRF 또는 Origin 검증 정책 변경, Redis refresh token hash/HMAC 저장은 이번 PR 범위가 아닙니다.

<br>

## ✅ 체크리스트

- [x] PR 제목 규칙 잘 지켰는가?
- [x] 추가/수정사항을 설명하였는가?
- [x] 테스트 결과 사진을 넣었는가? (API 계약 변경 없는 리팩터링/보안 속성 정리라 CLI 결과로 대체)
- [x] 이슈넘버를 적었는가?

## 🧪 테스트 결과

```bash
git diff --check origin/develop...HEAD
# 통과

./gradlew test --tests 'com.techfork.auth.security.handler.login.*' --tests 'com.techfork.auth.security.oauth.*'
# BUILD SUCCESSFUL, 27 tests passed
```

## 🔎 리뷰 결과

```text
$code-review auth/auth.security 구조 리뷰
- code-reviewer recommendation: REQUEST CHANGES for broader auth/security structure
- architect status: WATCH
```

- 이번 #433의 OAuth authorization request cookie 보강 자체는 방향 OK로 확인했습니다.
- broader auth/security 구조 정리는 #442 후속 이슈로 분리했습니다.
- OAuth 성공 redirect access token 노출은 #440 후속 이슈로 분리했습니다.
